### PR TITLE
Agent Retrieval and Evaluation Specification

### DIFF
--- a/.agents/skills/ferrus/SKILL.md
+++ b/.agents/skills/ferrus/SKILL.md
@@ -148,6 +148,15 @@ Supervisor sessions use `enqueue_task` for task creation and `archive_spec` for 
 | `reset` | Failed | Mark the failed task as reset |
 | `heartbeat` | any claimed | Executor-scoped lease renewal; returns `{"status":"renewed"}` or `{"status":"error","code":"..."}` |
 
+### Repository retrieval
+
+Both roles can use the optional read-only `repository_graph_status`, `repository_search`, and
+`repository_context` tools without a task lease. Check status first when availability is unknown, use search for
+exact path/symbol discovery, then request a small bounded context packet. Ask for snippets only when source text is
+needed; snippets are hash-verified against the returned snapshot. Graph use is optional, and a missing relationship
+means only “not known by this index,” not proof that the relationship does not exist. These tools never build or
+mutate the index and graph output is not injected into task or review prompts.
+
 ## MCP resources
 
 | URI | Contents |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,9 +28,11 @@ All three checks must pass before submitting: `clippy -D warnings`, `fmt --check
 ```
 src/
   main.rs                    # CLI entry, tracing init, HQ logger
-  cli/                       # clap entry and command implementations (init, serve, register)
+  cli/                       # clap entry and command implementations (init, serve, register, graph, ...)
   config/mod.rs              # Deserialize/update ferrus.toml (ChecksConfig, LimitsConfig, LeaseConfig, SpecConfig, HqConfig)
   config/claude.rs           # Claude MCP isolation config helpers
+  repository_graph/          # Backend-neutral graph contracts plus local source, index, SQLite query, diagnostics, and extractors
+  repository_graph_runtime.rs # Machine-local CLI/MCP adapter; resolves project identity, sidecar, freshness, and verified snippets
   templates.rs               # Embedded Markdown templates written by init/resource fallback
   specs.rs                   # Spec discovery, milestone parsing, selected milestone resolution
   agent_id.rs                # Stable agent IDs and MCP server names
@@ -64,6 +66,18 @@ src/
 **Tool files** expose `pub const DESCRIPTION: &str`, optionally `pub const INPUT_SCHEMA: &str`, and `pub async fn handler(...)`. Registered manually via `app.map_tool()` in `server/mod.rs` — no macros.
 
 **Runtime state**: SQLite is the runtime source of truth. MCP tools should resolve the caller’s `RuntimeTaskContext` from `ferrus.db`, update task/run rows transactionally, and write only scoped artifacts under `.ferrus/tasks/` and `.ferrus/runs/`.
+
+**Repository graph boundary**: the optional repository graph is derived machine-local state in `repo-graph.db`,
+separate from the orchestration `ferrus.db`. Keep backend-neutral identities, requests, responses, and ports under
+`src/repository_graph/`; keep project-local path/config/sidecar resolution in `src/repository_graph_runtime.rs`.
+Core config loading must remain lenient toward graph settings; graph operations validate `[repository_graph]`
+strictly only when invoked.
+
+**Repository retrieval tools**: `repository_graph_status`, `repository_search`, and `repository_context` are
+read-only, role-visible tools registered in `server/mod.rs`. They require no task lease and must not mutate tasks,
+runs, events, or either database. Do not inject graph output into task/review prompts. Structural responses omit
+source bodies; requested snippets must pass the snapshot-aware, hash-verified content boundary. Treat missing
+relationships as unknown, not absent.
 
 **Per-task state machine**: The old single global `STATE.json` is gone, but each SQLite task row still follows the same Supervisor–Executor lifecycle. In `--limit 1` this is effectively the old flow, only DB-backed:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,11 @@ Before submitting, `cargo clippy -- -D warnings`, `cargo fmt --check`, and `carg
 - Treat `.ferrus/TASK.md`, `.ferrus/SPEC_TEMPLATE.md`, and `.ferrus/CONSULT_TEMPLATE.md` as templates.
 - Do not recreate `.ferrus/STATE.json`, `.ferrus/STATE.lock`, or root runtime artifact mirrors.
 - Keep backend-specific behavior inside `src/agents/{claude,codex,qwen,opencode,goose}`.
+- Keep the optional repository graph sidecar (`repo-graph.db`) separate from orchestration state in `ferrus.db`.
+- Keep backend-neutral graph contracts in `src/repository_graph/` and local project/sidecar adaptation in
+  `src/repository_graph_runtime.rs`.
+- Treat repository retrieval tools as read-only and lease-independent; never infer that a missing graph
+  relationship proves absence in the source.
 
 ## Ferrus CLI
 
@@ -55,10 +60,22 @@ ferrus tasks list
 ferrus runs list
 ferrus events list
 ferrus migrate
+ferrus graph index [--full] [--json]
+ferrus graph status [--json]
+ferrus graph search <query> [--kind <kind>] [--path <path>] [--limit <n>] [--json]
+ferrus graph context (--node <id> | --symbol <key> | --path <path>) [--depth <n>] [--json]
 ```
 
 Claude Code role-scoped MCP configuration is stored in `.claude/mcp-supervisor.json` and
 `.claude/mcp-executor.json`; permissions are stored in `.claude/settings.local.json`.
+
+## Repository retrieval
+
+Supervisor and Executor MCP servers expose the optional read-only `repository_graph_status`,
+`repository_search`, and `repository_context` tools. Check status when graph availability is unknown, search for
+an exact path or symbol, and request a small bounded context packet only when it helps. Source snippets are opt-in
+and hash-verified; graph output is not automatically added to prompts. These tools never build or publish an index
+and do not require a claimed task.
 
 <!-- ferrus-supervisor-instructions -->
 ## Ferrus Supervisor

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Tasks are planned, implemented, checked, and reviewed in a structured, restart-s
 
 Everything is explicit:
 - Runtime state lives in SQLite; task context lives in scoped Markdown artifacts
+- Optional repository graph facts live in a separate machine-local SQLite sidecar
 - Agents are stateless between runs
 - Crashes are recoverable
 - No hidden context
@@ -156,7 +157,7 @@ pending
        ├─► reviewing ← /submit final gate pass
        │     ├─► addressing ← /reject
        │     └─► complete ← /approve
-       └─► failed ← retry or review-cycle limit
+       └─► failed ← retry, review-cycle, or executor-dispatch limit
 ```
 
 Any active Executor work state (Executing, Addressing) can pause to `Consultation` via `/consult`. HQ spawns the configured Supervisor in consultation mode, and the executor immediately calls `/wait_for_consult` to block until the Supervisor answers via `/respond_consult`.
@@ -197,6 +198,10 @@ Starts the agent coordination server on stdio. Agents load this as an MCP server
 | `executor` | `wait_for_task`, `check`, `consult`, `submit`, `wait_for_consult`, `ask_human`, `wait_for_answer`, `status`, `reset`, `heartbeat` |
 | *(omitted)* | All tools |
 
+All three server modes also expose the optional read-only repository retrieval tools
+`repository_graph_status`, `repository_search`, and `repository_context`. They do not require a task lease and never
+build an index or mutate task/run state.
+
 The unfiltered server additionally exposes compatibility tools such as `create_task` and `answer`. The `status` tool includes scoped SQLite task context when called by a running agent with a resolved runtime identity.
 
 ### `ferrus register [--supervisor <agent>] [--supervisor-model <model>] [--executor <agent>] [--executor-model <model>]`
@@ -234,6 +239,7 @@ ferrus graph search RuntimeTaskContext --kind struct --path src [--limit 20] [--
 ferrus graph show --node <node-id> [--json]
 ferrus graph show --symbol <semantic-key> [--json]
 ferrus graph show --path src/project.rs [--json]
+ferrus graph context (--node <node-id> | --symbol <semantic-key> | --path <path>) [--depth 2] [--max-results 50] [--json]
 ferrus graph neighbors <node-id> --direction both --depth 2 --limit 50 [--kind contains] [--json]
 ```
 
@@ -244,8 +250,18 @@ read-only and reports absent or incompatible storage without creating it.
 Every query reports the snapshot ID, freshness against the current source manifest, diagnostic counts,
 repository-relative evidence spans, provenance, and any truncation. CLI limits are requests: configured
 `[repository_graph.query_limits]` remain hard service caps. The derived sidecar is machine-local beside
-`ferrus.db`; it stores structural facts and content identities, not source bodies. Local Criterion benchmark
-methodology and the latest dogfood results are recorded in `docs/repository-graph-benchmarks.md`.
+`ferrus.db`; it stores structural facts and content identities, not source bodies.
+
+Supervisor and Executor agents can inspect the same published graph through `repository_graph_status`, find exact
+paths or symbols with `repository_search`, and assemble bounded deterministic evidence with `repository_context`.
+Source snippets are opt-in and hash-verified against the indexed snapshot. Graph output is not automatically
+injected into task or review prompts, and a missing relationship means only that the current index does not know it.
+
+The normative retrieval behavior is documented in
+[`docs/repository-graph-retrieval.md`](docs/repository-graph-retrieval.md). Local Criterion methodology and dogfood
+results live in [`docs/repository-graph-benchmarks.md`](docs/repository-graph-benchmarks.md); the reproducible
+26-case navigation evaluation and current automation decision are in
+[`docs/repository-graph-evaluations.md`](docs/repository-graph-evaluations.md).
 
 ### `ferrus projects list`
 
@@ -292,6 +308,7 @@ max_review_cycles = 3    # reject→fix cycles before state → Failed
 max_feedback_lines = 30  # trailing lines per failing command shown in /check and /submit output
 wait_timeout_secs = 60   # max duration of one wait_* tool call before it returns timeout so the agent can poll again
 max_parallel_tasks = 1   # maximum number of concurrent executor sessions
+max_executor_dispatches = 6 # headless executor sessions per work phase before state → Failed; 0 disables
 
 [lease]
 ttl_secs = 90                  # how long a claimed lease is valid without renewal

--- a/benches/repository_graph.rs
+++ b/benches/repository_graph.rs
@@ -152,7 +152,7 @@ fn verify_invariants() {
 
 fn search_request(fixture: &Fixture) -> SearchRequest {
     SearchRequest {
-        scope: QueryScope::v1(
+        scope: QueryScope::current(
             repository(),
             SnapshotSelector::Published(fixture.view.clone()),
             default_budget(&fixture.config.query_limits).unwrap(),

--- a/docs/repository-graph-evaluations.md
+++ b/docs/repository-graph-evaluations.md
@@ -1,0 +1,70 @@
+# Repository Graph Navigation Evaluations
+
+This document defines the deterministic RG2 navigation evaluation and records the current usefulness decision.
+The harness exercises the real filesystem source adapter, index coordinator, SQLite query implementation, search,
+context assembly, freshness comparison, and missing-sidecar behavior. It does not execute an LLM, so timings are
+retrieval/navigation proxies rather than end-to-end agent task durations.
+
+## Running the evaluation
+
+```sh
+cargo run --example repository_graph_eval -- --output /tmp/ferrus-rg2-eval.json
+```
+
+The command exits unsuccessfully when a required quality gate fails. Its versioned JSON report contains every case,
+expected and returned paths, graph-assisted and baseline metrics, cold/warm latency arrays, response-size arrays,
+gate observations, the deterministic fixture digest, and an automation recommendation. Cross-machine latency is
+recorded but is deliberately not compared with a fixed wall-clock threshold.
+
+`cargo test --test repository_graph_eval` runs the same corpus in the normal test gate and verifies the stable
+quality measurements. The corpus lives in `tests/fixtures/repository_graph_eval/cases.json`; the shared runner is
+under `tests/support/`, so evaluation code and fixtures do not become part of the production `ferrus` binary.
+
+## Corpus and baseline
+
+Corpus `rg2.5-v1` contains 26 labeled cases covering:
+
+- exact paths and exact unique symbols;
+- ambiguous symbols and supported discovery;
+- resolved dependencies, documentation, configuration, and malformed source;
+- unsupported macro/comment-only capability;
+- missing and stale indexes;
+- result truncation and repeated-query determinism.
+
+The fixture includes representative Rust modules, imports, duplicate names, Markdown, TOML, an executable entry
+point, malformed Rust, an intentionally unsupported comment-only concept, and unrelated filler files. Its digest
+includes both corpus JSON and all fixture paths/bodies.
+
+Graph-assisted cases issue one bounded graph operation and read zero source files unless a future case explicitly
+requests snippets. The deterministic baseline scans repository-relative paths/source files until all labeled
+relevant paths are found. Both sides record success, time to first relevant result, tool calls, files read, context
+bytes, graph-query bytes, and total measured duration.
+
+## Quality gates and current result
+
+The current deterministic run passes every initial RG2 gate:
+
+| Gate | Threshold | Observed |
+|---|---:|---:|
+| Exact path Recall@1 | 100% | 100% (4/4) |
+| Supported exact unique-symbol Recall@1 | 100% | 100% (4/4) |
+| Supported discovery Recall@10 | at least 90% | 93.75% (15/16) |
+| Repeated same-snapshot semantic determinism | 100% | 100% (2/2) |
+| No correctness regression versus supported navigation baseline | 100% | 100% (21/21) |
+| Median files-read or context-byte reduction | at least 20% | 100% files-read reduction |
+
+The same navigation subset currently has a negative median context-byte reduction (approximately `-772%`): broad
+`direction=both` context expansion can return substantially more serialized graph evidence than the baseline source
+scan, even though it avoids source-file reads. This is a real limitation, not a gate failure, because the normative
+threshold is files read **or** context bytes. It should guide ranking/policy work before any automatic injection.
+
+## Product decision
+
+The passing result makes stronger *optional* status/search guidance eligible. It does not enable automatic context
+injection: that remains outside Phase 2 and would be premature while context-byte volume is high and task worktree
+views are unavailable. The compact `ferrus://repository/summary` resource also remains unregistered; the evaluation
+provides no evidence that duplicating status in every resource consumer would reduce navigation cost.
+
+Future ranking or extractor revisions must rerun this corpus. A failed gate changes the report recommendation to
+`keep_stronger_guidance_disabled`; raw latency distributions remain diagnostic until stable platform-specific
+budgets are established.

--- a/docs/repository-graph-retrieval.md
+++ b/docs/repository-graph-retrieval.md
@@ -1,0 +1,74 @@
+# Repository Graph Retrieval Contract
+
+This document is the normative retrieval contract shared by the local CLI, role-scoped MCP adapters, and future
+remote repository-graph backends. Backend-specific storage, task leases, and process working directories are not
+part of this contract.
+
+## Version and identity
+
+Every request carries `scope.wire_version`, an explicit repository identity, a published-view or immutable-snapshot
+selector, and non-zero client budgets. Every successful snapshot query returns the supported wire version, the
+repository and snapshot identities, the indexed source-revision ID and manifest digest, freshness, diagnostics,
+pagination/truncation state, and operation data. Status uses the same envelope fields, with optional snapshot and
+source-revision identities when no compatible published snapshot exists.
+
+Cursors are opaque. A cursor is bound to the wire format, operation, immutable snapshot, and normalized request
+parameters. Reusing it for another operation, snapshot, search text, filter set, or lookup is `stale_cursor`.
+Publishing a newer view does not invalidate a cursor explicitly pinned to its immutable snapshot.
+
+## Orthogonal status
+
+Availability, the newest build attempt, and published-snapshot freshness remain independent:
+
+- availability is `not_built`, `available`, or `incompatible`;
+- build state is `building`, `complete`, `published`, `failed`, or `superseded` when an attempt exists;
+- freshness is `fresh`, `stale`, `unknown`, or `not_applicable`.
+
+This permits an available published snapshot to be reported together with a newer failed refresh. Machine-readable
+recommended actions are `index`, `wait_for_build`, `retry_index`, `refresh_index`, and `rebuild`. With no published
+snapshot, ordinary queries distinguish `not_built`, `index_building`, and `index_failed`; status returns those
+conditions as data so an agent can inspect them without treating optional graph absence as an internal failure.
+
+## Search
+
+Search considers normalized names, semantic keys, and repository-relative evidence paths. Node-kind filters are
+exact and path filters match the exact repository path or descendants; path text is escaped before SQL `LIKE`
+matching. The primary match classification and ordering are:
+
+1. exact semantic key;
+2. exact repository-relative path;
+3. exact normalized name;
+4. normalized-name prefix;
+5. normalized-name substring;
+6. semantic-key substring;
+7. path substring.
+
+Ties are ordered by normalized name and opaque node ID. Responses expose the primary `match_kind`, score, and all
+matched fields. Repeating a request against the same snapshot produces semantically identical ordered results.
+
+## Evidence and context contracts
+
+Returned graph facts retain extractor identity and version, evidence content identity, repository-relative path,
+optional half-open source span, resolution state, and confidence. Missing evidence remains explicit; it is never
+reconstructed from the process current working directory. An absent relationship means only that the index does
+not know it.
+
+Context requests use one or more typed node, semantic-key, or path seeds plus an explicit direction, edge-kind
+filter, and unresolved/external inclusion policy. Context items carry fact provenance and typed selection reasons.
+Ranking and assembly are implemented in RG2.2, but must preserve this request and response contract.
+
+## Diagnostics, pagination, and budgets
+
+Diagnostics contain bounded machine codes, severity, and optional repository-relative locations, never source
+bodies or free-form parser text. Summary counts describe the full snapshot diagnostic set; ordered diagnostic items
+are independently capped and state whether items were truncated.
+
+Service limits cap requested results, result bytes, depth, duration, and diagnostic items. Result and byte
+exhaustion returns the deterministic prefix that fits. A first item larger than the byte budget returns an empty,
+terminal truncated page rather than a cursor that cannot advance. Duration exhaustion returns a valid response
+with `duration` truncation and any completed deterministic prefix; it is not a generic backend error. A continuation
+cursor is issued only after at least one result was returned and only when that operation supports continuation.
+
+Invalid versions, requests, selectors, or cursors remain typed errors. Storage corruption or unavailability is a
+backend error; optional absence, active indexing, a failed build, incompatibility, staleness, and budget truncation
+must not be collapsed into that category.

--- a/docs/repository-graph-retrieval.md
+++ b/docs/repository-graph-retrieval.md
@@ -108,3 +108,10 @@ tool name, snapshot identity, freshness, duration, result count, serialized resp
 diagnostic count, and error category. Its metric type cannot represent request text, filters, repository paths,
 snippets, or source bodies. Telemetry remains operational and does not mutate either `ferrus.db` or the read-only
 repository graph sidecar.
+
+## Evaluation gate
+
+The deterministic navigation corpus, baseline definition, reproducible JSON runner, current quality results, and
+automation decision are documented in [Repository Graph Navigation Evaluations](repository-graph-evaluations.md).
+Retrieval or ranking changes must preserve its correctness and recall gates; latency remains recorded rather than
+hard-gated across machines.

--- a/docs/repository-graph-retrieval.md
+++ b/docs/repository-graph-retrieval.md
@@ -65,6 +65,21 @@ kind, semantic key, then opaque node ID. Selection priority is exact seed, conta
 dependency, documentation, configuration, then other relationships. Local assembly additionally has a bounded
 candidate/edge safety cap; exhausting it returns `capability` truncation rather than silently dropping facts.
 
+## Verified snippets
+
+Source text is opt-in on `repository_context`; structural results never embed file bodies by default. Requested
+snippets are deduplicated by repository path, span, and content identity, and are returned separately from ranked
+context items. The local adapter resolves every excerpt through `SnapshotContent` using the response repository,
+immutable snapshot, repository-relative path, and expected content digest. The reader holds a canonical source-root
+handle, rejects symbolic-link traversal, reapplies sensitive/source policy, verifies size, mode, and SHA-256 before
+slicing the half-open byte span, and then applies an independent aggregate snippet-byte cap.
+
+Changed, unavailable, excluded, or non-UTF-8 content is omitted and represented by bounded location-bearing
+diagnostics (`content.changed`, `content.unavailable`, or `content.non_utf8`). Snippet budget exhaustion is explicit
+and never causes unverified bytes to be returned. A compact `ferrus://repository/summary` resource is intentionally
+not registered in Phase 2 yet: before RG2.5 usefulness measurements it would duplicate status, consume prompt
+space, and weaken the status/search/context-on-demand guidance.
+
 ## Diagnostics, pagination, and budgets
 
 Diagnostics contain bounded machine codes, severity, and optional repository-relative locations, never source
@@ -80,3 +95,16 @@ cursor is issued only after at least one result was returned and only when that 
 Invalid versions, requests, selectors, or cursors remain typed errors. Storage corruption or unavailability is a
 backend error; optional absence, active indexing, a failed build, incompatibility, staleness, and budget truncation
 must not be collapsed into that category.
+
+## MCP boundary and telemetry
+
+Supervisor, Executor, and unfiltered servers expose the same read-only `repository_graph_status`,
+`repository_search`, and `repository_context` tools. None resolves, claims, renews, or mutates a task lease. Tool
+descriptions recommend status-first use, bounded requests, and the correct interpretation of missing relationships;
+task/review prompts contain no graph output.
+
+When `[repository_graph.telemetry].enabled = true`, each query emits one structured privacy-safe tracing metric with
+tool name, snapshot identity, freshness, duration, result count, serialized response bytes, truncation reason,
+diagnostic count, and error category. Its metric type cannot represent request text, filters, repository paths,
+snippets, or source bodies. Telemetry remains operational and does not mutate either `ferrus.db` or the read-only
+repository graph sidecar.

--- a/docs/repository-graph-retrieval.md
+++ b/docs/repository-graph-retrieval.md
@@ -55,7 +55,15 @@ not know it.
 
 Context requests use one or more typed node, semantic-key, or path seeds plus an explicit direction, edge-kind
 filter, and unresolved/external inclusion policy. Context items carry fact provenance and typed selection reasons.
-Ranking and assembly are implemented in RG2.2, but must preserve this request and response contract.
+Seed resolution is exact and may produce multiple nodes for a shared semantic key or evidence path; a missing seed
+is an invalid request rather than a guessed match. Expansion is cycle-safe and deduplicates nodes reached through
+multiple relationships while retaining their distinct selection reasons. Nodes without source evidence may guide
+traversal but are not emitted as context items.
+
+Context ranking is deterministic: best selection reason, expansion depth, evidence path and start offset, node
+kind, semantic key, then opaque node ID. Selection priority is exact seed, containment, declaration, resolved
+dependency, documentation, configuration, then other relationships. Local assembly additionally has a bounded
+candidate/edge safety cap; exhausting it returns `capability` truncation rather than silently dropping facts.
 
 ## Diagnostics, pagination, and budgets
 

--- a/docs/specs/2026-07-10-rg2-agent-retrieval.md
+++ b/docs/specs/2026-07-10-rg2-agent-retrieval.md
@@ -179,13 +179,20 @@ with status-first generated skill guidance and structured opt-in query telemetry
 snapshot, freshness, duration, counts, response bytes, truncation, and error category; their type cannot contain
 queries, paths, snippets, or source bodies, and repository reads remain independent from task leases/runtime state.
 
-- [ ] #2.5 Build repository navigation evaluations and establish usefulness gates
+- [x] #2.5 Build repository navigation evaluations and establish usefulness gates
 
 ID: rg2.5
 Depends on: rg2.3, rg2.4
 
 Create deterministic fixtures and graph-assisted versus baseline evaluation scenarios, record performance and
 context-volume results, and document thresholds for retrieval quality and later automation decisions.
+
+Implemented by the versioned 26-case corpus in `tests/fixtures/repository_graph_eval`, a shared real-index/query
+harness, `cargo test --test repository_graph_eval`, and the machine-readable
+`cargo run --example repository_graph_eval -- --output <path>` runner. Current gates achieve 100% exact-path and
+unique-symbol Recall@1, 93.75% supported-discovery Recall@10, 100% repeated-query determinism, no supported baseline
+regression, and 100% median files-read reduction. Context bytes remain substantially higher for broad traversal, so
+optional retrieval guidance is eligible while automatic injection and the summary resource remain disabled.
 
 ## Acceptance Criteria
 
@@ -229,6 +236,7 @@ context-volume results, and document thresholds for retrieval quality and later 
 - Token counting differs across agent models. Byte and character caps should remain authoritative even when an
   estimated token budget is reported.
 - Query metrics must be useful without logging sensitive user searches or source content.
-- It remains open whether `ferrus://repository/summary` adds value beyond the status and context tools.
+- RG2.5 found no evidence that `ferrus://repository/summary` adds value beyond status and on-demand tools, so it
+  remains unregistered; reevaluate only with a measured navigation benefit.
 - Cursor stability across snapshot publication must be defined; the safest default is to scope every cursor to
   one immutable snapshot.

--- a/docs/specs/2026-07-10-rg2-agent-retrieval.md
+++ b/docs/specs/2026-07-10-rg2-agent-retrieval.md
@@ -113,13 +113,18 @@ not optional polish.
 
 ## Milestones
 
-- [ ] #2.0 Stabilize repository retrieval semantics and response envelopes
+- [x] #2.0 Stabilize repository retrieval semantics and response envelopes
 
 ID: rg2.0
 Depends on: none
 
 Finalize MCP request/response schemas, freshness and error states, deterministic ordering, evidence rules,
 pagination, and hard budget behavior using the Phase 1 CLI queries as executable reference behavior.
+
+Normative contract: [Repository Graph Retrieval Contract](../repository-graph-retrieval.md). Implemented in
+`src/repository_graph/query.rs` and `src/repository_graph/query_sqlite.rs`, including typed context seeds, explicit
+source-revision envelopes, orthogonal index/build/freshness states, deterministic match classification,
+snapshot-bound pagination, bounded diagnostics, and valid truncation responses for hard budget exhaustion.
 
 - [ ] #2.1 Add graph status and bounded search MCP tools
 

--- a/docs/specs/2026-07-10-rg2-agent-retrieval.md
+++ b/docs/specs/2026-07-10-rg2-agent-retrieval.md
@@ -126,13 +126,18 @@ Normative contract: [Repository Graph Retrieval Contract](../repository-graph-re
 source-revision envelopes, orthogonal index/build/freshness states, deterministic match classification,
 snapshot-bound pagination, bounded diagnostics, and valid truncation responses for hard budget exhaustion.
 
-- [ ] #2.1 Add graph status and bounded search MCP tools
+- [x] #2.1 Add graph status and bounded search MCP tools
 
 ID: rg2.1
 Depends on: rg2.0
 
 Register read-only status and search tools for both roles, implement missing/stale/building/failed behavior,
 filters and pagination, and verify that graph reads require no task lease and mutate no runtime state.
+
+Implemented by the shared local adapter in `src/repository_graph_runtime.rs` and the role-visible
+`repository_graph_status` and `repository_search` handlers in `src/server/tools/`. The MCP boundary preserves
+Phase 1 status/search envelopes, bounded filters and cursors, uses no task context or lease helpers, and has a
+runtime-isolation test proving that reads neither open nor alter `ferrus.db`.
 
 - [ ] #2.2 Implement deterministic bounded context assembly
 

--- a/docs/specs/2026-07-10-rg2-agent-retrieval.md
+++ b/docs/specs/2026-07-10-rg2-agent-retrieval.md
@@ -139,13 +139,18 @@ Implemented by the shared local adapter in `src/repository_graph_runtime.rs` and
 Phase 1 status/search envelopes, bounded filters and cursors, uses no task context or lease helpers, and has a
 runtime-isolation test proving that reads neither open nor alter `ferrus.db`.
 
-- [ ] #2.2 Implement deterministic bounded context assembly
+- [x] #2.2 Implement deterministic bounded context assembly
 
 ID: rg2.2
 Depends on: rg2.0
 
 Build seed resolution, evidence-preserving expansion, deterministic ranking, deduplication, diagnostics,
 truncation, and continuation behavior for `repository_context`.
+
+Implemented by `SqliteGraphQuery::context`, with exact typed seed resolution, policy-aware cycle-safe expansion,
+evidence-preserving deterministic ranking, snapshot/parameter-bound cursors, diagnostics, and explicit
+result/byte/depth/duration/capability truncation. `ferrus graph context` consumes the same machine-local runtime
+adapter that the role-scoped MCP boundary will expose in RG2.4.
 
 - [ ] #2.3 Add hash-verified source snippets and repository summary
 

--- a/docs/specs/2026-07-10-rg2-agent-retrieval.md
+++ b/docs/specs/2026-07-10-rg2-agent-retrieval.md
@@ -152,7 +152,7 @@ evidence-preserving deterministic ranking, snapshot/parameter-bound cursors, dia
 result/byte/depth/duration/capability truncation. `ferrus graph context` consumes the same machine-local runtime
 adapter that the role-scoped MCP boundary will expose in RG2.4.
 
-- [ ] #2.3 Add hash-verified source snippets and repository summary
+- [x] #2.3 Add hash-verified source snippets and repository summary
 
 ID: rg2.3
 Depends on: rg2.1, rg2.2
@@ -160,13 +160,24 @@ Depends on: rg2.1, rg2.2
 Implement safe on-demand snippet retrieval with content-identity verification and sensitive-path checks, plus a
 strictly bounded deterministic summary resource if it remains useful after measurement.
 
-- [ ] #2.4 Integrate role-scoped MCP registration, guidance, and query telemetry
+Implemented by `LocalSnapshotContent` and the shared context runtime adapter. Opt-in snippets are root-confined,
+symlink-safe, source-policy checked, SHA-256 verified against immutable snapshot file metadata, span sliced,
+deduplicated, and independently byte bounded; changed/unavailable content produces location-bearing diagnostics.
+The conditional summary resource remains unregistered until RG2.5 demonstrates value because it currently
+duplicates status and would add unsolicited context volume.
+
+- [x] #2.4 Integrate role-scoped MCP registration, guidance, and query telemetry
 
 ID: rg2.4
 Depends on: rg2.1, rg2.2
 
 Complete server registration, tool schemas, tests, user and agent guidance, and privacy-safe query metrics without
 injecting graph output into task or review prompts.
+
+Implemented by the bounded `repository_context` schema/handler registered beside status and search for both roles,
+with status-first generated skill guidance and structured opt-in query telemetry. Metrics record only tool,
+snapshot, freshness, duration, counts, response bytes, truncation, and error category; their type cannot contain
+queries, paths, snippets, or source bodies, and repository reads remain independent from task leases/runtime state.
 
 - [ ] #2.5 Build repository navigation evaluations and establish usefulness gates
 

--- a/examples/repository_graph_eval.rs
+++ b/examples/repository_graph_eval.rs
@@ -1,0 +1,39 @@
+#[path = "../tests/support/repository_graph_eval.rs"]
+mod repository_graph_eval;
+
+use anyhow::{Context, Result, bail};
+use ferrus::repository_graph::extractors::cargo::run_parser_worker_if_requested;
+
+fn main() -> Result<()> {
+    if run_parser_worker_if_requested().context("Cargo parser worker protocol failed")? {
+        return Ok(());
+    }
+
+    let mut output = None;
+    let mut arguments = std::env::args().skip(1);
+    while let Some(argument) = arguments.next() {
+        match argument.as_str() {
+            "--output" => {
+                output = Some(
+                    arguments
+                        .next()
+                        .context("--output requires a JSON report path")?,
+                );
+            }
+            unknown => bail!("unknown repository graph evaluation argument: {unknown}"),
+        }
+    }
+
+    let report = repository_graph_eval::run_evaluation()?;
+    let passed = report.gates.all_passed;
+    let json = serde_json::to_string_pretty(&report)?;
+    if let Some(path) = output {
+        std::fs::write(path, format!("{json}\n"))?;
+    } else {
+        println!("{json}");
+    }
+    if !passed {
+        bail!("one or more repository graph usefulness gates failed");
+    }
+    Ok(())
+}

--- a/src/agents/codex/mod.rs
+++ b/src/agents/codex/mod.rs
@@ -428,6 +428,8 @@ fn auto_approved_tools(role: &str) -> &'static [&'static str] {
             "status",
             "reset",
             "heartbeat",
+            "repository_graph_status",
+            "repository_search",
         ],
         ROLE_SUPERVISOR => &[
             "enqueue_task",
@@ -442,6 +444,8 @@ fn auto_approved_tools(role: &str) -> &'static [&'static str] {
             "ask_human",
             "wait_for_answer",
             "heartbeat",
+            "repository_graph_status",
+            "repository_search",
         ],
         _ => &[],
     }
@@ -787,6 +791,8 @@ args = []
         let tools = entry.get("tools").and_then(toml::Value::as_table).unwrap();
         assert!(tools.contains_key("wait_for_task"));
         assert!(tools.contains_key("submit"));
+        assert!(tools.contains_key("repository_graph_status"));
+        assert!(tools.contains_key("repository_search"));
         assert!(!tools.contains_key("approve"));
     }
 
@@ -800,14 +806,16 @@ args = []
         assert!(tools.contains_key("archive_spec"));
         assert!(tools.contains_key("wait_for_consultation"));
         assert!(tools.contains_key("heartbeat"));
+        assert!(tools.contains_key("repository_graph_status"));
+        assert!(tools.contains_key("repository_search"));
         assert!(!tools.contains_key("create_task"));
         assert!(!tools.contains_key("submit"));
     }
 
     #[test]
     fn codex_tool_approval_sets_match_role_needs() {
-        assert!(auto_approved_tools(ROLE_EXECUTOR).len() <= 10);
-        assert!(auto_approved_tools(ROLE_SUPERVISOR).len() <= 12);
+        assert!(auto_approved_tools(ROLE_EXECUTOR).len() <= 12);
+        assert!(auto_approved_tools(ROLE_SUPERVISOR).len() <= 14);
     }
 
     #[test]

--- a/src/agents/codex/mod.rs
+++ b/src/agents/codex/mod.rs
@@ -430,6 +430,7 @@ fn auto_approved_tools(role: &str) -> &'static [&'static str] {
             "heartbeat",
             "repository_graph_status",
             "repository_search",
+            "repository_context",
         ],
         ROLE_SUPERVISOR => &[
             "enqueue_task",
@@ -446,6 +447,7 @@ fn auto_approved_tools(role: &str) -> &'static [&'static str] {
             "heartbeat",
             "repository_graph_status",
             "repository_search",
+            "repository_context",
         ],
         _ => &[],
     }
@@ -793,6 +795,10 @@ args = []
         assert!(tools.contains_key("submit"));
         assert!(tools.contains_key("repository_graph_status"));
         assert!(tools.contains_key("repository_search"));
+        assert_eq!(
+            tools["repository_context"]["approval_mode"].as_str(),
+            Some("approve")
+        );
         assert!(!tools.contains_key("approve"));
     }
 
@@ -808,14 +814,18 @@ args = []
         assert!(tools.contains_key("heartbeat"));
         assert!(tools.contains_key("repository_graph_status"));
         assert!(tools.contains_key("repository_search"));
+        assert_eq!(
+            tools["repository_context"]["approval_mode"].as_str(),
+            Some("approve")
+        );
         assert!(!tools.contains_key("create_task"));
         assert!(!tools.contains_key("submit"));
     }
 
     #[test]
     fn codex_tool_approval_sets_match_role_needs() {
-        assert!(auto_approved_tools(ROLE_EXECUTOR).len() <= 12);
-        assert!(auto_approved_tools(ROLE_SUPERVISOR).len() <= 14);
+        assert!(auto_approved_tools(ROLE_EXECUTOR).len() <= 13);
+        assert!(auto_approved_tools(ROLE_SUPERVISOR).len() <= 15);
     }
 
     #[test]

--- a/src/cli/commands/graph.rs
+++ b/src/cli/commands/graph.rs
@@ -1,6 +1,5 @@
 use std::{
     num::{NonZeroU32, NonZeroU64},
-    path::{Path, PathBuf},
     sync::atomic::{AtomicU64, Ordering},
     time::{SystemTime, UNIX_EPOCH},
 };
@@ -11,32 +10,30 @@ use serde::Serialize;
 use sha2::{Digest as _, Sha256};
 
 use crate::{
-    project,
     repository_graph::{
-        QUERY_WIRE_VERSION,
         config::RepositoryGraphConfig,
         domain::{
             Availability, BuildId, EdgeTarget, Freshness, NodeId, PublishedViewName, QueryBudget,
-            RepoPath, RepositoryId, RepositoryNamespace, RepositoryRef, SemanticKey,
+            RepoPath, SemanticKey,
         },
         health::{SidecarHealth, inspect_health_at},
-        index::{IndexCoordinator, IndexOutcome, IndexRequest, active_extractor_identities},
+        index::{IndexCoordinator, IndexOutcome, IndexRequest},
         ports::GraphQuery,
         query::{
             DiagnosticsEnvelope, EdgeDirection, FreshnessEnvelope, NeighborhoodRequest, PageInfo,
-            PageRequest, QueryScope, RetrievalAction, SearchRequest, ShowLookup, ShowRequest,
-            SnapshotSelector, StatusData, StatusRequest, StatusResponse,
+            PageRequest, SearchRequest, ShowLookup, ShowRequest, StatusResponse,
         },
-        query_sqlite::{FreshnessComparison, SqliteGraphQuery, default_budget},
-        source::{LocalRepositorySource, SourceDiscoveryContext},
+        query_sqlite::{SqliteGraphQuery, default_budget},
         sqlite::{
-            OpenQuerySidecarResult, OpenSidecarResult, SIDECAR_FILE_NAME, Sidecar,
-            open_for_build_at, open_for_query_at,
+            OpenQuerySidecarResult, OpenSidecarResult, Sidecar, open_for_build_at,
+            open_for_query_at,
         },
+    },
+    repository_graph_runtime::{
+        CANONICAL_VIEW, LocalGraphContext, sidecar_path, status_response_at,
     },
 };
 
-const CANONICAL_VIEW: &str = "canonical";
 static BUILD_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Subcommand)]
@@ -152,64 +149,6 @@ pub async fn run(command: GraphCommand) -> Result<()> {
     }
 }
 
-struct LocalGraphContext {
-    root: std::path::PathBuf,
-    repository: RepositoryRef,
-    config: RepositoryGraphConfig,
-}
-
-impl LocalGraphContext {
-    async fn load(require_enabled: bool) -> Result<Self> {
-        let root = project::canonical_project_root().await?;
-        let contents = tokio::fs::read_to_string(root.join("ferrus.toml"))
-            .await
-            .context("ferrus.toml not found — run ferrus init first")?;
-        let config = RepositoryGraphConfig::from_ferrus_toml(&contents)
-            .context("Invalid [repository_graph] configuration")?;
-        if require_enabled && !config.enabled {
-            anyhow::bail!(
-                "repository graph is disabled; set repository_graph.enabled = true in ferrus.toml"
-            );
-        }
-        let project_id = project::current_project_id().await?;
-        Ok(Self {
-            root,
-            repository: RepositoryRef {
-                namespace: RepositoryNamespace::new(format!("local:{project_id}"))?,
-                repository_id: RepositoryId::new("root")?,
-            },
-            config,
-        })
-    }
-
-    fn discover(&self) -> Result<LocalRepositorySource> {
-        let identities = active_extractor_identities(&self.config)?;
-        let context = SourceDiscoveryContext::from_config(
-            self.repository.clone(),
-            &self.config,
-            &identities,
-        )?;
-        LocalRepositorySource::discover(&self.root, context)
-            .context("Failed to discover the canonical repository source")
-    }
-
-    fn freshness_comparison(&self) -> Result<Option<FreshnessComparison>> {
-        if !self.config.enabled {
-            return Ok(None);
-        }
-        let source = self.discover()?;
-        Ok(Some(FreshnessComparison::from_manifest(source.manifest())))
-    }
-
-    fn scope(&self, budget: QueryBudget) -> Result<QueryScope> {
-        Ok(QueryScope::current(
-            self.repository.clone(),
-            SnapshotSelector::Published(PublishedViewName::new(CANONICAL_VIEW)?),
-            budget,
-        ))
-    }
-}
-
 #[derive(Serialize)]
 struct IndexOutput {
     status: &'static str,
@@ -310,47 +249,6 @@ async fn status(json: bool) -> Result<()> {
         }
     }
     Ok(())
-}
-
-fn status_response_at(
-    context: &LocalGraphContext,
-    sidecar_path: &Path,
-    freshness_comparison: Option<FreshnessComparison>,
-) -> Result<StatusResponse> {
-    match open_for_query_at(sidecar_path) {
-        Ok(OpenQuerySidecarResult::Ready(sidecar)) => {
-            let query = SqliteGraphQuery::new(
-                &sidecar,
-                context.config.query_limits.clone(),
-                freshness_comparison,
-            );
-            Ok(query.status(&StatusRequest {
-                scope: context.scope(default_budget(&context.config.query_limits)?)?,
-            })?)
-        }
-        Ok(OpenQuerySidecarResult::Absent) => unavailable_status(
-            context.repository.clone(),
-            Availability::NotBuilt,
-            "not_built",
-        ),
-        Ok(OpenQuerySidecarResult::NeedsMigration {
-            found_schema_version,
-        }) => unavailable_status(
-            context.repository.clone(),
-            Availability::Incompatible,
-            &format!("schema_{found_schema_version}_needs_migration"),
-        ),
-        Ok(OpenQuerySidecarResult::RequiresRebuild(_)) => unavailable_status(
-            context.repository.clone(),
-            Availability::Incompatible,
-            "incompatible_schema",
-        ),
-        Err(_) => unavailable_status(
-            context.repository.clone(),
-            Availability::Incompatible,
-            "sidecar_unreadable",
-        ),
-    }
 }
 
 async fn search(
@@ -546,12 +444,6 @@ async fn ready_query_sidecar() -> Result<Sidecar> {
     }
 }
 
-async fn sidecar_path() -> Result<PathBuf> {
-    Ok(project::current_project_data_dir()
-        .await?
-        .join(SIDECAR_FILE_NAME))
-}
-
 fn requested_budget(
     config: &RepositoryGraphConfig,
     results: Option<u32>,
@@ -570,42 +462,6 @@ fn requested_budget(
         NonZeroU32::new(defaults.max_diagnostics)
             .context("repository_graph.query_limits.max_diagnostics must be greater than zero")?,
     ))
-}
-
-fn unavailable_status(
-    repository: RepositoryRef,
-    availability: Availability,
-    reason: &str,
-) -> Result<StatusResponse> {
-    Ok(StatusResponse {
-        wire_version: QUERY_WIRE_VERSION,
-        repository,
-        snapshot_id: None,
-        source_revision: None,
-        freshness: FreshnessEnvelope {
-            freshness: Freshness::NotApplicable,
-            compared_manifest: None,
-            reason_codes: vec![reason.to_string()],
-        },
-        diagnostics: DiagnosticsEnvelope::default(),
-        page: PageInfo {
-            next_cursor: None,
-            truncation: None,
-        },
-        data: StatusData {
-            availability,
-            build_state: None,
-            build_id: None,
-            published_view: Some(PublishedViewName::new(CANONICAL_VIEW)?),
-            graph_model_version: None,
-            statistics: None,
-            recommended_action: Some(match availability {
-                Availability::NotBuilt => RetrievalAction::Index,
-                Availability::Incompatible => RetrievalAction::Rebuild,
-                Availability::Available => RetrievalAction::RefreshIndex,
-            }),
-        },
-    })
 }
 
 fn print_query_header(
@@ -709,25 +565,5 @@ mod tests {
     fn evidence_locations_are_repository_relative() {
         let path = RepoPath::new("src/main.rs").unwrap();
         assert_eq!(evidence_location(Some(&path), None), "src/main.rs");
-    }
-
-    #[test]
-    fn unreadable_sidecar_is_reported_as_incompatible_status() {
-        let directory = tempfile::tempdir().unwrap();
-        let sidecar_path = directory.path().join(SIDECAR_FILE_NAME);
-        std::fs::write(&sidecar_path, b"not a sqlite database").unwrap();
-        let context = LocalGraphContext {
-            root: directory.path().to_path_buf(),
-            repository: RepositoryRef {
-                namespace: RepositoryNamespace::new("local:test").unwrap(),
-                repository_id: RepositoryId::new("root").unwrap(),
-            },
-            config: RepositoryGraphConfig::default(),
-        };
-
-        let response = status_response_at(&context, &sidecar_path, None).unwrap();
-
-        assert_eq!(response.data.availability, Availability::Incompatible);
-        assert_eq!(response.freshness.reason_codes, ["sidecar_unreadable"]);
     }
 }

--- a/src/cli/commands/graph.rs
+++ b/src/cli/commands/graph.rs
@@ -20,8 +20,9 @@ use crate::{
         index::{IndexCoordinator, IndexOutcome, IndexRequest},
         ports::GraphQuery,
         query::{
-            DiagnosticsEnvelope, EdgeDirection, FreshnessEnvelope, NeighborhoodRequest, PageInfo,
-            PageRequest, SearchRequest, ShowLookup, ShowRequest, StatusResponse,
+            ContextPolicy, ContextRequest, ContextSeed, DiagnosticsEnvelope, EdgeDirection,
+            FreshnessEnvelope, NeighborhoodRequest, PageInfo, PageRequest, SearchRequest,
+            ShowLookup, ShowRequest, StatusResponse,
         },
         query_sqlite::{SqliteGraphQuery, default_budget},
         sqlite::{
@@ -71,6 +72,8 @@ pub enum GraphCommand {
     },
     /// Inspect nodes selected by opaque id, semantic key, or evidence path.
     Show(ShowArgs),
+    /// Assemble deterministic evidence-backed context around one exact seed.
+    Context(ContextArgs),
     /// Traverse a bounded incoming/outgoing graph neighborhood.
     Neighbors {
         node_id: String,
@@ -108,6 +111,32 @@ pub struct ShowArgs {
     json: bool,
 }
 
+#[derive(Debug, Args)]
+#[group(skip)]
+pub struct ContextArgs {
+    /// Seed context with one opaque node id.
+    #[arg(long)]
+    node: Option<String>,
+    /// Seed context with one exact semantic key.
+    #[arg(long)]
+    symbol: Option<String>,
+    /// Seed context with one exact repository-relative evidence path.
+    #[arg(long)]
+    path: Option<String>,
+    /// Requested expansion depth; the configured service cap still applies.
+    #[arg(long)]
+    depth: Option<u32>,
+    /// Requested result count; the configured service cap still applies.
+    #[arg(long = "max-results")]
+    max_results: Option<u32>,
+    /// Requested response bytes; the configured service cap still applies.
+    #[arg(long = "max-bytes")]
+    max_bytes: Option<u64>,
+    /// Emit one machine-readable JSON document.
+    #[arg(long)]
+    json: bool,
+}
+
 #[derive(Debug, Clone, Copy, Default, ValueEnum)]
 pub enum Direction {
     Outgoing,
@@ -138,6 +167,7 @@ pub async fn run(command: GraphCommand) -> Result<()> {
             json,
         } => search(query, kinds, path, limit, json).await,
         GraphCommand::Show(args) => show(args).await,
+        GraphCommand::Context(args) => context(args).await,
         GraphCommand::Neighbors {
             node_id,
             direction,
@@ -266,7 +296,7 @@ async fn search(
         context.freshness_comparison()?,
     );
     let response = query.search(&SearchRequest {
-        scope: context.scope(requested_budget(&context.config, limit, None)?)?,
+        scope: context.scope(requested_budget(&context.config, limit, None, None)?)?,
         text,
         node_kinds: kinds,
         paths: path
@@ -370,6 +400,80 @@ async fn show(args: ShowArgs) -> Result<()> {
     Ok(())
 }
 
+async fn context(args: ContextArgs) -> Result<()> {
+    if usize::from(args.node.is_some())
+        + usize::from(args.symbol.is_some())
+        + usize::from(args.path.is_some())
+        != 1
+    {
+        anyhow::bail!("graph context requires exactly one of --node, --symbol, or --path");
+    }
+    let context = LocalGraphContext::load(true).await?;
+    let seed = if let Some(node) = args.node {
+        ContextSeed::Node(NodeId::new(node)?)
+    } else if let Some(symbol) = args.symbol {
+        ContextSeed::Symbol(SemanticKey::new(symbol)?)
+    } else {
+        ContextSeed::Path(
+            RepoPath::new(args.path.expect("one context seed is required"))
+                .context("--path must be repository-relative")?,
+        )
+    };
+    let response = context
+        .context(&ContextRequest {
+            scope: context.scope(requested_budget(
+                &context.config,
+                args.max_results,
+                args.max_bytes,
+                args.depth,
+            )?)?,
+            seeds: vec![seed],
+            policy: ContextPolicy {
+                direction: EdgeDirection::Both,
+                edge_kinds: vec![],
+                include_unresolved: false,
+                include_external: false,
+            },
+            page: PageRequest { cursor: None },
+        })
+        .await??;
+    if args.json {
+        print_json(&response)?;
+    } else {
+        print_query_header(
+            response.snapshot_id.as_str(),
+            &response.freshness,
+            &response.diagnostics,
+            &response.page,
+        );
+        for item in &response.data.items {
+            let reasons = item
+                .selection_reasons
+                .iter()
+                .map(|reason| format!("{:?}", reason.kind))
+                .collect::<Vec<_>>()
+                .join(",");
+            println!(
+                "{} {} {}",
+                item.kind,
+                item.semantic_key
+                    .as_ref()
+                    .map_or(item.node_id.as_str(), |key| key.as_str()),
+                evidence_location(Some(&item.path), item.span.as_ref())
+            );
+            println!(
+                "  selected={} resolution={:?} confidence={:?} extractor={}@{}",
+                reasons,
+                item.provenance.resolution,
+                item.provenance.confidence,
+                item.provenance.extractor.id,
+                item.provenance.extractor.version
+            );
+        }
+    }
+    Ok(())
+}
+
 async fn neighbors(
     node_id: String,
     direction: Direction,
@@ -386,7 +490,7 @@ async fn neighbors(
         context.freshness_comparison()?,
     );
     let response = query.neighborhood(&NeighborhoodRequest {
-        scope: context.scope(requested_budget(&context.config, limit, depth)?)?,
+        scope: context.scope(requested_budget(&context.config, limit, None, depth)?)?,
         roots: vec![NodeId::new(node_id)?],
         direction: direction.into(),
         edge_kinds: kinds,
@@ -447,14 +551,15 @@ async fn ready_query_sidecar() -> Result<Sidecar> {
 fn requested_budget(
     config: &RepositoryGraphConfig,
     results: Option<u32>,
+    bytes: Option<u64>,
     depth: Option<u32>,
 ) -> Result<QueryBudget> {
     let defaults = &config.query_limits;
     Ok(QueryBudget::new(
         NonZeroU32::new(results.unwrap_or(defaults.max_results))
             .context("--limit must be greater than zero")?,
-        NonZeroU64::new(defaults.max_bytes)
-            .context("repository_graph.query_limits.max_bytes must be greater than zero")?,
+        NonZeroU64::new(bytes.unwrap_or(defaults.max_bytes))
+            .context("--max-bytes must be greater than zero")?,
         NonZeroU32::new(depth.unwrap_or(defaults.max_depth))
             .context("--depth must be greater than zero")?,
         NonZeroU64::new(defaults.max_duration_ms)
@@ -557,8 +662,9 @@ mod tests {
     #[test]
     fn requested_budgets_reject_zero_cli_values() {
         let config = RepositoryGraphConfig::default();
-        assert!(requested_budget(&config, Some(0), None).is_err());
-        assert!(requested_budget(&config, None, Some(0)).is_err());
+        assert!(requested_budget(&config, Some(0), None, None).is_err());
+        assert!(requested_budget(&config, None, Some(0), None).is_err());
+        assert!(requested_budget(&config, None, None, Some(0)).is_err());
     }
 
     #[test]

--- a/src/cli/commands/graph.rs
+++ b/src/cli/commands/graph.rs
@@ -419,24 +419,28 @@ async fn context(args: ContextArgs) -> Result<()> {
                 .context("--path must be repository-relative")?,
         )
     };
-    let response = context
-        .context(&ContextRequest {
-            scope: context.scope(requested_budget(
-                &context.config,
-                args.max_results,
-                args.max_bytes,
-                args.depth,
-            )?)?,
-            seeds: vec![seed],
-            policy: ContextPolicy {
-                direction: EdgeDirection::Both,
-                edge_kinds: vec![],
-                include_unresolved: false,
-                include_external: false,
-            },
-            page: PageRequest { cursor: None },
-        })
-        .await??;
+    let sidecar = ready_query_sidecar().await?;
+    let query = SqliteGraphQuery::new(
+        &sidecar,
+        context.config.query_limits.clone(),
+        context.freshness_comparison()?,
+    );
+    let response = query.context(&ContextRequest {
+        scope: context.scope(requested_budget(
+            &context.config,
+            args.max_results,
+            args.max_bytes,
+            args.depth,
+        )?)?,
+        seeds: vec![seed],
+        policy: ContextPolicy {
+            direction: EdgeDirection::Both,
+            edge_kinds: vec![],
+            include_unresolved: false,
+            include_external: false,
+        },
+        page: PageRequest { cursor: None },
+    })?;
     if args.json {
         print_json(&response)?;
     } else {

--- a/src/cli/commands/graph.rs
+++ b/src/cli/commands/graph.rs
@@ -23,9 +23,9 @@ use crate::{
         index::{IndexCoordinator, IndexOutcome, IndexRequest, active_extractor_identities},
         ports::GraphQuery,
         query::{
-            DiagnosticSummary, EdgeDirection, FreshnessEnvelope, NeighborhoodRequest, PageInfo,
-            PageRequest, QueryScope, SearchRequest, ShowLookup, ShowRequest, SnapshotSelector,
-            StatusData, StatusRequest, StatusResponse,
+            DiagnosticsEnvelope, EdgeDirection, FreshnessEnvelope, NeighborhoodRequest, PageInfo,
+            PageRequest, QueryScope, RetrievalAction, SearchRequest, ShowLookup, ShowRequest,
+            SnapshotSelector, StatusData, StatusRequest, StatusResponse,
         },
         query_sqlite::{FreshnessComparison, SqliteGraphQuery, default_budget},
         source::{LocalRepositorySource, SourceDiscoveryContext},
@@ -202,7 +202,7 @@ impl LocalGraphContext {
     }
 
     fn scope(&self, budget: QueryBudget) -> Result<QueryScope> {
-        Ok(QueryScope::v1(
+        Ok(QueryScope::current(
             self.repository.clone(),
             SnapshotSelector::Published(PublishedViewName::new(CANONICAL_VIEW)?),
             budget,
@@ -567,6 +567,8 @@ fn requested_budget(
             .context("--depth must be greater than zero")?,
         NonZeroU64::new(defaults.max_duration_ms)
             .context("repository_graph.query_limits.max_duration_ms must be greater than zero")?,
+        NonZeroU32::new(defaults.max_diagnostics)
+            .context("repository_graph.query_limits.max_diagnostics must be greater than zero")?,
     ))
 }
 
@@ -579,18 +581,29 @@ fn unavailable_status(
         wire_version: QUERY_WIRE_VERSION,
         repository,
         snapshot_id: None,
+        source_revision: None,
         freshness: FreshnessEnvelope {
             freshness: Freshness::NotApplicable,
             compared_manifest: None,
             reason_codes: vec![reason.to_string()],
         },
-        diagnostics: DiagnosticSummary::default(),
+        diagnostics: DiagnosticsEnvelope::default(),
+        page: PageInfo {
+            next_cursor: None,
+            truncation: None,
+        },
         data: StatusData {
             availability,
             build_state: None,
+            build_id: None,
             published_view: Some(PublishedViewName::new(CANONICAL_VIEW)?),
             graph_model_version: None,
             statistics: None,
+            recommended_action: Some(match availability {
+                Availability::NotBuilt => RetrievalAction::Index,
+                Availability::Incompatible => RetrievalAction::Rebuild,
+                Availability::Available => RetrievalAction::RefreshIndex,
+            }),
         },
     })
 }
@@ -598,7 +611,7 @@ fn unavailable_status(
 fn print_query_header(
     snapshot: &str,
     freshness: &FreshnessEnvelope,
-    diagnostics: &DiagnosticSummary,
+    diagnostics: &DiagnosticsEnvelope,
     page: &PageInfo,
 ) {
     println!("Snapshot: {snapshot}");
@@ -617,10 +630,11 @@ fn print_query_header(
     }
 }
 
-fn print_diagnostics(diagnostics: &DiagnosticSummary) {
+fn print_diagnostics(diagnostics: &DiagnosticsEnvelope) {
+    let summary = &diagnostics.summary;
     println!(
         "Diagnostics: {} info, {} warnings, {} errors",
-        diagnostics.info, diagnostics.warning, diagnostics.error
+        summary.info, summary.warning, summary.error
     );
 }
 

--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -358,6 +358,15 @@ Supervisor sessions use `enqueue_task` for task creation and `archive_spec` for 
 | `reset` | Failed | Mark the failed task as reset |
 | `heartbeat` | any claimed | Renew lease; returns `{"status":"renewed"}` or `{"status":"error","code":"..."}` |
 
+### Repository retrieval
+
+Both roles can use the optional read-only `repository_graph_status`, `repository_search`, and
+`repository_context` tools without a task lease. Check status first when availability is unknown, use search for
+exact path/symbol discovery, then request a small bounded context packet. Ask for snippets only when source text is
+needed; snippets are hash-verified against the returned snapshot. Graph use is optional, and a missing relationship
+means only “not known by this index,” not proof that the relationship does not exist. These tools never build or
+mutate the index and graph output is not injected into task or review prompts.
+
 ## MCP resources
 
 | URI | Contents |

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -227,4 +227,25 @@ mod tests {
             .is_ok()
         );
     }
+
+    #[test]
+    fn graph_context_surface_parses_seed_and_hard_budget_requests() {
+        assert!(
+            Cli::try_parse_from([
+                "ferrus",
+                "graph",
+                "context",
+                "--symbol",
+                "rust:struct:src/lib.rs:Thing",
+                "--depth",
+                "2",
+                "--max-results",
+                "12",
+                "--max-bytes",
+                "4096",
+                "--json",
+            ])
+            .is_ok()
+        );
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod hq;
 mod legacy_state;
 mod platform;
 mod project;
+mod repository_graph_runtime;
 mod runtime_status;
 mod runtime_table;
 mod server;

--- a/src/repository_graph/config.rs
+++ b/src/repository_graph/config.rs
@@ -152,6 +152,7 @@ pub struct QueryLimitsConfig {
     pub max_bytes: u64,
     pub max_depth: u32,
     pub max_duration_ms: u64,
+    pub max_diagnostics: u32,
 }
 
 impl Default for QueryLimitsConfig {
@@ -161,6 +162,7 @@ impl Default for QueryLimitsConfig {
             max_bytes: 256 * 1024,
             max_depth: 3,
             max_duration_ms: 2_000,
+            max_diagnostics: 50,
         }
     }
 }
@@ -450,6 +452,7 @@ max_results = 100
 max_bytes = 262144
 max_depth = 3
 max_duration_ms = 2000
+max_diagnostics = 50
 
 [retention]
 max_snapshots = 5

--- a/src/repository_graph/config.rs
+++ b/src/repository_graph/config.rs
@@ -150,6 +150,8 @@ impl Default for IndexLimitsConfig {
 pub struct QueryLimitsConfig {
     pub max_results: u32,
     pub max_bytes: u64,
+    /// Independent aggregate cap for source snippets attached to one context response.
+    pub max_snippet_bytes: u64,
     pub max_depth: u32,
     pub max_duration_ms: u64,
     pub max_diagnostics: u32,
@@ -160,6 +162,7 @@ impl Default for QueryLimitsConfig {
         Self {
             max_results: 100,
             max_bytes: 256 * 1024,
+            max_snippet_bytes: 32 * 1024,
             max_depth: 3,
             max_duration_ms: 2_000,
             max_diagnostics: 50,
@@ -450,6 +453,7 @@ max_diagnostics = 1000
 [query_limits]
 max_results = 100
 max_bytes = 262144
+max_snippet_bytes = 32768
 max_depth = 3
 max_duration_ms = 2000
 max_diagnostics = 50

--- a/src/repository_graph/domain.rs
+++ b/src/repository_graph/domain.rs
@@ -468,6 +468,7 @@ pub struct QueryBudget {
     pub max_bytes: NonZeroU64,
     pub max_depth: NonZeroU32,
     pub max_duration_ms: NonZeroU64,
+    pub max_diagnostics: NonZeroU32,
 }
 
 impl QueryBudget {
@@ -476,12 +477,14 @@ impl QueryBudget {
         max_bytes: NonZeroU64,
         max_depth: NonZeroU32,
         max_duration_ms: NonZeroU64,
+        max_diagnostics: NonZeroU32,
     ) -> Self {
         Self {
             max_results,
             max_bytes,
             max_depth,
             max_duration_ms,
+            max_diagnostics,
         }
     }
 }

--- a/src/repository_graph/fixtures/query_v2_error.json
+++ b/src/repository_graph/fixtures/query_v2_error.json
@@ -1,5 +1,5 @@
 {
-  "wire_version": 1,
+  "wire_version": 2,
   "code": "stale_cursor",
   "message": "cursor no longer matches snapshot",
   "retryable": false,

--- a/src/repository_graph/fixtures/query_v2_search.json
+++ b/src/repository_graph/fixtures/query_v2_search.json
@@ -1,6 +1,6 @@
 {
   "scope": {
-    "wire_version": 1,
+    "wire_version": 2,
     "repository": {
       "namespace": "local:test",
       "repository_id": "root"
@@ -13,7 +13,8 @@
       "max_results": 20,
       "max_bytes": 16384,
       "max_depth": 2,
-      "max_duration_ms": 500
+      "max_duration_ms": 500,
+      "max_diagnostics": 10
     }
   },
   "text": "RuntimeTaskContext",

--- a/src/repository_graph/fixtures/query_v2_status.json
+++ b/src/repository_graph/fixtures/query_v2_status.json
@@ -1,0 +1,49 @@
+{
+  "wire_version": 2,
+  "repository": {
+    "namespace": "local:test",
+    "repository_id": "root"
+  },
+  "snapshot_id": "snapshot-1",
+  "source_revision": {
+    "id": "revision-1",
+    "manifest_digest": {
+      "algorithm": "sha256",
+      "value": "00"
+    }
+  },
+  "freshness": {
+    "freshness": "fresh",
+    "compared_manifest": {
+      "algorithm": "sha256",
+      "value": "00"
+    },
+    "reason_codes": []
+  },
+  "diagnostics": {
+    "summary": {
+      "info": 0,
+      "warning": 0,
+      "error": 0
+    },
+    "items": [],
+    "truncated": false
+  },
+  "page": {
+    "next_cursor": null,
+    "truncation": null
+  },
+  "data": {
+    "availability": "available",
+    "build_state": "published",
+    "build_id": "build-1",
+    "published_view": "canonical",
+    "graph_model_version": 1,
+    "statistics": {
+      "files": 2,
+      "nodes": 8,
+      "edges": 7
+    },
+    "recommended_action": null
+  }
+}

--- a/src/repository_graph/index.rs
+++ b/src/repository_graph/index.rs
@@ -839,7 +839,7 @@ mod tests {
         let query = SqliteGraphQuery::new(sidecar, config.query_limits.clone(), None);
         query
             .status(&StatusRequest {
-                scope: QueryScope::v1(
+                scope: QueryScope::current(
                     repository(),
                     SnapshotSelector::Published(PublishedViewName::new("canonical").unwrap()),
                     default_budget(&config.query_limits).unwrap(),
@@ -1041,7 +1041,7 @@ mod tests {
 
         let first_source = discover(repository_dir.path(), &config);
         let first = run(&mut sidecar, &first_source, &config, "build-1", false).unwrap();
-        let first_warning_count = status(&sidecar, &config).diagnostics.warning;
+        let first_warning_count = status(&sidecar, &config).diagnostics.summary.warning;
 
         write(
             &repository_dir.path().join(".ferrus/project.toml"),
@@ -1052,7 +1052,7 @@ mod tests {
         assert_eq!(second.snapshot.id, first.snapshot.id);
         assert!(second.reused_existing_snapshot);
         assert_eq!(
-            status(&sidecar, &config).diagnostics.warning,
+            status(&sidecar, &config).diagnostics.summary.warning,
             first_warning_count + 1
         );
         assert!(
@@ -1068,7 +1068,7 @@ mod tests {
         let third = run(&mut sidecar, &third_source, &config, "build-3", false).unwrap();
         assert_eq!(third.snapshot.id, first.snapshot.id);
         assert_eq!(
-            status(&sidecar, &config).diagnostics.warning,
+            status(&sidecar, &config).diagnostics.summary.warning,
             first_warning_count
         );
         assert!(

--- a/src/repository_graph/mod.rs
+++ b/src/repository_graph/mod.rs
@@ -25,7 +25,7 @@ mod contracts;
 
 /// Schema-independent graph model version.
 pub const GRAPH_MODEL_VERSION: u32 = 1;
-/// Version of request/response JSON contracts introduced by this phase.
-pub const QUERY_WIRE_VERSION: u32 = 1;
+/// Version of the repository retrieval request/response JSON contract.
+pub const QUERY_WIRE_VERSION: u32 = 2;
 /// Version of the extractor input/output contract.
 pub const EXTRACTOR_CONTRACT_VERSION: u32 = 2;

--- a/src/repository_graph/query.rs
+++ b/src/repository_graph/query.rs
@@ -12,9 +12,10 @@ use thiserror::Error;
 use super::{
     QUERY_WIRE_VERSION,
     domain::{
-        Availability, BuildState, Digest, EdgeId, EdgeTarget, FactProvenance, Freshness, GraphNode,
-        NodeId, PageCursor, PublishedViewName, QueryBudget, RepoPath, RepositoryRef, SemanticKey,
-        SnapshotId, SourceSpan,
+        Availability, BuildId, BuildState, DiagnosticCode, DiagnosticLocation, DiagnosticSeverity,
+        Digest, EdgeId, EdgeTarget, FactProvenance, Freshness, GraphNode, NodeId, PageCursor,
+        PublishedViewName, QueryBudget, RepoPath, RepositoryRef, SemanticKey, SnapshotId,
+        SourceRevisionId, SourceSpan,
     },
 };
 
@@ -34,7 +35,11 @@ pub struct QueryScope {
 }
 
 impl QueryScope {
-    pub fn v1(repository: RepositoryRef, snapshot: SnapshotSelector, budget: QueryBudget) -> Self {
+    pub fn current(
+        repository: RepositoryRef,
+        snapshot: SnapshotSelector,
+        budget: QueryBudget,
+    ) -> Self {
         Self {
             wire_version: QUERY_WIRE_VERSION,
             repository,
@@ -103,12 +108,29 @@ pub struct NeighborhoodRequest {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ContextRequest {
     pub scope: QueryScope,
-    pub objective: String,
-    #[serde(default)]
-    pub anchors: Vec<NodeId>,
-    #[serde(default)]
-    pub paths: Vec<RepoPath>,
+    pub seeds: Vec<ContextSeed>,
+    pub policy: ContextPolicy,
     pub page: PageRequest,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "value", rename_all = "snake_case")]
+pub enum ContextSeed {
+    Node(NodeId),
+    Symbol(SemanticKey),
+    Path(RepoPath),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContextPolicy {
+    #[serde(default)]
+    pub direction: EdgeDirection,
+    #[serde(default)]
+    pub edge_kinds: Vec<String>,
+    #[serde(default)]
+    pub include_unresolved: bool,
+    #[serde(default)]
+    pub include_external: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -144,12 +166,44 @@ pub struct FreshnessEnvelope {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SourceRevisionEnvelope {
+    pub id: SourceRevisionId,
+    pub manifest_digest: Digest,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RetrievalAction {
+    Index,
+    WaitForBuild,
+    RetryIndex,
+    RefreshIndex,
+    Rebuild,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QueryDiagnostic {
+    pub severity: DiagnosticSeverity,
+    pub code: DiagnosticCode,
+    pub location: Option<DiagnosticLocation>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DiagnosticsEnvelope {
+    pub summary: DiagnosticSummary,
+    #[serde(default)]
+    pub items: Vec<QueryDiagnostic>,
+    pub truncated: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct QueryResponse<T> {
     pub wire_version: u32,
     pub repository: RepositoryRef,
     pub snapshot_id: SnapshotId,
+    pub source_revision: SourceRevisionEnvelope,
     pub freshness: FreshnessEnvelope,
-    pub diagnostics: DiagnosticSummary,
+    pub diagnostics: DiagnosticsEnvelope,
     pub page: PageInfo,
     pub data: T,
 }
@@ -157,10 +211,13 @@ pub struct QueryResponse<T> {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StatusData {
     pub availability: Availability,
+    /// State of the newest build attempt, independently from the published snapshot.
     pub build_state: Option<BuildState>,
+    pub build_id: Option<BuildId>,
     pub published_view: Option<PublishedViewName>,
     pub graph_model_version: Option<u32>,
     pub statistics: Option<SnapshotStatistics>,
+    pub recommended_action: Option<RetrievalAction>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -168,8 +225,10 @@ pub struct StatusResponse {
     pub wire_version: u32,
     pub repository: RepositoryRef,
     pub snapshot_id: Option<SnapshotId>,
+    pub source_revision: Option<SourceRevisionEnvelope>,
     pub freshness: FreshnessEnvelope,
-    pub diagnostics: DiagnosticSummary,
+    pub diagnostics: DiagnosticsEnvelope,
+    pub page: PageInfo,
     pub data: StatusData,
 }
 
@@ -195,9 +254,22 @@ pub struct SearchHit {
     pub path: Option<RepoPath>,
     pub span: Option<SourceSpan>,
     pub provenance: FactProvenance,
+    pub match_kind: SearchMatchKind,
     pub score: f64,
     #[serde(default)]
     pub matched_fields: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SearchMatchKind {
+    ExactSemanticKey,
+    ExactPath,
+    ExactNormalizedName,
+    NormalizedNamePrefix,
+    NormalizedNameContains,
+    SemanticKeyContains,
+    PathContains,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -241,16 +313,38 @@ pub struct NeighborhoodData {
 
 pub type NeighborhoodResponse = QueryResponse<NeighborhoodData>;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ContextItem {
-    pub node_id: Option<NodeId>,
+    pub node_id: NodeId,
+    pub kind: String,
+    pub semantic_key: Option<SemanticKey>,
     pub path: RepoPath,
     pub span: Option<SourceSpan>,
     pub content_identity: Digest,
-    pub relevance_reason: String,
+    pub provenance: FactProvenance,
+    pub selection_reasons: Vec<ContextSelectionReason>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContextSelectionReason {
+    pub kind: ContextSelectionKind,
+    pub via_node: Option<NodeId>,
+    pub via_edge: Option<EdgeId>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ContextSelectionKind {
+    ExactSeed,
+    Containment,
+    Declaration,
+    ResolvedDependency,
+    Documentation,
+    Configuration,
+    Relationship,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ContextData {
     pub items: Vec<ContextItem>,
 }
@@ -263,6 +357,8 @@ pub enum QueryErrorCode {
     UnsupportedWireVersion,
     InvalidRequest,
     NotBuilt,
+    IndexBuilding,
+    IndexFailed,
     Incompatible,
     SnapshotNotFound,
     StaleCursor,
@@ -279,6 +375,8 @@ pub struct QueryError {
     pub code: QueryErrorCode,
     pub message: String,
     pub retryable: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recommended_action: Option<RetrievalAction>,
     #[serde(default)]
     pub details: BTreeMap<String, String>,
 }
@@ -312,7 +410,10 @@ mod tests {
     use std::num::{NonZeroU32, NonZeroU64};
 
     use super::*;
-    use crate::repository_graph::domain::{RepositoryId, RepositoryNamespace};
+    use crate::repository_graph::domain::{
+        Confidence, ExtractorId, ExtractorIdentity, RepositoryId, RepositoryNamespace,
+        ResolutionState, SourceEvidence,
+    };
 
     fn repository() -> RepositoryRef {
         RepositoryRef {
@@ -327,13 +428,14 @@ mod tests {
             NonZeroU64::new(16_384).unwrap(),
             NonZeroU32::new(2).unwrap(),
             NonZeroU64::new(500).unwrap(),
+            NonZeroU32::new(10).unwrap(),
         )
     }
 
     #[test]
     fn every_query_scope_serializes_explicit_wire_version_and_budgets() {
         let request = SearchRequest {
-            scope: QueryScope::v1(
+            scope: QueryScope::current(
                 repository(),
                 SnapshotSelector::Published(PublishedViewName::new("canonical").unwrap()),
                 budget(),
@@ -369,11 +471,31 @@ mod tests {
     #[test]
     fn context_items_are_references_and_do_not_embed_source_bodies() {
         let fields = serde_json::to_value(ContextItem {
-            node_id: None,
+            node_id: NodeId::new("node:main").unwrap(),
+            kind: "file".to_string(),
+            semantic_key: None,
             path: RepoPath::new("src/main.rs").unwrap(),
             span: None,
             content_identity: Digest::new("sha256", "00").unwrap(),
-            relevance_reason: "entry point".to_string(),
+            provenance: FactProvenance {
+                extractor: ExtractorIdentity {
+                    id: ExtractorId::new("generic").unwrap(),
+                    version: "1".to_string(),
+                    contract_version: 1,
+                },
+                evidence: Some(SourceEvidence {
+                    path: RepoPath::new("src/main.rs").unwrap(),
+                    content_identity: Digest::new("sha256", "00").unwrap(),
+                    span: None,
+                }),
+                resolution: ResolutionState::Resolved,
+                confidence: Confidence::Exact,
+            },
+            selection_reasons: vec![ContextSelectionReason {
+                kind: ContextSelectionKind::ExactSeed,
+                via_node: None,
+                via_edge: None,
+            }],
         })
         .unwrap();
         assert!(fields.get("bytes").is_none());
@@ -381,9 +503,39 @@ mod tests {
     }
 
     #[test]
-    fn search_request_serialization_matches_v1_fixture() {
+    fn context_requests_use_typed_seeds_and_explicit_expansion_policy() {
+        let request = ContextRequest {
+            scope: QueryScope::current(
+                repository(),
+                SnapshotSelector::Published(PublishedViewName::new("canonical").unwrap()),
+                budget(),
+            ),
+            seeds: vec![
+                ContextSeed::Node(NodeId::new("node:main").unwrap()),
+                ContextSeed::Symbol(SemanticKey::new("rust:crate::main").unwrap()),
+                ContextSeed::Path(RepoPath::new("src/main.rs").unwrap()),
+            ],
+            policy: ContextPolicy {
+                direction: EdgeDirection::Both,
+                edge_kinds: vec!["contains".to_string()],
+                include_unresolved: false,
+                include_external: false,
+            },
+            page: PageRequest { cursor: None },
+        };
+        let json = serde_json::to_value(request).unwrap();
+
+        assert_eq!(json["seeds"][0]["type"], "node");
+        assert_eq!(json["seeds"][1]["type"], "symbol");
+        assert_eq!(json["seeds"][2]["type"], "path");
+        assert_eq!(json["policy"]["direction"], "both");
+        assert_eq!(json["scope"]["budget"]["max_diagnostics"], 10);
+    }
+
+    #[test]
+    fn search_request_serialization_matches_v2_fixture() {
         let request = SearchRequest {
-            scope: QueryScope::v1(
+            scope: QueryScope::current(
                 repository(),
                 SnapshotSelector::Published(PublishedViewName::new("canonical").unwrap()),
                 budget(),
@@ -395,7 +547,7 @@ mod tests {
         };
         assert_eq!(
             serde_json::to_string_pretty(&request).unwrap(),
-            include_str!("fixtures/query_v1_search.json")
+            include_str!("fixtures/query_v2_search.json")
                 .trim()
                 .replace("\r\n", "\n")
         );
@@ -408,6 +560,7 @@ mod tests {
             code: QueryErrorCode::StaleCursor,
             message: "cursor no longer matches snapshot".to_string(),
             retryable: false,
+            recommended_action: None,
             details: BTreeMap::from([
                 ("z".to_string(), "last".to_string()),
                 ("a".to_string(), "first".to_string()),
@@ -415,7 +568,50 @@ mod tests {
         };
         assert_eq!(
             serde_json::to_string_pretty(&error).unwrap(),
-            include_str!("fixtures/query_v1_error.json")
+            include_str!("fixtures/query_v2_error.json")
+                .trim()
+                .replace("\r\n", "\n")
+        );
+    }
+
+    #[test]
+    fn status_response_serialization_matches_v2_envelope_fixture() {
+        let response = StatusResponse {
+            wire_version: QUERY_WIRE_VERSION,
+            repository: repository(),
+            snapshot_id: Some(SnapshotId::new("snapshot-1").unwrap()),
+            source_revision: Some(SourceRevisionEnvelope {
+                id: SourceRevisionId::new("revision-1").unwrap(),
+                manifest_digest: Digest::new("sha256", "00").unwrap(),
+            }),
+            freshness: FreshnessEnvelope {
+                freshness: Freshness::Fresh,
+                compared_manifest: Some(Digest::new("sha256", "00").unwrap()),
+                reason_codes: vec![],
+            },
+            diagnostics: DiagnosticsEnvelope::default(),
+            page: PageInfo {
+                next_cursor: None,
+                truncation: None,
+            },
+            data: StatusData {
+                availability: Availability::Available,
+                build_state: Some(BuildState::Published),
+                build_id: Some(BuildId::new("build-1").unwrap()),
+                published_view: Some(PublishedViewName::new("canonical").unwrap()),
+                graph_model_version: Some(1),
+                statistics: Some(SnapshotStatistics {
+                    files: 2,
+                    nodes: 8,
+                    edges: 7,
+                }),
+                recommended_action: None,
+            },
+        };
+
+        assert_eq!(
+            serde_json::to_string_pretty(&response).unwrap(),
+            include_str!("fixtures/query_v2_status.json")
                 .trim()
                 .replace("\r\n", "\n")
         );

--- a/src/repository_graph/query.rs
+++ b/src/repository_graph/query.rs
@@ -347,9 +347,23 @@ pub enum ContextSelectionKind {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ContextData {
     pub items: Vec<ContextItem>,
+    /// Deduplicated, hash-verified source excerpts requested by the caller.
+    /// Structural query implementations leave this empty; a trusted
+    /// `SnapshotContent` boundary may populate it without changing ranking.
+    #[serde(default)]
+    pub snippets: Vec<ContextSnippet>,
 }
 
 pub type ContextResponse = QueryResponse<ContextData>;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContextSnippet {
+    pub path: RepoPath,
+    pub span: Option<SourceSpan>,
+    pub verified_content_identity: Digest,
+    pub text: String,
+    pub truncated: bool,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/src/repository_graph/query_sqlite.rs
+++ b/src/repository_graph/query_sqlite.rs
@@ -20,7 +20,7 @@ use super::{
         NodeId, PageCursor, RepoPath, RepositoryRef, ResolutionState, SemanticKey, SnapshotId,
         SourceEvidence, SourcePosition, SourceSpan,
     },
-    ports::{GraphQuery, SourceManifest},
+    ports::{GraphQuery, SourceFileDescriptor, SourceFileMode, SourceManifest},
     query::{
         ContextData, ContextItem, ContextRequest, ContextResponse, ContextSeed,
         ContextSelectionKind, ContextSelectionReason, DiagnosticSummary, DiagnosticsEnvelope,
@@ -1315,7 +1315,10 @@ impl GraphQuery for SqliteGraphQuery<'_> {
             freshness: scope.freshness,
             diagnostics,
             page,
-            data: ContextData { items },
+            data: ContextData {
+                items,
+                snippets: vec![],
+            },
         })
     }
 }
@@ -2341,6 +2344,52 @@ fn stale_cursor_error() -> QueryError {
         recommended_action: None,
         details: BTreeMap::new(),
     }
+}
+
+/// Loads the immutable file identities needed by a `SnapshotContent`
+/// implementation without exposing the SQLite connection outside the graph
+/// library boundary.
+pub fn snapshot_file_descriptors(
+    sidecar: &Sidecar,
+    snapshot_id: &SnapshotId,
+    paths: &BTreeSet<RepoPath>,
+) -> Result<Vec<SourceFileDescriptor>, QueryError> {
+    let mut files = Vec::with_capacity(paths.len());
+    for path in paths {
+        let stored = sidecar
+            .connection()
+            .query_row(
+                "SELECT content_algorithm, content_digest, byte_length, file_mode \
+                 FROM files WHERE snapshot_id = ?1 AND path = ?2",
+                params![snapshot_id.as_str(), path.as_str()],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, i64>(2)?,
+                        row.get::<_, i64>(3)?,
+                    ))
+                },
+            )
+            .optional()
+            .map_err(|_| backend_error())?;
+        let Some((algorithm, value, byte_len, file_mode)) = stored else {
+            continue;
+        };
+        let byte_len = u64::try_from(byte_len).map_err(|_| backend_error())?;
+        let file_mode = match file_mode {
+            0 => SourceFileMode::Regular,
+            1 => SourceFileMode::Executable,
+            _ => return Err(backend_error()),
+        };
+        files.push(SourceFileDescriptor {
+            path: path.clone(),
+            content_identity: Digest::new(algorithm, value).map_err(|_| backend_error())?,
+            byte_len,
+            file_mode,
+        });
+    }
+    Ok(files)
 }
 
 pub fn default_budget(

--- a/src/repository_graph/query_sqlite.rs
+++ b/src/repository_graph/query_sqlite.rs
@@ -1235,7 +1235,7 @@ impl GraphQuery for SqliteGraphQuery<'_> {
             return Err(invalid_request("context requires 1..=32 seeds"));
         }
         validate_filters(&request.policy.edge_kinds, 0)?;
-        let fingerprint = context_cursor_fingerprint(request)?;
+        let fingerprint = context_cursor_fingerprint(request, scope.budget.max_depth)?;
         let offset = decode_cursor(
             request.page.cursor.as_ref(),
             "context",
@@ -1991,13 +1991,17 @@ fn show_cursor_fingerprint(request: &ShowRequest) -> Result<String, QueryError> 
 #[derive(Serialize)]
 struct ContextCursorParameters<'a> {
     seeds: Vec<String>,
+    max_depth: u32,
     direction: EdgeDirection,
     edge_kinds: Vec<&'a str>,
     include_unresolved: bool,
     include_external: bool,
 }
 
-fn context_cursor_fingerprint(request: &ContextRequest) -> Result<String, QueryError> {
+fn context_cursor_fingerprint(
+    request: &ContextRequest,
+    max_depth: u32,
+) -> Result<String, QueryError> {
     let mut seeds = request
         .seeds
         .iter()
@@ -2017,6 +2021,7 @@ fn context_cursor_fingerprint(request: &ContextRequest) -> Result<String, QueryE
         "context",
         &ContextCursorParameters {
             seeds,
+            max_depth,
             direction: request.policy.direction,
             edge_kinds,
             include_unresolved: request.policy.include_unresolved,
@@ -2620,6 +2625,15 @@ mod tests {
                 .iter()
                 .all(|right| left.node_id != right.node_id)
         }));
+
+        let mut service_capped_depth = request.clone();
+        service_capped_depth.scope.budget.max_depth = std::num::NonZeroU32::new(99).unwrap();
+        assert!(query.context(&service_capped_depth).is_ok());
+
+        let mut changed_depth = request.clone();
+        changed_depth.scope.budget.max_depth = std::num::NonZeroU32::new(1).unwrap();
+        let error = query.context(&changed_depth).unwrap_err();
+        assert_eq!(error.code, QueryErrorCode::StaleCursor);
 
         request.policy.direction = EdgeDirection::Outgoing;
         let error = query.context(&request).unwrap_err();

--- a/src/repository_graph/query_sqlite.rs
+++ b/src/repository_graph/query_sqlite.rs
@@ -6,7 +6,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use rusqlite::{Connection, Error as SqliteError, ErrorCode, Row, params};
+use rusqlite::{Connection, Error as SqliteError, ErrorCode, OptionalExtension, Row, params};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
 
@@ -14,19 +14,21 @@ use super::{
     QUERY_WIRE_VERSION,
     config::QueryLimitsConfig,
     domain::{
-        Availability, Confidence, Digest, EdgeId, EdgeTarget, ExtractorId, ExtractorIdentity,
-        FactProvenance, Freshness, GraphEdge, GraphNode, GraphSnapshot, GraphValue, NodeId,
-        PageCursor, RepoPath, RepositoryRef, ResolutionState, SemanticKey, SnapshotId,
+        Availability, BuildId, BuildState, Confidence, DiagnosticCode, DiagnosticLocation,
+        DiagnosticSeverity, Digest, EdgeId, EdgeTarget, ExtractorId, ExtractorIdentity,
+        FactProvenance, Freshness, GraphBuild, GraphEdge, GraphNode, GraphSnapshot, GraphValue,
+        NodeId, PageCursor, RepoPath, RepositoryRef, ResolutionState, SemanticKey, SnapshotId,
         SourceEvidence, SourcePosition, SourceSpan,
     },
     ports::{GraphQuery, SourceManifest},
     query::{
-        ContextRequest, ContextResponse, DiagnosticSummary, EdgeDirection, FreshnessEnvelope,
-        NeighborhoodData, NeighborhoodEdge, NeighborhoodNode, NeighborhoodRequest,
-        NeighborhoodResponse, PageInfo, QueryError, QueryErrorCode, QueryResponse, SearchData,
-        SearchHit, SearchRequest, SearchResponse, ShowData, ShowLookup, ShowRequest, ShowResponse,
-        SnapshotSelector, SnapshotStatistics, StatusData, StatusRequest, StatusResponse,
-        Truncation, TruncationReason,
+        ContextRequest, ContextResponse, DiagnosticSummary, DiagnosticsEnvelope, EdgeDirection,
+        FreshnessEnvelope, NeighborhoodData, NeighborhoodEdge, NeighborhoodNode,
+        NeighborhoodRequest, NeighborhoodResponse, PageInfo, QueryDiagnostic, QueryError,
+        QueryErrorCode, QueryResponse, RetrievalAction, SearchData, SearchHit, SearchMatchKind,
+        SearchRequest, SearchResponse, ShowData, ShowLookup, ShowRequest, ShowResponse,
+        SnapshotSelector, SnapshotStatistics, SourceRevisionEnvelope, StatusData, StatusRequest,
+        StatusResponse, Truncation, TruncationReason,
     },
     sqlite::Sidecar,
     store::StoreError,
@@ -72,7 +74,12 @@ impl Drop for QueryDeadline<'_> {
 }
 
 struct SearchRows {
-    rows: Vec<(GraphNode, f64)>,
+    rows: Vec<(GraphNode, SearchMatchKind)>,
+    deadline_exceeded: bool,
+}
+
+struct NodeRows {
+    rows: Vec<GraphNode>,
     deadline_exceeded: bool,
 }
 
@@ -83,6 +90,15 @@ struct SearchPathFilter<'a> {
 }
 
 impl SearchRows {
+    fn deadline_exceeded() -> Self {
+        Self {
+            rows: Vec::new(),
+            deadline_exceeded: true,
+        }
+    }
+}
+
+impl NodeRows {
     fn deadline_exceeded() -> Self {
         Self {
             rows: Vec::new(),
@@ -130,19 +146,25 @@ impl<'a> SqliteGraphQuery<'a> {
     fn resolve_scope(&self, scope: &super::query::QueryScope) -> Result<ResolvedScope, QueryError> {
         validate_wire_version(scope.wire_version)?;
         let budget = EffectiveBudget::new(&scope.budget, &self.limits)?;
-        let (snapshot, published_view) = match &scope.snapshot {
+        let (snapshot, published_view, source_revision_id) = match &scope.snapshot {
             SnapshotSelector::Published(name) => {
                 let view = self
                     .sidecar
                     .published_view(&scope.repository, name)
                     .map_err(store_query_error)?
-                    .ok_or_else(not_built_error)?;
+                    .ok_or_else(|| self.unpublished_index_error(&scope.repository))?;
                 let snapshot = self
                     .sidecar
                     .snapshot(&view.snapshot_id)
                     .map_err(store_query_error)?
                     .ok_or_else(backend_error)?;
-                (snapshot, Some(name.clone()))
+                let source_revision_id = self
+                    .sidecar
+                    .build(&view.build_id)
+                    .map_err(store_query_error)?
+                    .ok_or_else(backend_error)?
+                    .source_revision_id;
+                (snapshot, Some(name.clone()), source_revision_id)
             }
             SnapshotSelector::Snapshot(id) => {
                 let snapshot = self
@@ -150,7 +172,8 @@ impl<'a> SqliteGraphQuery<'a> {
                     .snapshot(id)
                     .map_err(store_query_error)?
                     .ok_or_else(snapshot_not_found_error)?;
-                (snapshot, None)
+                let source_revision_id = snapshot.source_revision_id.clone();
+                (snapshot, None, source_revision_id)
             }
         };
         if snapshot.repository != scope.repository {
@@ -161,9 +184,43 @@ impl<'a> SqliteGraphQuery<'a> {
             repository: scope.repository.clone(),
             snapshot,
             published_view,
+            source_revision_id,
             freshness,
             budget,
         })
+    }
+
+    fn latest_build(&self, repository: &RepositoryRef) -> Result<Option<GraphBuild>, QueryError> {
+        let build_id = self
+            .sidecar
+            .connection()
+            .query_row(
+                "SELECT id FROM index_builds \
+                 WHERE repository_namespace = ?1 AND repository_id = ?2 \
+                 ORDER BY started_at DESC, id DESC LIMIT 1",
+                params![
+                    repository.namespace.as_str(),
+                    repository.repository_id.as_str(),
+                ],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(sqlite_query_error)?
+            .map(BuildId::new)
+            .transpose()
+            .map_err(|_| backend_error())?;
+        build_id
+            .map(|id| self.sidecar.build(&id).map_err(store_query_error))
+            .transpose()
+            .map(Option::flatten)
+    }
+
+    fn unpublished_index_error(&self, repository: &RepositoryRef) -> QueryError {
+        match self.latest_build(repository) {
+            Ok(Some(build)) if build.state == BuildState::Building => index_building_error(),
+            Ok(Some(build)) if build.state == BuildState::Failed => index_failed_error(),
+            _ => not_built_error(),
+        }
     }
 
     fn status_at(
@@ -174,16 +231,17 @@ impl<'a> SqliteGraphQuery<'a> {
         validate_wire_version(request.scope.wire_version)?;
         let budget = EffectiveBudget::new(&request.scope.budget, &self.limits)?;
         let duration = Duration::from_millis(budget.max_duration_ms);
-        if started.elapsed() >= duration {
-            return Err(duration_budget_exceeded_error());
-        }
-        let _deadline = QueryDeadline::install(self.sidecar.connection(), started, duration)?;
         let resolved = match self.resolve_scope(&request.scope) {
             Ok(resolved) => resolved,
             Err(error)
-                if error.code == QueryErrorCode::NotBuilt
-                    && matches!(request.scope.snapshot, SnapshotSelector::Published(_)) =>
+                if matches!(
+                    error.code,
+                    QueryErrorCode::NotBuilt
+                        | QueryErrorCode::IndexBuilding
+                        | QueryErrorCode::IndexFailed
+                ) && matches!(request.scope.snapshot, SnapshotSelector::Published(_)) =>
             {
+                let latest_build = self.latest_build(&request.scope.repository)?;
                 let published_view = match &request.scope.snapshot {
                     SnapshotSelector::Published(name) => Some(name.clone()),
                     SnapshotSelector::Snapshot(_) => None,
@@ -192,6 +250,7 @@ impl<'a> SqliteGraphQuery<'a> {
                     wire_version: QUERY_WIRE_VERSION,
                     repository: request.scope.repository.clone(),
                     snapshot_id: None,
+                    source_revision: None,
                     freshness: FreshnessEnvelope {
                         freshness: Freshness::NotApplicable,
                         compared_manifest: self
@@ -200,46 +259,102 @@ impl<'a> SqliteGraphQuery<'a> {
                             .map(|comparison| comparison.source_manifest_digest.clone()),
                         reason_codes: vec!["not_built".to_string()],
                     },
-                    diagnostics: DiagnosticSummary::default(),
+                    diagnostics: if started.elapsed() >= duration {
+                        truncated_diagnostics()
+                    } else {
+                        DiagnosticsEnvelope::default()
+                    },
+                    page: page_info(
+                        (started.elapsed() >= duration).then_some(TruncationReason::Duration),
+                        0,
+                        0,
+                        0,
+                        None,
+                    )?,
                     data: StatusData {
                         availability: Availability::NotBuilt,
-                        build_state: None,
+                        build_state: latest_build.as_ref().map(|build| build.state),
+                        build_id: latest_build.as_ref().map(|build| build.id.clone()),
                         published_view,
                         graph_model_version: None,
                         statistics: None,
+                        recommended_action: Some(match error.code {
+                            QueryErrorCode::IndexBuilding => RetrievalAction::WaitForBuild,
+                            QueryErrorCode::IndexFailed => RetrievalAction::RetryIndex,
+                            _ => RetrievalAction::Index,
+                        }),
                     },
                 });
             }
             Err(error) => return Err(error),
         };
-        let build_state = self
-            .sidecar
-            .build(&resolved.snapshot.completed_by)
-            .map_err(store_query_error)?
-            .map(|build| build.state);
-        let diagnostics = self.diagnostics(&resolved.snapshot.id)?;
-        let statistics = self.statistics(&resolved.snapshot.id)?;
         if started.elapsed() >= duration {
-            return Err(duration_budget_exceeded_error());
+            return Ok(available_status_response(
+                &resolved,
+                None,
+                truncated_diagnostics(),
+                None,
+                true,
+            ));
         }
-        Ok(StatusResponse {
-            wire_version: QUERY_WIRE_VERSION,
-            repository: resolved.repository,
-            snapshot_id: Some(resolved.snapshot.id.clone()),
-            freshness: resolved.freshness,
+        let deadline = QueryDeadline::install(self.sidecar.connection(), started, duration)?;
+        let latest_build = match self.latest_build(&resolved.repository) {
+            Ok(build) => build,
+            Err(error) if error.code == QueryErrorCode::BudgetExceeded => {
+                return Ok(available_status_response(
+                    &resolved,
+                    None,
+                    truncated_diagnostics(),
+                    None,
+                    true,
+                ));
+            }
+            Err(error) => return Err(error),
+        };
+        let diagnostics =
+            match self.diagnostics(&resolved.snapshot.id, resolved.budget.max_diagnostics) {
+                Ok(diagnostics) => diagnostics,
+                Err(error) if error.code == QueryErrorCode::BudgetExceeded => {
+                    return Ok(available_status_response(
+                        &resolved,
+                        latest_build.as_ref(),
+                        truncated_diagnostics(),
+                        None,
+                        true,
+                    ));
+                }
+                Err(error) => return Err(error),
+            };
+        let statistics = match self.statistics(&resolved.snapshot.id) {
+            Ok(statistics) => statistics,
+            Err(error) if error.code == QueryErrorCode::BudgetExceeded => {
+                return Ok(available_status_response(
+                    &resolved,
+                    latest_build.as_ref(),
+                    diagnostics,
+                    None,
+                    true,
+                ));
+            }
+            Err(error) => return Err(error),
+        };
+        drop(deadline);
+        Ok(available_status_response(
+            &resolved,
+            latest_build.as_ref(),
             diagnostics,
-            data: StatusData {
-                availability: Availability::Available,
-                build_state,
-                published_view: resolved.published_view,
-                graph_model_version: Some(resolved.snapshot.graph_model_version),
-                statistics: Some(statistics),
-            },
-        })
+            Some(statistics),
+            started.elapsed() >= duration,
+        ))
     }
 
-    fn diagnostics(&self, snapshot: &SnapshotId) -> Result<DiagnosticSummary, QueryError> {
-        self.sidecar
+    fn diagnostics(
+        &self,
+        snapshot: &SnapshotId,
+        max_diagnostics: u32,
+    ) -> Result<DiagnosticsEnvelope, QueryError> {
+        let summary = self
+            .sidecar
             .connection()
             .query_row(
                 "SELECT \
@@ -260,7 +375,82 @@ impl<'a> SqliteGraphQuery<'a> {
                     })
                 },
             )
-            .map_err(sqlite_query_error)
+            .map_err(sqlite_query_error)?;
+        let mut statement = self
+            .sidecar
+            .connection()
+            .prepare(
+                "SELECT diagnostic.severity, diagnostic.code, diagnostic.path, \
+                        diagnostic.span_start_byte, diagnostic.span_end_byte, \
+                        diagnostic.span_start_line, diagnostic.span_start_column, \
+                        diagnostic.span_end_line, diagnostic.span_end_column \
+                 FROM diagnostics AS diagnostic \
+                 JOIN snapshot_diagnostic_sets AS current \
+                   ON current.snapshot_id = diagnostic.snapshot_id \
+                  AND current.build_id = diagnostic.build_id \
+                 WHERE diagnostic.snapshot_id = ?1 \
+                 ORDER BY CASE diagnostic.severity \
+                              WHEN 'error' THEN 0 WHEN 'warning' THEN 1 ELSE 2 END, \
+                          diagnostic.code, COALESCE(diagnostic.path, ''), \
+                          COALESCE(diagnostic.span_start_byte, -1), diagnostic.id \
+                 LIMIT ?2",
+            )
+            .map_err(sqlite_query_error)?;
+        let mut rows = statement
+            .query(params![
+                snapshot.as_str(),
+                i64::from(max_diagnostics.saturating_add(1)),
+            ])
+            .map_err(sqlite_query_error)?;
+        let mut items = Vec::new();
+        while let Some(row) = rows.next().map_err(sqlite_query_error)? {
+            let severity = diagnostic_severity(&value::<String>(row, 0)?)?;
+            let code =
+                DiagnosticCode::new(value::<String>(row, 1)?).map_err(|_| backend_error())?;
+            let path = value::<Option<String>>(row, 2)?;
+            let span = decode_span(row, 3, 4, 5, 6, 7, 8)?;
+            let location = match (path, span) {
+                (Some(path), span) => Some(DiagnosticLocation {
+                    path: RepoPath::new(path).map_err(|_| backend_error())?,
+                    span,
+                }),
+                (None, None) => None,
+                (None, Some(_)) => return Err(backend_error()),
+            };
+            items.push(QueryDiagnostic {
+                severity,
+                code,
+                location,
+            });
+        }
+        let truncated = items.len() > max_diagnostics as usize;
+        items.truncate(max_diagnostics as usize);
+        Ok(DiagnosticsEnvelope {
+            summary,
+            items,
+            truncated,
+        })
+    }
+
+    fn diagnostics_with_deadline(
+        &self,
+        scope: &ResolvedScope,
+        started: Instant,
+    ) -> Result<(DiagnosticsEnvelope, bool), QueryError> {
+        let duration = Duration::from_millis(scope.budget.max_duration_ms);
+        if started.elapsed() >= duration {
+            return Ok((truncated_diagnostics(), true));
+        }
+        let deadline = QueryDeadline::install(self.sidecar.connection(), started, duration)?;
+        let diagnostics = self.diagnostics(&scope.snapshot.id, scope.budget.max_diagnostics);
+        drop(deadline);
+        match diagnostics {
+            Ok(diagnostics) => Ok((diagnostics, started.elapsed() >= duration)),
+            Err(error) if error.code == QueryErrorCode::BudgetExceeded => {
+                Ok((truncated_diagnostics(), true))
+            }
+            Err(error) => Err(error),
+        }
     }
 
     fn statistics(&self, snapshot: &SnapshotId) -> Result<SnapshotStatistics, QueryError> {
@@ -308,12 +498,14 @@ impl<'a> SqliteGraphQuery<'a> {
         let sql = format!(
             "SELECT {NODE_COLUMNS}, \
                 CASE \
-                    WHEN normalized_name = ?2 THEN 1.0 \
-                    WHEN normalized_name LIKE ?3 ESCAPE '\\' THEN 0.9 \
-                    WHEN normalized_name LIKE ?4 ESCAPE '\\' THEN 0.8 \
-                    WHEN lower(COALESCE(semantic_key, '')) LIKE ?4 ESCAPE '\\' THEN 0.7 \
-                    ELSE 0.6 \
-                END AS score \
+                    WHEN lower(COALESCE(semantic_key, '')) = ?2 THEN 0 \
+                    WHEN lower(COALESCE(evidence_path, '')) = ?2 THEN 1 \
+                    WHEN normalized_name = ?2 THEN 2 \
+                    WHEN normalized_name LIKE ?3 ESCAPE '\\' THEN 3 \
+                    WHEN normalized_name LIKE ?4 ESCAPE '\\' THEN 4 \
+                    WHEN lower(COALESCE(semantic_key, '')) LIKE ?4 ESCAPE '\\' THEN 5 \
+                    ELSE 6 \
+                END AS match_rank \
              FROM nodes \
              WHERE snapshot_id = ?1 \
                AND (normalized_name = ?2 \
@@ -328,7 +520,7 @@ impl<'a> SqliteGraphQuery<'a> {
                        OR evidence_path LIKE \
                           json_extract(requested_path.value, '$.descendants') ESCAPE '\\'\
                )) \
-             ORDER BY score DESC, normalized_name, id \
+             ORDER BY match_rank, normalized_name, id \
              LIMIT ?7 OFFSET ?8"
         );
         let limit = i64::from(scope.budget.max_results.saturating_add(1));
@@ -365,7 +557,10 @@ impl<'a> SqliteGraphQuery<'a> {
         let mut found = Vec::new();
         loop {
             match rows.next() {
-                Ok(Some(row)) => found.push((decode_node(row)?, value(row, 19)?)),
+                Ok(Some(row)) => found.push((
+                    decode_node(row)?,
+                    search_match_kind(value::<i64>(row, 19)?)?,
+                )),
                 Ok(None) => break,
                 Err(error) if sqlite_deadline_exceeded(&error) => {
                     return Ok(SearchRows::deadline_exceeded());
@@ -385,7 +580,7 @@ impl<'a> SqliteGraphQuery<'a> {
         request: &ShowRequest,
         offset: u64,
         started: Instant,
-    ) -> Result<Vec<GraphNode>, QueryError> {
+    ) -> Result<NodeRows, QueryError> {
         let (predicate, lookup) = match &request.lookup {
             ShowLookup::Node(id) => ("id = ?2", id.as_str()),
             ShowLookup::Symbol(key) => ("semantic_key = ?2", key.as_str()),
@@ -401,20 +596,40 @@ impl<'a> SqliteGraphQuery<'a> {
             started,
             Duration::from_millis(scope.budget.max_duration_ms),
         )?;
-        let mut statement = connection.prepare(&sql).map_err(sqlite_query_error)?;
-        let mut rows = statement
-            .query(params![
-                scope.snapshot.id.as_str(),
-                lookup,
-                i64::from(scope.budget.max_results.saturating_add(1)),
-                i64::try_from(offset).map_err(|_| stale_cursor_error())?,
-            ])
-            .map_err(sqlite_query_error)?;
+        let mut statement = match connection.prepare(&sql) {
+            Ok(statement) => statement,
+            Err(error) if sqlite_deadline_exceeded(&error) => {
+                return Ok(NodeRows::deadline_exceeded());
+            }
+            Err(_) => return Err(backend_error()),
+        };
+        let mut rows = match statement.query(params![
+            scope.snapshot.id.as_str(),
+            lookup,
+            i64::from(scope.budget.max_results.saturating_add(1)),
+            i64::try_from(offset).map_err(|_| stale_cursor_error())?,
+        ]) {
+            Ok(rows) => rows,
+            Err(error) if sqlite_deadline_exceeded(&error) => {
+                return Ok(NodeRows::deadline_exceeded());
+            }
+            Err(_) => return Err(backend_error()),
+        };
         let mut found = Vec::new();
-        while let Some(row) = rows.next().map_err(sqlite_query_error)? {
-            found.push(decode_node(row)?);
+        loop {
+            match rows.next() {
+                Ok(Some(row)) => found.push(decode_node(row)?),
+                Ok(None) => break,
+                Err(error) if sqlite_deadline_exceeded(&error) => {
+                    return Ok(NodeRows::deadline_exceeded());
+                }
+                Err(_) => return Err(backend_error()),
+            }
         }
-        Ok(found)
+        Ok(NodeRows {
+            rows: found,
+            deadline_exceeded: false,
+        })
     }
 
     fn node(&self, snapshot: &SnapshotId, id: &NodeId) -> Result<Option<GraphNode>, QueryError> {
@@ -423,12 +638,12 @@ impl<'a> SqliteGraphQuery<'a> {
             .sidecar
             .connection()
             .prepare(&sql)
-            .map_err(|_| backend_error())?;
+            .map_err(sqlite_query_error)?;
         let mut rows = statement
             .query(params![snapshot.as_str(), id.as_str()])
-            .map_err(|_| backend_error())?;
+            .map_err(sqlite_query_error)?;
         rows.next()
-            .map_err(|_| backend_error())?
+            .map_err(sqlite_query_error)?
             .map(decode_node)
             .transpose()
     }
@@ -469,7 +684,7 @@ impl<'a> SqliteGraphQuery<'a> {
             .sidecar
             .connection()
             .prepare(&sql)
-            .map_err(|_| backend_error())?;
+            .map_err(sqlite_query_error)?;
         let mut rows = statement
             .query(params![
                 snapshot.as_str(),
@@ -478,9 +693,9 @@ impl<'a> SqliteGraphQuery<'a> {
                 excluded,
                 i64::from(limit.saturating_add(1)),
             ])
-            .map_err(|_| backend_error())?;
+            .map_err(sqlite_query_error)?;
         let mut found = Vec::new();
-        while let Some(row) = rows.next().map_err(|_| backend_error())? {
+        while let Some(row) = rows.next().map_err(sqlite_query_error)? {
             found.push(decode_edge(row)?);
         }
         Ok(found)
@@ -510,7 +725,7 @@ impl GraphQuery for SqliteGraphQuery<'_> {
         let mut reason = search_rows
             .deadline_exceeded
             .then_some(TruncationReason::Duration);
-        for (node, score) in rows {
+        for (node, match_kind) in rows {
             if hits.len() >= scope.budget.max_results as usize {
                 reason = Some(TruncationReason::Results);
                 break;
@@ -519,7 +734,7 @@ impl GraphQuery for SqliteGraphQuery<'_> {
                 reason = Some(TruncationReason::Duration);
                 break;
             }
-            let hit = search_hit(node, score, request.text.trim());
+            let hit = search_hit(node, match_kind, request.text.trim());
             let bytes = serialized_len(&hit)?;
             if returned_bytes.saturating_add(bytes) > scope.budget.max_bytes {
                 reason = Some(TruncationReason::Bytes);
@@ -527,6 +742,11 @@ impl GraphQuery for SqliteGraphQuery<'_> {
             }
             returned_bytes = returned_bytes.saturating_add(bytes);
             hits.push(hit);
+        }
+        let (diagnostics, diagnostics_timed_out) =
+            self.diagnostics_with_deadline(&scope, started)?;
+        if diagnostics_timed_out {
+            reason = Some(TruncationReason::Duration);
         }
         let page = page_info(
             reason,
@@ -544,8 +764,9 @@ impl GraphQuery for SqliteGraphQuery<'_> {
             wire_version: QUERY_WIRE_VERSION,
             repository: scope.repository,
             snapshot_id: scope.snapshot.id.clone(),
+            source_revision: source_revision(&scope.snapshot, &scope.source_revision_id),
             freshness: scope.freshness,
-            diagnostics: self.diagnostics(&scope.snapshot.id)?,
+            diagnostics,
             page,
             data: SearchData { hits },
         })
@@ -561,14 +782,16 @@ impl GraphQuery for SqliteGraphQuery<'_> {
             &scope.snapshot.id,
             &fingerprint,
         )?;
-        let rows = self.show_rows(&scope, request, offset, started)?;
-        if rows.is_empty() && offset == 0 {
+        let show_rows = self.show_rows(&scope, request, offset, started)?;
+        if show_rows.rows.is_empty() && !show_rows.deadline_exceeded && offset == 0 {
             return Err(invalid_request("graph lookup matched no nodes"));
         }
         let mut nodes = Vec::new();
         let mut returned_bytes = 0_u64;
-        let mut reason = None;
-        for node in rows {
+        let mut reason = show_rows
+            .deadline_exceeded
+            .then_some(TruncationReason::Duration);
+        for node in show_rows.rows {
             if nodes.len() >= scope.budget.max_results as usize {
                 reason = Some(TruncationReason::Results);
                 break;
@@ -584,6 +807,11 @@ impl GraphQuery for SqliteGraphQuery<'_> {
             }
             returned_bytes = returned_bytes.saturating_add(bytes);
             nodes.push(node);
+        }
+        let (diagnostics, diagnostics_timed_out) =
+            self.diagnostics_with_deadline(&scope, started)?;
+        if diagnostics_timed_out {
+            reason = Some(TruncationReason::Duration);
         }
         let page = page_info(
             reason,
@@ -601,8 +829,9 @@ impl GraphQuery for SqliteGraphQuery<'_> {
             wire_version: QUERY_WIRE_VERSION,
             repository: scope.repository,
             snapshot_id: scope.snapshot.id.clone(),
+            source_revision: source_revision(&scope.snapshot, &scope.source_revision_id),
             freshness: scope.freshness,
-            diagnostics: self.diagnostics(&scope.snapshot.id)?,
+            diagnostics,
             page,
             data: ShowData { nodes },
         })
@@ -623,6 +852,11 @@ impl GraphQuery for SqliteGraphQuery<'_> {
             return Err(invalid_request("neighborhood requires 1..=32 roots"));
         }
         validate_filters(&request.edge_kinds, 0)?;
+        let deadline = QueryDeadline::install(
+            self.sidecar.connection(),
+            started,
+            Duration::from_millis(scope.budget.max_duration_ms),
+        )?;
 
         let mut nodes = BTreeMap::new();
         let mut edges = BTreeMap::new();
@@ -630,9 +864,17 @@ impl GraphQuery for SqliteGraphQuery<'_> {
         let mut returned_bytes = 0_u64;
         let mut reason = None;
         for root in &request.roots {
-            let node = self
-                .node(&scope.snapshot.id, root)?
-                .ok_or_else(|| invalid_request("neighborhood root was not found"))?;
+            let node = match self.node(&scope.snapshot.id, root) {
+                Ok(Some(node)) => node,
+                Ok(None) => {
+                    return Err(invalid_request("neighborhood root was not found"));
+                }
+                Err(error) if error.code == QueryErrorCode::BudgetExceeded => {
+                    reason = Some(TruncationReason::Duration);
+                    break;
+                }
+                Err(error) => return Err(error),
+            };
             let item = neighborhood_node(node);
             let bytes = serialized_len(&item)?;
             if nodes.len() >= scope.budget.max_results as usize
@@ -661,18 +903,23 @@ impl GraphQuery for SqliteGraphQuery<'_> {
                 break;
             }
             if depth >= scope.budget.max_depth {
-                if !self
-                    .edges(
-                        &scope.snapshot.id,
-                        &current,
-                        request.direction,
-                        &request.edge_kinds,
-                        std::iter::empty::<&EdgeId>(),
-                        1,
-                    )?
-                    .is_empty()
-                {
-                    reason = Some(TruncationReason::Depth);
+                match self.edges(
+                    &scope.snapshot.id,
+                    &current,
+                    request.direction,
+                    &request.edge_kinds,
+                    std::iter::empty::<&EdgeId>(),
+                    1,
+                ) {
+                    Ok(edges) if !edges.is_empty() => {
+                        reason = Some(TruncationReason::Depth);
+                    }
+                    Ok(_) => {}
+                    Err(error) if error.code == QueryErrorCode::BudgetExceeded => {
+                        reason = Some(TruncationReason::Duration);
+                        break;
+                    }
+                    Err(error) => return Err(error),
                 }
                 continue;
             }
@@ -684,14 +931,22 @@ impl GraphQuery for SqliteGraphQuery<'_> {
                 reason = Some(TruncationReason::Results);
                 break;
             }
-            for edge in self.edges(
+            let next_edges = match self.edges(
                 &scope.snapshot.id,
                 &current,
                 request.direction,
                 &request.edge_kinds,
                 edges.keys(),
                 remaining,
-            )? {
+            ) {
+                Ok(edges) => edges,
+                Err(error) if error.code == QueryErrorCode::BudgetExceeded => {
+                    reason = Some(TruncationReason::Duration);
+                    break;
+                }
+                Err(error) => return Err(error),
+            };
+            for edge in next_edges {
                 if edges.contains_key(&edge.id) {
                     continue;
                 }
@@ -718,9 +973,15 @@ impl GraphQuery for SqliteGraphQuery<'_> {
                     reason = Some(TruncationReason::Results);
                     break;
                 }
-                let next = self
-                    .node(&scope.snapshot.id, &next_id)?
-                    .ok_or_else(backend_error)?;
+                let next = match self.node(&scope.snapshot.id, &next_id) {
+                    Ok(Some(node)) => node,
+                    Ok(None) => return Err(backend_error()),
+                    Err(error) if error.code == QueryErrorCode::BudgetExceeded => {
+                        reason = Some(TruncationReason::Duration);
+                        break;
+                    }
+                    Err(error) => return Err(error),
+                };
                 let next = neighborhood_node(next);
                 let bytes = serialized_len(&next)?;
                 if returned_bytes.saturating_add(bytes) > scope.budget.max_bytes {
@@ -733,6 +994,12 @@ impl GraphQuery for SqliteGraphQuery<'_> {
             }
         }
 
+        drop(deadline);
+        let (diagnostics, diagnostics_timed_out) =
+            self.diagnostics_with_deadline(&scope, started)?;
+        if diagnostics_timed_out {
+            reason = Some(TruncationReason::Duration);
+        }
         let page = page_info(
             reason,
             nodes.len() + edges.len(),
@@ -744,8 +1011,9 @@ impl GraphQuery for SqliteGraphQuery<'_> {
             wire_version: QUERY_WIRE_VERSION,
             repository: scope.repository,
             snapshot_id: scope.snapshot.id.clone(),
+            source_revision: source_revision(&scope.snapshot, &scope.source_revision_id),
             freshness: scope.freshness,
-            diagnostics: self.diagnostics(&scope.snapshot.id)?,
+            diagnostics,
             page,
             data: NeighborhoodData {
                 nodes: nodes.into_values().collect(),
@@ -765,6 +1033,7 @@ struct ResolvedScope {
     repository: RepositoryRef,
     snapshot: super::domain::GraphSnapshot,
     published_view: Option<super::domain::PublishedViewName>,
+    source_revision_id: super::domain::SourceRevisionId,
     freshness: FreshnessEnvelope,
     budget: EffectiveBudget,
 }
@@ -775,6 +1044,7 @@ struct EffectiveBudget {
     max_bytes: u64,
     max_depth: u32,
     max_duration_ms: u64,
+    max_diagnostics: u32,
 }
 
 impl EffectiveBudget {
@@ -786,12 +1056,14 @@ impl EffectiveBudget {
             || service.max_bytes == 0
             || service.max_depth == 0
             || service.max_duration_ms == 0
+            || service.max_diagnostics == 0
         {
             return Err(QueryError {
                 wire_version: QUERY_WIRE_VERSION,
                 code: QueryErrorCode::BackendUnavailable,
                 message: "repository graph query limits are invalid".to_string(),
                 retryable: false,
+                recommended_action: None,
                 details: BTreeMap::new(),
             });
         }
@@ -800,6 +1072,7 @@ impl EffectiveBudget {
             max_bytes: requested.max_bytes.get().min(service.max_bytes),
             max_depth: requested.max_depth.get().min(service.max_depth),
             max_duration_ms: requested.max_duration_ms.get().min(service.max_duration_ms),
+            max_diagnostics: requested.max_diagnostics.get().min(service.max_diagnostics),
         })
     }
 }
@@ -813,6 +1086,7 @@ fn validate_wire_version(version: u32) -> Result<(), QueryError> {
             code: QueryErrorCode::UnsupportedWireVersion,
             message: "repository graph query wire version is unsupported".to_string(),
             retryable: false,
+            recommended_action: None,
             details: BTreeMap::new(),
         })
     }
@@ -872,7 +1146,71 @@ fn freshness(expected: &GraphSnapshot, actual: Option<&FreshnessComparison>) -> 
     }
 }
 
-fn search_hit(node: GraphNode, score: f64, query: &str) -> SearchHit {
+fn source_revision(
+    snapshot: &GraphSnapshot,
+    source_revision_id: &super::domain::SourceRevisionId,
+) -> SourceRevisionEnvelope {
+    SourceRevisionEnvelope {
+        id: source_revision_id.clone(),
+        manifest_digest: snapshot.source_manifest_digest.clone(),
+    }
+}
+
+fn available_status_response(
+    resolved: &ResolvedScope,
+    latest_build: Option<&GraphBuild>,
+    diagnostics: DiagnosticsEnvelope,
+    statistics: Option<SnapshotStatistics>,
+    duration_truncated: bool,
+) -> StatusResponse {
+    StatusResponse {
+        wire_version: QUERY_WIRE_VERSION,
+        repository: resolved.repository.clone(),
+        snapshot_id: Some(resolved.snapshot.id.clone()),
+        source_revision: Some(source_revision(
+            &resolved.snapshot,
+            &resolved.source_revision_id,
+        )),
+        freshness: resolved.freshness.clone(),
+        diagnostics,
+        page: PageInfo {
+            next_cursor: None,
+            truncation: duration_truncated.then_some(Truncation {
+                reason: TruncationReason::Duration,
+                returned_results: 0,
+                returned_bytes: 0,
+                explored_depth: 0,
+            }),
+        },
+        data: StatusData {
+            availability: Availability::Available,
+            build_state: latest_build.map(|build| build.state),
+            build_id: latest_build.map(|build| build.id.clone()),
+            published_view: resolved.published_view.clone(),
+            graph_model_version: Some(resolved.snapshot.graph_model_version),
+            statistics,
+            recommended_action: status_action(latest_build, resolved.freshness.freshness),
+        },
+    }
+}
+
+fn truncated_diagnostics() -> DiagnosticsEnvelope {
+    DiagnosticsEnvelope {
+        truncated: true,
+        ..DiagnosticsEnvelope::default()
+    }
+}
+
+fn status_action(build: Option<&GraphBuild>, freshness: Freshness) -> Option<RetrievalAction> {
+    match build.map(|build| build.state) {
+        Some(BuildState::Building) => Some(RetrievalAction::WaitForBuild),
+        Some(BuildState::Failed) => Some(RetrievalAction::RetryIndex),
+        _ if freshness == Freshness::Stale => Some(RetrievalAction::RefreshIndex),
+        _ => None,
+    }
+}
+
+fn search_hit(node: GraphNode, match_kind: SearchMatchKind, query: &str) -> SearchHit {
     let normalized = query.to_lowercase();
     let mut matched_fields = Vec::new();
     if node
@@ -915,8 +1253,36 @@ fn search_hit(node: GraphNode, score: f64, query: &str) -> SearchHit {
         path,
         span,
         provenance: node.provenance,
-        score,
+        match_kind,
+        score: match_kind.score(),
         matched_fields,
+    }
+}
+
+impl SearchMatchKind {
+    fn score(self) -> f64 {
+        match self {
+            Self::ExactSemanticKey => 1.0,
+            Self::ExactPath => 0.99,
+            Self::ExactNormalizedName => 0.98,
+            Self::NormalizedNamePrefix => 0.9,
+            Self::NormalizedNameContains => 0.8,
+            Self::SemanticKeyContains => 0.7,
+            Self::PathContains => 0.6,
+        }
+    }
+}
+
+fn search_match_kind(rank: i64) -> Result<SearchMatchKind, QueryError> {
+    match rank {
+        0 => Ok(SearchMatchKind::ExactSemanticKey),
+        1 => Ok(SearchMatchKind::ExactPath),
+        2 => Ok(SearchMatchKind::ExactNormalizedName),
+        3 => Ok(SearchMatchKind::NormalizedNamePrefix),
+        4 => Ok(SearchMatchKind::NormalizedNameContains),
+        5 => Ok(SearchMatchKind::SemanticKeyContains),
+        6 => Ok(SearchMatchKind::PathContains),
+        _ => Err(backend_error()),
     }
 }
 
@@ -1275,6 +1641,15 @@ fn confidence(value: &str) -> Result<Confidence, QueryError> {
     }
 }
 
+fn diagnostic_severity(value: &str) -> Result<DiagnosticSeverity, QueryError> {
+    match value {
+        "info" => Ok(DiagnosticSeverity::Info),
+        "warning" => Ok(DiagnosticSeverity::Warning),
+        "error" => Ok(DiagnosticSeverity::Error),
+        _ => Err(backend_error()),
+    }
+}
+
 fn optional_u32(value: Option<i64>) -> Result<Option<u32>, QueryError> {
     value
         .map(u32::try_from)
@@ -1335,6 +1710,7 @@ fn invalid_request(message: &'static str) -> QueryError {
         code: QueryErrorCode::InvalidRequest,
         message: message.to_string(),
         retryable: false,
+        recommended_action: None,
         details: BTreeMap::new(),
     }
 }
@@ -1345,6 +1721,7 @@ fn backend_error() -> QueryError {
         code: QueryErrorCode::BackendUnavailable,
         message: "repository graph storage is unavailable or inconsistent".to_string(),
         retryable: true,
+        recommended_action: None,
         details: BTreeMap::new(),
     }
 }
@@ -1355,6 +1732,7 @@ fn duration_budget_exceeded_error() -> QueryError {
         code: QueryErrorCode::BudgetExceeded,
         message: "repository graph query exceeded the duration budget".to_string(),
         retryable: false,
+        recommended_action: None,
         details: BTreeMap::new(),
     }
 }
@@ -1365,6 +1743,30 @@ fn not_built_error() -> QueryError {
         code: QueryErrorCode::NotBuilt,
         message: "repository graph is not built; run `ferrus graph index`".to_string(),
         retryable: false,
+        recommended_action: Some(RetrievalAction::Index),
+        details: BTreeMap::new(),
+    }
+}
+
+fn index_building_error() -> QueryError {
+    QueryError {
+        wire_version: QUERY_WIRE_VERSION,
+        code: QueryErrorCode::IndexBuilding,
+        message: "repository graph is currently building; retry after indexing completes"
+            .to_string(),
+        retryable: true,
+        recommended_action: Some(RetrievalAction::WaitForBuild),
+        details: BTreeMap::new(),
+    }
+}
+
+fn index_failed_error() -> QueryError {
+    QueryError {
+        wire_version: QUERY_WIRE_VERSION,
+        code: QueryErrorCode::IndexFailed,
+        message: "repository graph build failed; run `ferrus graph index` to retry".to_string(),
+        retryable: false,
+        recommended_action: Some(RetrievalAction::RetryIndex),
         details: BTreeMap::new(),
     }
 }
@@ -1375,6 +1777,7 @@ fn snapshot_not_found_error() -> QueryError {
         code: QueryErrorCode::SnapshotNotFound,
         message: "repository graph snapshot was not found".to_string(),
         retryable: false,
+        recommended_action: None,
         details: BTreeMap::new(),
     }
 }
@@ -1386,6 +1789,7 @@ fn stale_cursor_error() -> QueryError {
         message: "repository graph cursor does not match this query snapshot or parameters"
             .to_string(),
         retryable: false,
+        recommended_action: None,
         details: BTreeMap::new(),
     }
 }
@@ -1402,6 +1806,8 @@ pub fn default_budget(
             .ok_or_else(|| invalid_request("query max_depth must be greater than zero"))?,
         NonZeroU64::new(limits.max_duration_ms)
             .ok_or_else(|| invalid_request("query max_duration_ms must be greater than zero"))?,
+        NonZeroU32::new(limits.max_diagnostics)
+            .ok_or_else(|| invalid_request("query max_diagnostics must be greater than zero"))?,
     ))
 }
 
@@ -1410,10 +1816,15 @@ mod tests {
     use super::*;
     use crate::repository_graph::{
         config::RepositoryGraphConfig,
-        domain::{BuildId, PublishedViewName, RepositoryId, RepositoryNamespace},
+        domain::{
+            Availability, BuildId, BuildState, DiagnosticCode, DiagnosticSeverity, GraphBuild,
+            GraphDiagnostic, PublishedViewName, RepositoryId, RepositoryNamespace, SnapshotId,
+            SourceRevisionId,
+        },
         index::{IndexCoordinator, IndexRequest, active_extractor_identities},
         source::{FilesystemRepositorySource, SourceDiscoveryContext},
         sqlite::{OpenSidecarResult, open_for_build_at},
+        store::BuildFailure,
     };
 
     fn repository() -> RepositoryRef {
@@ -1492,7 +1903,7 @@ mod tests {
     }
 
     fn scope(config: &RepositoryGraphConfig) -> super::super::query::QueryScope {
-        super::super::query::QueryScope::v1(
+        super::super::query::QueryScope::current(
             repository(),
             SnapshotSelector::Published(PublishedViewName::new("canonical").unwrap()),
             default_budget(&config.query_limits).unwrap(),
@@ -1505,7 +1916,7 @@ mod tests {
         let query = SqliteGraphQuery::new(
             &sidecar,
             config.query_limits.clone(),
-            Some(freshness_comparison),
+            Some(freshness_comparison.clone()),
         );
         let search = query
             .search(&SearchRequest {
@@ -1517,6 +1928,10 @@ mod tests {
             })
             .unwrap();
         assert_eq!(search.freshness.freshness, Freshness::Fresh);
+        assert_eq!(
+            search.source_revision.manifest_digest,
+            freshness_comparison.source_manifest_digest
+        );
         assert!(!search.data.hits.is_empty());
         let hit = &search.data.hits[0];
         assert_eq!(hit.path.as_ref().unwrap().as_str(), "src/lib.rs");
@@ -1547,6 +1962,192 @@ mod tests {
                 .nodes
                 .iter()
                 .any(|node| node.id == hit.node_id)
+        );
+    }
+
+    #[test]
+    fn search_classifies_exact_matches_and_is_snapshot_deterministic() {
+        let (_source, _sidecar_dir, sidecar, config, comparison) = indexed_fixture();
+        let query = SqliteGraphQuery::new(&sidecar, config.query_limits.clone(), Some(comparison));
+
+        for (text, expected) in [
+            ("RuntimeTaskContext", SearchMatchKind::ExactNormalizedName),
+            ("src/lib.rs", SearchMatchKind::ExactPath),
+        ] {
+            let request = SearchRequest {
+                scope: scope(&config),
+                text: text.to_string(),
+                node_kinds: vec![],
+                paths: vec![],
+                page: super::super::query::PageRequest { cursor: None },
+            };
+            let first = query.search(&request).unwrap();
+            let second = query.search(&request).unwrap();
+
+            assert_eq!(first.data.hits.first().unwrap().match_kind, expected);
+            assert_eq!(
+                serde_json::to_value(first).unwrap(),
+                serde_json::to_value(second).unwrap()
+            );
+        }
+
+        let symbol = query
+            .search(&SearchRequest {
+                scope: scope(&config),
+                text: "RuntimeTaskContext".to_string(),
+                node_kinds: vec!["struct".to_string()],
+                paths: vec![],
+                page: super::super::query::PageRequest { cursor: None },
+            })
+            .unwrap()
+            .data
+            .hits
+            .into_iter()
+            .find_map(|hit| hit.semantic_key)
+            .unwrap();
+        let exact_symbol = query
+            .search(&SearchRequest {
+                scope: scope(&config),
+                text: symbol.as_str().to_string(),
+                node_kinds: vec![],
+                paths: vec![],
+                page: super::super::query::PageRequest { cursor: None },
+            })
+            .unwrap();
+        assert_eq!(
+            exact_symbol.data.hits.first().unwrap().match_kind,
+            SearchMatchKind::ExactSemanticKey
+        );
+    }
+
+    #[test]
+    fn previous_wire_versions_are_rejected_explicitly() {
+        let (_source, _sidecar_dir, sidecar, config, _comparison) = indexed_fixture();
+        let query = SqliteGraphQuery::new(&sidecar, config.query_limits.clone(), None);
+        let mut request_scope = scope(&config);
+        request_scope.wire_version = QUERY_WIRE_VERSION - 1;
+
+        let error = query
+            .status(&StatusRequest {
+                scope: request_scope,
+            })
+            .unwrap_err();
+
+        assert_eq!(error.code, QueryErrorCode::UnsupportedWireVersion);
+        assert_eq!(error.wire_version, QUERY_WIRE_VERSION);
+    }
+
+    #[test]
+    fn unbuilt_status_and_queries_distinguish_building_and_failed_attempts() {
+        let sidecar_dir = tempfile::tempdir().unwrap();
+        let OpenSidecarResult::Ready(mut sidecar) =
+            open_for_build_at(&sidecar_dir.path().join("repo-graph.db")).unwrap()
+        else {
+            panic!("new sidecar unexpectedly requires rebuild");
+        };
+        let config = RepositoryGraphConfig::default();
+        let build = GraphBuild {
+            id: BuildId::new("build-in-progress").unwrap(),
+            repository: repository(),
+            source_revision_id: SourceRevisionId::new("revision-next").unwrap(),
+            prospective_snapshot_id: SnapshotId::new("snapshot-next").unwrap(),
+            state: BuildState::Building,
+        };
+        sidecar.start_build(&build).unwrap();
+
+        let query = SqliteGraphQuery::new(&sidecar, config.query_limits.clone(), None);
+        let status = query
+            .status(&StatusRequest {
+                scope: scope(&config),
+            })
+            .unwrap();
+        assert_eq!(status.data.availability, Availability::NotBuilt);
+        assert_eq!(status.data.build_state, Some(BuildState::Building));
+        assert_eq!(
+            status.data.recommended_action,
+            Some(RetrievalAction::WaitForBuild)
+        );
+        let error = query
+            .search(&SearchRequest {
+                scope: scope(&config),
+                text: "anything".to_string(),
+                node_kinds: vec![],
+                paths: vec![],
+                page: super::super::query::PageRequest { cursor: None },
+            })
+            .unwrap_err();
+        assert_eq!(error.code, QueryErrorCode::IndexBuilding);
+
+        drop(query);
+        sidecar
+            .fail_build(&BuildFailure {
+                build_id: build.id,
+                code: DiagnosticCode::new("index.failed").unwrap(),
+            })
+            .unwrap();
+        let query = SqliteGraphQuery::new(&sidecar, config.query_limits.clone(), None);
+        let status = query
+            .status(&StatusRequest {
+                scope: scope(&config),
+            })
+            .unwrap();
+        assert_eq!(status.data.build_state, Some(BuildState::Failed));
+        assert_eq!(
+            status.data.recommended_action,
+            Some(RetrievalAction::RetryIndex)
+        );
+        let error = query
+            .search(&SearchRequest {
+                scope: scope(&config),
+                text: "anything".to_string(),
+                node_kinds: vec![],
+                paths: vec![],
+                page: super::super::query::PageRequest { cursor: None },
+            })
+            .unwrap_err();
+        assert_eq!(error.code, QueryErrorCode::IndexFailed);
+    }
+
+    #[test]
+    fn diagnostics_are_deterministic_and_capped_independently() {
+        let (_source, _sidecar_dir, mut sidecar, mut config, _comparison) = indexed_fixture();
+        let snapshot = sidecar
+            .published_snapshot(&repository(), &PublishedViewName::new("canonical").unwrap())
+            .unwrap()
+            .unwrap();
+        for code in ["query.z", "query.a", "query.m"] {
+            sidecar
+                .record_diagnostic(&GraphDiagnostic {
+                    build_id: BuildId::new("build-query").unwrap(),
+                    snapshot_id: Some(snapshot.id.clone()),
+                    severity: DiagnosticSeverity::Warning,
+                    code: DiagnosticCode::new(code).unwrap(),
+                    location: None,
+                    metrics: BTreeMap::new(),
+                })
+                .unwrap();
+        }
+        config.query_limits.max_diagnostics = 2;
+        let query = SqliteGraphQuery::new(&sidecar, config.query_limits.clone(), None);
+        let response = query
+            .search(&SearchRequest {
+                scope: scope(&config),
+                text: "RuntimeTaskContext".to_string(),
+                node_kinds: vec![],
+                paths: vec![],
+                page: super::super::query::PageRequest { cursor: None },
+            })
+            .unwrap();
+
+        assert!(response.diagnostics.truncated);
+        assert_eq!(response.diagnostics.items.len(), 2);
+        assert!(response.diagnostics.summary.warning >= 3);
+        assert!(
+            response
+                .diagnostics
+                .items
+                .windows(2)
+                .all(|items| { items[0].code.as_str() <= items[1].code.as_str() })
         );
     }
 
@@ -1776,11 +2377,12 @@ mod tests {
         let started = Instant::now()
             - Duration::from_millis(config.query_limits.max_duration_ms.saturating_add(1));
 
-        let error = query
+        let rows = query
             .show_rows(&resolved_scope, &request, 0, started)
-            .unwrap_err();
+            .unwrap();
 
-        assert_eq!(error.code, QueryErrorCode::BudgetExceeded);
+        assert!(rows.deadline_exceeded);
+        assert!(rows.rows.is_empty());
     }
 
     #[test]
@@ -1790,16 +2392,20 @@ mod tests {
         let started = Instant::now()
             - Duration::from_millis(config.query_limits.max_duration_ms.saturating_add(1));
 
-        let error = query
+        let response = query
             .status_at(
                 &StatusRequest {
                     scope: scope(&config),
                 },
                 started,
             )
-            .unwrap_err();
+            .unwrap();
 
-        assert_eq!(error.code, QueryErrorCode::BudgetExceeded);
+        assert_eq!(
+            response.page.truncation.unwrap().reason,
+            TruncationReason::Duration
+        );
+        assert!(response.data.statistics.is_none());
     }
 
     #[test]

--- a/src/repository_graph/query_sqlite.rs
+++ b/src/repository_graph/query_sqlite.rs
@@ -1,7 +1,7 @@
 //! Bounded read-only SQLite implementation of the portable graph query contract.
 
 use std::{
-    collections::{BTreeMap, VecDeque},
+    collections::{BTreeMap, BTreeSet, VecDeque},
     num::{NonZeroU32, NonZeroU64},
     time::{Duration, Instant},
 };
@@ -22,8 +22,9 @@ use super::{
     },
     ports::{GraphQuery, SourceManifest},
     query::{
-        ContextRequest, ContextResponse, DiagnosticSummary, DiagnosticsEnvelope, EdgeDirection,
-        FreshnessEnvelope, NeighborhoodData, NeighborhoodEdge, NeighborhoodNode,
+        ContextData, ContextItem, ContextRequest, ContextResponse, ContextSeed,
+        ContextSelectionKind, ContextSelectionReason, DiagnosticSummary, DiagnosticsEnvelope,
+        EdgeDirection, FreshnessEnvelope, NeighborhoodData, NeighborhoodEdge, NeighborhoodNode,
         NeighborhoodRequest, NeighborhoodResponse, PageInfo, QueryDiagnostic, QueryError,
         QueryErrorCode, QueryResponse, RetrievalAction, SearchData, SearchHit, SearchMatchKind,
         SearchRequest, SearchResponse, ShowData, ShowLookup, ShowRequest, ShowResponse,
@@ -45,6 +46,7 @@ const EDGE_COLUMNS: &str = "snapshot_id, id, kind, source_node_id, target_node_i
     span_end_column";
 const MAX_FILTERS: usize = 32;
 const MAX_QUERY_TEXT_BYTES: usize = 512;
+const MAX_CONTEXT_CANDIDATES: usize = 4_096;
 const SQLITE_PROGRESS_OPS: i32 = 100;
 
 struct QueryDeadline<'connection> {
@@ -81,6 +83,18 @@ struct SearchRows {
 struct NodeRows {
     rows: Vec<GraphNode>,
     deadline_exceeded: bool,
+}
+
+struct ContextCandidate {
+    node: GraphNode,
+    depth: u32,
+    selection_reasons: Vec<ContextSelectionReason>,
+}
+
+struct ContextAssembly {
+    candidates: Vec<ContextCandidate>,
+    explored_depth: u32,
+    truncation: Option<TruncationReason>,
 }
 
 #[derive(Serialize)]
@@ -700,6 +714,198 @@ impl<'a> SqliteGraphQuery<'a> {
         }
         Ok(found)
     }
+
+    fn context_seed_nodes(
+        &self,
+        snapshot: &SnapshotId,
+        seed: &ContextSeed,
+    ) -> Result<Vec<GraphNode>, QueryError> {
+        if let ContextSeed::Node(id) = seed {
+            return Ok(self.node(snapshot, id)?.into_iter().collect());
+        }
+        let (predicate, value) = match seed {
+            ContextSeed::Symbol(key) => ("semantic_key = ?2", key.as_str()),
+            ContextSeed::Path(path) => ("evidence_path = ?2", path.as_str()),
+            ContextSeed::Node(_) => unreachable!("node seeds return above"),
+        };
+        let sql = format!(
+            "SELECT {NODE_COLUMNS} FROM nodes WHERE snapshot_id = ?1 AND {predicate} \
+             ORDER BY kind, COALESCE(semantic_key, ''), id LIMIT ?3"
+        );
+        let mut statement = self
+            .sidecar
+            .connection()
+            .prepare(&sql)
+            .map_err(sqlite_query_error)?;
+        let mut rows = statement
+            .query(params![
+                snapshot.as_str(),
+                value,
+                i64::try_from(MAX_CONTEXT_CANDIDATES + 1).expect("context cap fits in i64"),
+            ])
+            .map_err(sqlite_query_error)?;
+        let mut found = Vec::new();
+        while let Some(row) = rows.next().map_err(sqlite_query_error)? {
+            found.push(decode_node(row)?);
+        }
+        Ok(found)
+    }
+
+    fn assemble_context(
+        &self,
+        scope: &ResolvedScope,
+        request: &ContextRequest,
+        started: Instant,
+    ) -> Result<ContextAssembly, QueryError> {
+        let mut candidates = BTreeMap::<NodeId, ContextCandidate>::new();
+        let mut frontier = Vec::new();
+        let mut truncation = None;
+
+        let mut seeds = request
+            .seeds
+            .iter()
+            .map(|seed| Ok((context_seed_key(seed)?, seed)))
+            .collect::<Result<Vec<_>, QueryError>>()?;
+        seeds.sort_by(|left, right| left.0.cmp(&right.0));
+        seeds.dedup_by(|left, right| left.0 == right.0);
+        for (_, seed) in seeds {
+            let mut nodes = match self.context_seed_nodes(&scope.snapshot.id, seed) {
+                Ok(nodes) => nodes,
+                Err(error) if error.code == QueryErrorCode::BudgetExceeded => {
+                    set_context_truncation(&mut truncation, TruncationReason::Duration);
+                    break;
+                }
+                Err(error) => return Err(error),
+            };
+            if nodes.is_empty() {
+                return Err(invalid_request("context seed matched no nodes"));
+            }
+            if nodes.len() > MAX_CONTEXT_CANDIDATES {
+                nodes.truncate(MAX_CONTEXT_CANDIDATES);
+                set_context_truncation(&mut truncation, TruncationReason::Capability);
+            }
+            for node in nodes {
+                let id = node.id.clone();
+                if !candidates.contains_key(&id) && candidates.len() >= MAX_CONTEXT_CANDIDATES {
+                    set_context_truncation(&mut truncation, TruncationReason::Capability);
+                    break;
+                }
+                let is_new = insert_context_candidate(
+                    &mut candidates,
+                    node,
+                    0,
+                    ContextSelectionReason {
+                        kind: ContextSelectionKind::ExactSeed,
+                        via_node: None,
+                        via_edge: None,
+                    },
+                );
+                if is_new {
+                    frontier.push(id);
+                }
+            }
+        }
+
+        frontier.sort();
+        let mut frontier = frontier
+            .into_iter()
+            .map(|node| (node, 0_u32))
+            .collect::<VecDeque<_>>();
+        let mut seen_edges = BTreeSet::<EdgeId>::new();
+        let mut explored_depth = 0_u32;
+
+        'walk: while let Some((current, depth)) = frontier.pop_front() {
+            explored_depth = explored_depth.max(depth);
+            if started.elapsed().as_millis() >= u128::from(scope.budget.max_duration_ms) {
+                set_context_truncation(&mut truncation, TruncationReason::Duration);
+                break;
+            }
+            let remaining_edges = MAX_CONTEXT_CANDIDATES.saturating_sub(seen_edges.len());
+            if remaining_edges == 0 {
+                set_context_truncation(&mut truncation, TruncationReason::Capability);
+                break;
+            }
+            let mut edges = match self.edges(
+                &scope.snapshot.id,
+                &current,
+                request.policy.direction,
+                &request.policy.edge_kinds,
+                seen_edges.iter(),
+                u32::try_from(remaining_edges).expect("context cap fits in u32"),
+            ) {
+                Ok(edges) => edges,
+                Err(error) if error.code == QueryErrorCode::BudgetExceeded => {
+                    set_context_truncation(&mut truncation, TruncationReason::Duration);
+                    break;
+                }
+                Err(error) => return Err(error),
+            };
+            if edges.len() > remaining_edges {
+                edges.truncate(remaining_edges);
+                set_context_truncation(&mut truncation, TruncationReason::Capability);
+            }
+            if depth >= scope.budget.max_depth {
+                if edges
+                    .iter()
+                    .any(|edge| context_edge_allowed(edge, request) && edge_targets_node(edge))
+                {
+                    set_context_truncation(&mut truncation, TruncationReason::Depth);
+                }
+                continue;
+            }
+
+            for edge in edges {
+                seen_edges.insert(edge.id.clone());
+                if !context_edge_allowed(&edge, request) {
+                    continue;
+                }
+                let Some(next_id) = adjacent_node(&edge, &current, request.policy.direction) else {
+                    continue;
+                };
+                let next = match self.node(&scope.snapshot.id, &next_id) {
+                    Ok(Some(node)) => node,
+                    Ok(None) => return Err(backend_error()),
+                    Err(error) if error.code == QueryErrorCode::BudgetExceeded => {
+                        set_context_truncation(&mut truncation, TruncationReason::Duration);
+                        break 'walk;
+                    }
+                    Err(error) => return Err(error),
+                };
+                if !context_node_allowed(&next, request) {
+                    continue;
+                }
+                let next_depth = depth.saturating_add(1);
+                let reason = ContextSelectionReason {
+                    kind: context_selection_kind(&edge, &current, &next),
+                    via_node: Some(current.clone()),
+                    via_edge: Some(edge.id.clone()),
+                };
+                if !candidates.contains_key(&next_id) && candidates.len() >= MAX_CONTEXT_CANDIDATES
+                {
+                    set_context_truncation(&mut truncation, TruncationReason::Capability);
+                    break 'walk;
+                }
+                let is_new = insert_context_candidate(&mut candidates, next, next_depth, reason);
+                if is_new {
+                    frontier.push_back((next_id, next_depth));
+                }
+            }
+        }
+
+        let mut candidates = candidates
+            .into_values()
+            .filter(|candidate| candidate.node.provenance.evidence.is_some())
+            .collect::<Vec<_>>();
+        for candidate in &mut candidates {
+            sort_context_reasons(&mut candidate.selection_reasons);
+        }
+        candidates.sort_by(context_candidate_order);
+        Ok(ContextAssembly {
+            candidates,
+            explored_depth,
+            truncation,
+        })
+    }
 }
 
 impl GraphQuery for SqliteGraphQuery<'_> {
@@ -1022,10 +1228,95 @@ impl GraphQuery for SqliteGraphQuery<'_> {
         })
     }
 
-    fn context(&self, _request: &ContextRequest) -> Result<ContextResponse, QueryError> {
-        Err(invalid_request(
-            "ranked repository context is not available until repository graph phase 2",
-        ))
+    fn context(&self, request: &ContextRequest) -> Result<ContextResponse, QueryError> {
+        let started = Instant::now();
+        let scope = self.resolve_scope(&request.scope)?;
+        if request.seeds.is_empty() || request.seeds.len() > MAX_FILTERS {
+            return Err(invalid_request("context requires 1..=32 seeds"));
+        }
+        validate_filters(&request.policy.edge_kinds, 0)?;
+        let fingerprint = context_cursor_fingerprint(request)?;
+        let offset = decode_cursor(
+            request.page.cursor.as_ref(),
+            "context",
+            &scope.snapshot.id,
+            &fingerprint,
+        )?;
+        let deadline = QueryDeadline::install(
+            self.sidecar.connection(),
+            started,
+            Duration::from_millis(scope.budget.max_duration_ms),
+        )?;
+        let assembly = self.assemble_context(&scope, request, started)?;
+        drop(deadline);
+
+        let offset = usize::try_from(offset).map_err(|_| stale_cursor_error())?;
+        if offset > assembly.candidates.len() {
+            return Err(stale_cursor_error());
+        }
+        let mut candidates = assembly.candidates.into_iter().skip(offset).peekable();
+        let mut items = Vec::new();
+        let mut returned_bytes = 0_u64;
+        let mut reason = None;
+        for candidate in candidates.by_ref() {
+            if items.len() >= scope.budget.max_results as usize {
+                reason = Some(TruncationReason::Results);
+                break;
+            }
+            if started.elapsed().as_millis() >= u128::from(scope.budget.max_duration_ms) {
+                reason = Some(TruncationReason::Duration);
+                break;
+            }
+            let item = context_item(candidate);
+            let bytes = serialized_len(&item)?;
+            if returned_bytes.saturating_add(bytes) > scope.budget.max_bytes {
+                reason = Some(TruncationReason::Bytes);
+                break;
+            }
+            returned_bytes = returned_bytes.saturating_add(bytes);
+            items.push(item);
+        }
+        let has_more_candidates = candidates.peek().is_some()
+            || matches!(
+                reason,
+                Some(TruncationReason::Results | TruncationReason::Bytes)
+            );
+        if reason.is_none() {
+            reason = assembly.truncation;
+        }
+        let (diagnostics, diagnostics_timed_out) =
+            self.diagnostics_with_deadline(&scope, started)?;
+        if diagnostics_timed_out {
+            reason = Some(TruncationReason::Duration);
+        }
+        let cursor = (has_more_candidates
+            && matches!(
+                reason,
+                Some(TruncationReason::Results | TruncationReason::Bytes)
+            ))
+        .then_some((
+            "context",
+            &scope.snapshot.id,
+            fingerprint.as_str(),
+            u64::try_from(offset + items.len()).unwrap_or(u64::MAX),
+        ));
+        let page = page_info(
+            reason,
+            items.len(),
+            returned_bytes,
+            assembly.explored_depth,
+            cursor,
+        )?;
+        Ok(QueryResponse {
+            wire_version: QUERY_WIRE_VERSION,
+            repository: scope.repository,
+            snapshot_id: scope.snapshot.id.clone(),
+            source_revision: source_revision(&scope.snapshot, &scope.source_revision_id),
+            freshness: scope.freshness,
+            diagnostics,
+            page,
+            data: ContextData { items },
+        })
     }
 }
 
@@ -1286,6 +1577,223 @@ fn search_match_kind(rank: i64) -> Result<SearchMatchKind, QueryError> {
     }
 }
 
+fn insert_context_candidate(
+    candidates: &mut BTreeMap<NodeId, ContextCandidate>,
+    node: GraphNode,
+    depth: u32,
+    reason: ContextSelectionReason,
+) -> bool {
+    match candidates.entry(node.id.clone()) {
+        std::collections::btree_map::Entry::Occupied(mut entry) => {
+            let candidate = entry.get_mut();
+            candidate.depth = candidate.depth.min(depth);
+            if !candidate.selection_reasons.contains(&reason) {
+                candidate.selection_reasons.push(reason);
+            }
+            false
+        }
+        std::collections::btree_map::Entry::Vacant(entry) => {
+            entry.insert(ContextCandidate {
+                node,
+                depth,
+                selection_reasons: vec![reason],
+            });
+            true
+        }
+    }
+}
+
+fn context_edge_allowed(edge: &GraphEdge, request: &ContextRequest) -> bool {
+    match edge.provenance.resolution {
+        ResolutionState::Resolved => true,
+        ResolutionState::Unresolved => request.policy.include_unresolved,
+        ResolutionState::External => request.policy.include_external,
+    }
+}
+
+fn context_node_allowed(node: &GraphNode, request: &ContextRequest) -> bool {
+    match node.provenance.resolution {
+        ResolutionState::Resolved => true,
+        ResolutionState::Unresolved => request.policy.include_unresolved,
+        ResolutionState::External => request.policy.include_external,
+    }
+}
+
+fn edge_targets_node(edge: &GraphEdge) -> bool {
+    matches!(edge.target, EdgeTarget::Node(_))
+}
+
+fn context_selection_kind(
+    edge: &GraphEdge,
+    current: &NodeId,
+    next: &GraphNode,
+) -> ContextSelectionKind {
+    if edge.provenance.resolution == ResolutionState::Resolved
+        && matches!(edge.kind.as_str(), "imports" | "re_exports" | "depends_on")
+    {
+        return ContextSelectionKind::ResolvedDependency;
+    }
+    if next.kind == "document" {
+        return ContextSelectionKind::Documentation;
+    }
+    if matches!(
+        next.kind.as_str(),
+        "manifest"
+            | "configuration"
+            | "entry_point"
+            | "cargo_workspace"
+            | "cargo_package"
+            | "cargo_target"
+            | "dependency"
+    ) {
+        return ContextSelectionKind::Configuration;
+    }
+    if edge.kind == "declares_module"
+        || edge.kind == "contains" && edge.source == *current && is_declaration_node(next)
+    {
+        return ContextSelectionKind::Declaration;
+    }
+    if edge.kind == "contains" {
+        return ContextSelectionKind::Containment;
+    }
+    ContextSelectionKind::Relationship
+}
+
+fn is_declaration_node(node: &GraphNode) -> bool {
+    matches!(
+        node.kind.as_str(),
+        "module"
+            | "mod_declaration"
+            | "struct"
+            | "enum"
+            | "union"
+            | "trait"
+            | "impl"
+            | "function"
+            | "type_alias"
+            | "const"
+            | "static"
+            | "macro"
+    )
+}
+
+fn context_selection_rank(kind: ContextSelectionKind) -> u8 {
+    match kind {
+        ContextSelectionKind::ExactSeed => 0,
+        ContextSelectionKind::Containment => 1,
+        ContextSelectionKind::Declaration => 2,
+        ContextSelectionKind::ResolvedDependency => 3,
+        ContextSelectionKind::Documentation => 4,
+        ContextSelectionKind::Configuration => 5,
+        ContextSelectionKind::Relationship => 6,
+    }
+}
+
+fn sort_context_reasons(reasons: &mut Vec<ContextSelectionReason>) {
+    reasons.sort_by(|left, right| {
+        context_selection_rank(left.kind)
+            .cmp(&context_selection_rank(right.kind))
+            .then_with(|| {
+                left.via_node
+                    .as_ref()
+                    .map(NodeId::as_str)
+                    .cmp(&right.via_node.as_ref().map(NodeId::as_str))
+            })
+            .then_with(|| {
+                left.via_edge
+                    .as_ref()
+                    .map(EdgeId::as_str)
+                    .cmp(&right.via_edge.as_ref().map(EdgeId::as_str))
+            })
+    });
+    reasons.dedup();
+}
+
+fn context_candidate_order(
+    left: &ContextCandidate,
+    right: &ContextCandidate,
+) -> std::cmp::Ordering {
+    let left_evidence = left
+        .node
+        .provenance
+        .evidence
+        .as_ref()
+        .expect("context candidates without evidence are filtered before sorting");
+    let right_evidence = right
+        .node
+        .provenance
+        .evidence
+        .as_ref()
+        .expect("context candidates without evidence are filtered before sorting");
+    let left_rank = left
+        .selection_reasons
+        .iter()
+        .map(|reason| context_selection_rank(reason.kind))
+        .min()
+        .unwrap_or(u8::MAX);
+    let right_rank = right
+        .selection_reasons
+        .iter()
+        .map(|reason| context_selection_rank(reason.kind))
+        .min()
+        .unwrap_or(u8::MAX);
+    left_rank
+        .cmp(&right_rank)
+        .then_with(|| left.depth.cmp(&right.depth))
+        .then_with(|| left_evidence.path.cmp(&right_evidence.path))
+        .then_with(|| {
+            left_evidence
+                .span
+                .as_ref()
+                .map(|span| span.start.byte_offset)
+                .unwrap_or(u64::MAX)
+                .cmp(
+                    &right_evidence
+                        .span
+                        .as_ref()
+                        .map(|span| span.start.byte_offset)
+                        .unwrap_or(u64::MAX),
+                )
+        })
+        .then_with(|| left.node.kind.cmp(&right.node.kind))
+        .then_with(|| left.node.semantic_key.cmp(&right.node.semantic_key))
+        .then_with(|| left.node.id.cmp(&right.node.id))
+}
+
+fn context_item(candidate: ContextCandidate) -> ContextItem {
+    let evidence = candidate
+        .node
+        .provenance
+        .evidence
+        .clone()
+        .expect("context candidates without evidence are filtered before materialization");
+    ContextItem {
+        node_id: candidate.node.id,
+        kind: candidate.node.kind,
+        semantic_key: candidate.node.semantic_key,
+        path: evidence.path,
+        span: evidence.span,
+        content_identity: evidence.content_identity,
+        provenance: candidate.node.provenance,
+        selection_reasons: candidate.selection_reasons,
+    }
+}
+
+fn set_context_truncation(current: &mut Option<TruncationReason>, next: TruncationReason) {
+    fn priority(reason: TruncationReason) -> u8 {
+        match reason {
+            TruncationReason::Duration => 0,
+            TruncationReason::Capability => 1,
+            TruncationReason::Depth => 2,
+            TruncationReason::Bytes => 3,
+            TruncationReason::Results => 4,
+        }
+    }
+    if current.is_none_or(|reason| priority(next) < priority(reason)) {
+        *current = Some(next);
+    }
+}
+
 fn neighborhood_node(node: GraphNode) -> NeighborhoodNode {
     let path = node
         .provenance
@@ -1475,6 +1983,47 @@ fn search_cursor_fingerprint(request: &SearchRequest) -> Result<String, QueryErr
 
 fn show_cursor_fingerprint(request: &ShowRequest) -> Result<String, QueryError> {
     cursor_fingerprint("show", &request.lookup)
+}
+
+#[derive(Serialize)]
+struct ContextCursorParameters<'a> {
+    seeds: Vec<String>,
+    direction: EdgeDirection,
+    edge_kinds: Vec<&'a str>,
+    include_unresolved: bool,
+    include_external: bool,
+}
+
+fn context_cursor_fingerprint(request: &ContextRequest) -> Result<String, QueryError> {
+    let mut seeds = request
+        .seeds
+        .iter()
+        .map(context_seed_key)
+        .collect::<Result<Vec<_>, _>>()?;
+    seeds.sort_unstable();
+    seeds.dedup();
+    let mut edge_kinds = request
+        .policy
+        .edge_kinds
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    edge_kinds.sort_unstable();
+    edge_kinds.dedup();
+    cursor_fingerprint(
+        "context",
+        &ContextCursorParameters {
+            seeds,
+            direction: request.policy.direction,
+            edge_kinds,
+            include_unresolved: request.policy.include_unresolved,
+            include_external: request.policy.include_external,
+        },
+    )
+}
+
+fn context_seed_key(seed: &ContextSeed) -> Result<String, QueryError> {
+    serde_json::to_string(seed).map_err(|_| backend_error())
 }
 
 fn cursor_fingerprint<T: Serialize>(operation: &str, parameters: &T) -> Result<String, QueryError> {
@@ -1908,6 +2457,383 @@ mod tests {
             SnapshotSelector::Published(PublishedViewName::new("canonical").unwrap()),
             default_budget(&config.query_limits).unwrap(),
         )
+    }
+
+    fn context_request(config: &RepositoryGraphConfig, seed: ContextSeed) -> ContextRequest {
+        ContextRequest {
+            scope: scope(config),
+            seeds: vec![seed],
+            policy: super::super::query::ContextPolicy {
+                direction: EdgeDirection::Both,
+                edge_kinds: vec![],
+                include_unresolved: false,
+                include_external: false,
+            },
+            page: super::super::query::PageRequest { cursor: None },
+        }
+    }
+
+    fn fixture_symbol(query: &SqliteGraphQuery<'_>, config: &RepositoryGraphConfig) -> SemanticKey {
+        query
+            .search(&SearchRequest {
+                scope: scope(config),
+                text: "RuntimeTaskContext".to_string(),
+                node_kinds: vec!["struct".to_string()],
+                paths: vec![],
+                page: super::super::query::PageRequest { cursor: None },
+            })
+            .unwrap()
+            .data
+            .hits
+            .into_iter()
+            .find_map(|hit| hit.semantic_key)
+            .unwrap()
+    }
+
+    #[test]
+    fn context_resolves_seeds_ranks_deduplicates_and_preserves_evidence() {
+        let (_source, _sidecar_dir, sidecar, config, comparison) = indexed_fixture();
+        let query = SqliteGraphQuery::new(&sidecar, config.query_limits.clone(), Some(comparison));
+        let symbol = ContextSeed::Symbol(fixture_symbol(&query, &config));
+        let request = context_request(&config, symbol.clone());
+
+        let first = query.context(&request).unwrap();
+        let second = query.context(&request).unwrap();
+
+        assert!(!first.data.items.is_empty());
+        assert_eq!(
+            first.data.items[0].selection_reasons[0].kind,
+            ContextSelectionKind::ExactSeed
+        );
+        assert_eq!(
+            serde_json::to_value(&first).unwrap(),
+            serde_json::to_value(&second).unwrap()
+        );
+        let mut node_ids = BTreeSet::new();
+        let mut selection_kinds = BTreeSet::new();
+        for item in &first.data.items {
+            assert!(node_ids.insert(item.node_id.clone()));
+            let evidence = item.provenance.evidence.as_ref().unwrap();
+            assert_eq!(item.path, evidence.path);
+            assert_eq!(item.span, evidence.span);
+            assert_eq!(item.content_identity, evidence.content_identity);
+            let mut reasons = item.selection_reasons.clone();
+            sort_context_reasons(&mut reasons);
+            reasons.dedup();
+            assert_eq!(item.selection_reasons, reasons);
+            selection_kinds.extend(
+                item.selection_reasons
+                    .iter()
+                    .map(|reason| context_selection_rank(reason.kind)),
+            );
+        }
+        assert!(
+            selection_kinds.contains(&context_selection_rank(ContextSelectionKind::Containment))
+        );
+        assert!(
+            selection_kinds.contains(&context_selection_rank(ContextSelectionKind::Declaration))
+        );
+
+        let mut ordered = context_request(&config, symbol.clone());
+        ordered
+            .seeds
+            .push(ContextSeed::Path(RepoPath::new("src/lib.rs").unwrap()));
+        let mut reversed = ordered.clone();
+        reversed.seeds.reverse();
+        assert_eq!(
+            serde_json::to_value(query.context(&ordered).unwrap()).unwrap(),
+            serde_json::to_value(query.context(&reversed).unwrap()).unwrap()
+        );
+    }
+
+    #[test]
+    fn context_pagination_is_snapshot_and_parameter_bound() {
+        let (_source, _sidecar_dir, sidecar, mut config, _comparison) = indexed_fixture();
+        config.query_limits.max_results = 2;
+        let query = SqliteGraphQuery::new(&sidecar, config.query_limits.clone(), None);
+        let mut request = context_request(
+            &config,
+            ContextSeed::Symbol(fixture_symbol(&query, &config)),
+        );
+
+        let first = query.context(&request).unwrap();
+        assert_eq!(first.data.items.len(), 2);
+        assert_eq!(
+            first.page.truncation.as_ref().unwrap().reason,
+            TruncationReason::Results
+        );
+        request.page.cursor = first.page.next_cursor.clone();
+        let second = query.context(&request).unwrap();
+        assert!(first.data.items.iter().all(|left| {
+            second
+                .data
+                .items
+                .iter()
+                .all(|right| left.node_id != right.node_id)
+        }));
+
+        request.policy.direction = EdgeDirection::Outgoing;
+        let error = query.context(&request).unwrap_err();
+        assert_eq!(error.code, QueryErrorCode::StaleCursor);
+    }
+
+    #[test]
+    fn context_depth_and_byte_budgets_return_terminal_truncation() {
+        let (_source, _sidecar_dir, sidecar, mut config, _comparison) = indexed_fixture();
+        config.query_limits.max_depth = 1;
+        let query = SqliteGraphQuery::new(&sidecar, config.query_limits.clone(), None);
+        let seed = ContextSeed::Symbol(fixture_symbol(&query, &config));
+
+        let depth = query
+            .context(&context_request(&config, seed.clone()))
+            .unwrap();
+        assert_eq!(
+            depth.page.truncation.as_ref().unwrap().reason,
+            TruncationReason::Depth
+        );
+        assert!(depth.page.next_cursor.is_none());
+
+        config.query_limits.max_bytes = 1;
+        let query = SqliteGraphQuery::new(&sidecar, config.query_limits.clone(), None);
+        let bytes = query.context(&context_request(&config, seed)).unwrap();
+        assert!(bytes.data.items.is_empty());
+        assert_eq!(
+            bytes.page.truncation.as_ref().unwrap().reason,
+            TruncationReason::Bytes
+        );
+        assert!(bytes.page.next_cursor.is_none());
+    }
+
+    #[test]
+    fn context_rejects_empty_and_missing_seeds() {
+        let (_source, _sidecar_dir, sidecar, config, _comparison) = indexed_fixture();
+        let query = SqliteGraphQuery::new(&sidecar, config.query_limits.clone(), None);
+        let mut request = context_request(
+            &config,
+            ContextSeed::Node(NodeId::new("node:missing").unwrap()),
+        );
+        assert_eq!(
+            query.context(&request).unwrap_err().code,
+            QueryErrorCode::InvalidRequest
+        );
+        request.seeds.clear();
+        assert_eq!(
+            query.context(&request).unwrap_err().code,
+            QueryErrorCode::InvalidRequest
+        );
+    }
+
+    #[test]
+    fn context_policy_controls_unresolved_and_external_candidates() {
+        for (resolution, include_unresolved, include_external) in
+            [("unresolved", true, false), ("external", false, true)]
+        {
+            let (_source, _sidecar_dir, sidecar, config, _comparison) = indexed_fixture();
+            let (file, classified, edge): (String, String, String) = sidecar
+                .connection()
+                .query_row(
+                    "SELECT edge.source_node_id, edge.target_node_id, edge.id \
+                     FROM edges AS edge \
+                     JOIN nodes AS source ON source.snapshot_id = edge.snapshot_id \
+                                         AND source.id = edge.source_node_id \
+                     JOIN nodes AS target ON target.snapshot_id = edge.snapshot_id \
+                                         AND target.id = edge.target_node_id \
+                     WHERE edge.kind = 'classified_as' \
+                       AND source.kind = 'file' \
+                       AND source.evidence_path = 'Cargo.toml' \
+                       AND target.kind = 'configuration' \
+                     LIMIT 1",
+                    [],
+                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+                )
+                .unwrap();
+            sidecar
+                .connection()
+                .execute(
+                    "UPDATE nodes SET resolution_state = ?1 WHERE id = ?2",
+                    params![resolution, classified],
+                )
+                .unwrap();
+            sidecar
+                .connection()
+                .execute(
+                    "UPDATE edges SET resolution_state = ?1 WHERE id = ?2",
+                    params![resolution, edge],
+                )
+                .unwrap();
+            let query = SqliteGraphQuery::new(&sidecar, config.query_limits.clone(), None);
+            let mut request =
+                context_request(&config, ContextSeed::Node(NodeId::new(file).unwrap()));
+            request.policy.direction = EdgeDirection::Outgoing;
+            request.policy.edge_kinds = vec!["classified_as".to_string()];
+
+            let excluded = query.context(&request).unwrap();
+            assert!(
+                excluded
+                    .data
+                    .items
+                    .iter()
+                    .all(|item| item.node_id.as_str() != classified)
+            );
+
+            request.policy.include_unresolved = include_unresolved;
+            request.policy.include_external = include_external;
+            let included = query.context(&request).unwrap();
+            let classified_item = included
+                .data
+                .items
+                .iter()
+                .find(|item| item.node_id.as_str() == classified)
+                .unwrap();
+            assert!(
+                classified_item
+                    .selection_reasons
+                    .iter()
+                    .any(|reason| reason.kind == ContextSelectionKind::Configuration)
+            );
+        }
+    }
+
+    #[test]
+    fn context_classifies_documentation_facts_ahead_of_generic_relationships() {
+        let (_source, _sidecar_dir, sidecar, config, _comparison) =
+            indexed_fixture_with_extra_files(&[("README.md", "# Fixture\n")]);
+        let (file, document): (String, String) = sidecar
+            .connection()
+            .query_row(
+                "SELECT edge.source_node_id, edge.target_node_id \
+                 FROM edges AS edge \
+                 JOIN nodes AS source ON source.snapshot_id = edge.snapshot_id \
+                                     AND source.id = edge.source_node_id \
+                 JOIN nodes AS target ON target.snapshot_id = edge.snapshot_id \
+                                     AND target.id = edge.target_node_id \
+                 WHERE edge.kind = 'classified_as' \
+                   AND source.evidence_path = 'README.md' \
+                   AND target.kind = 'document' \
+                 LIMIT 1",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        let query = SqliteGraphQuery::new(&sidecar, config.query_limits.clone(), None);
+        let mut request = context_request(&config, ContextSeed::Node(NodeId::new(file).unwrap()));
+        request.policy.direction = EdgeDirection::Outgoing;
+        request.policy.edge_kinds = vec!["classified_as".to_string()];
+
+        let response = query.context(&request).unwrap();
+        let item = response
+            .data
+            .items
+            .iter()
+            .find(|item| item.node_id.as_str() == document)
+            .unwrap();
+
+        assert!(
+            item.selection_reasons
+                .iter()
+                .any(|reason| reason.kind == ContextSelectionKind::Documentation)
+        );
+    }
+
+    #[test]
+    fn context_labels_resolved_import_targets_as_dependencies() {
+        let (_source, _sidecar_dir, sidecar, config, _comparison) =
+            indexed_fixture_with_extra_files(&[
+                (
+                    "src/lib.rs",
+                    "pub mod api;\nuse crate::api::Api;\npub fn make() -> Api { Api }\n",
+                ),
+                ("src/api.rs", "pub struct Api;\n"),
+            ]);
+        let (source, target): (String, String) = sidecar
+            .connection()
+            .query_row(
+                "SELECT source_node_id, target_node_id FROM edges \
+                 WHERE kind = 'imports' AND target_node_id IS NOT NULL \
+                 ORDER BY id LIMIT 1",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        let query = SqliteGraphQuery::new(&sidecar, config.query_limits.clone(), None);
+        let mut request = context_request(&config, ContextSeed::Node(NodeId::new(source).unwrap()));
+        request.policy.direction = EdgeDirection::Outgoing;
+        request.policy.edge_kinds = vec!["imports".to_string()];
+
+        let response = query.context(&request).unwrap();
+        let target = response
+            .data
+            .items
+            .iter()
+            .find(|item| item.node_id.as_str() == target)
+            .unwrap();
+
+        assert!(
+            target
+                .selection_reasons
+                .iter()
+                .any(|reason| reason.kind == ContextSelectionKind::ResolvedDependency)
+        );
+        assert_eq!(target.provenance.resolution, ResolutionState::Resolved);
+    }
+
+    #[test]
+    fn context_assembly_observes_an_expired_deadline() {
+        let (_source, _sidecar_dir, sidecar, config, _comparison) = indexed_fixture();
+        let query = SqliteGraphQuery::new(&sidecar, config.query_limits.clone(), None);
+        let request = context_request(
+            &config,
+            ContextSeed::Symbol(fixture_symbol(&query, &config)),
+        );
+        let resolved = query.resolve_scope(&request.scope).unwrap();
+        let started = Instant::now()
+            - Duration::from_millis(config.query_limits.max_duration_ms.saturating_add(1));
+        let deadline = QueryDeadline::install(
+            sidecar.connection(),
+            started,
+            Duration::from_millis(config.query_limits.max_duration_ms),
+        )
+        .unwrap();
+
+        let assembly = query
+            .assemble_context(&resolved, &request, started)
+            .unwrap();
+        drop(deadline);
+
+        assert_eq!(assembly.truncation, Some(TruncationReason::Duration));
+    }
+
+    #[test]
+    fn context_returns_bounded_snapshot_diagnostics() {
+        let (_source, _sidecar_dir, mut sidecar, mut config, _comparison) = indexed_fixture();
+        let snapshot = sidecar
+            .published_snapshot(&repository(), &PublishedViewName::new("canonical").unwrap())
+            .unwrap()
+            .unwrap();
+        for code in ["context.a", "context.b"] {
+            sidecar
+                .record_diagnostic(&GraphDiagnostic {
+                    build_id: BuildId::new("build-query").unwrap(),
+                    snapshot_id: Some(snapshot.id.clone()),
+                    severity: DiagnosticSeverity::Warning,
+                    code: DiagnosticCode::new(code).unwrap(),
+                    location: None,
+                    metrics: BTreeMap::new(),
+                })
+                .unwrap();
+        }
+        config.query_limits.max_diagnostics = 1;
+        let query = SqliteGraphQuery::new(&sidecar, config.query_limits.clone(), None);
+        let request = context_request(
+            &config,
+            ContextSeed::Symbol(fixture_symbol(&query, &config)),
+        );
+
+        let response = query.context(&request).unwrap();
+
+        assert!(response.diagnostics.summary.warning >= 2);
+        assert_eq!(response.diagnostics.items.len(), 1);
+        assert!(response.diagnostics.truncated);
     }
 
     #[test]

--- a/src/repository_graph/source/mod.rs
+++ b/src/repository_graph/source/mod.rs
@@ -18,9 +18,10 @@ mod filesystem;
 mod git;
 
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeMap, BTreeSet},
     fs::{self, File},
     io::{self, Read},
+    num::NonZeroU64,
     path::{Component, Path, PathBuf},
     sync::Arc,
 };
@@ -35,10 +36,11 @@ use super::{
         canonical_pattern_body,
     },
     domain::{
-        DiagnosticCode, Digest, ExtractorIdentity, RepoPath, RepositoryRef, SourceKind,
+        DiagnosticCode, Digest, ExtractorIdentity, RepoPath, RepositoryRef, SnapshotId, SourceKind,
         SourceRevision, SourceRevisionId,
     },
-    ports::{RepositorySource, SourceFileDescriptor, SourceFileMode},
+    ports::{RepositorySource, SnapshotContent, SourceFileDescriptor, SourceFileMode},
+    query::{ContentRequest, ContentResponse, QueryError, QueryErrorCode, RetrievalAction},
 };
 
 pub use super::ports::{SourceContent, SourceDiagnostic, SourceDiscoveryMetrics, SourceManifest};
@@ -565,6 +567,160 @@ impl RepositorySource for LocalRepositorySource {
     }
 }
 
+/// A repository-root-confined reader for file identities persisted in one
+/// immutable graph snapshot. It never discovers source identity from the
+/// process working directory and never follows symbolic links.
+pub struct LocalSnapshotContent {
+    root: SourceRoot,
+    repository: RepositoryRef,
+    snapshot_id: SnapshotId,
+    files: BTreeMap<RepoPath, SourceFileDescriptor>,
+    policy: SourcePolicy,
+    hard_max_bytes: NonZeroU64,
+}
+
+impl LocalSnapshotContent {
+    pub fn new(
+        root: impl AsRef<Path>,
+        repository: RepositoryRef,
+        snapshot_id: SnapshotId,
+        config: &SourceConfig,
+        files: Vec<SourceFileDescriptor>,
+        hard_max_bytes: NonZeroU64,
+    ) -> Result<Self, SourceError> {
+        let root = fs::canonicalize(root.as_ref()).map_err(|source| SourceError::Io {
+            operation: "canonicalize snapshot content root",
+            source,
+        })?;
+        Ok(Self {
+            root: SourceRoot::new(root)?,
+            repository,
+            snapshot_id,
+            files: files
+                .into_iter()
+                .map(|file| (file.path.clone(), file))
+                .collect(),
+            policy: SourcePolicy::new(config)?,
+            hard_max_bytes,
+        })
+    }
+}
+
+impl SnapshotContent for LocalSnapshotContent {
+    fn read_verified(&self, request: &ContentRequest) -> Result<ContentResponse, QueryError> {
+        if request.wire_version != super::QUERY_WIRE_VERSION {
+            return Err(content_error(
+                QueryErrorCode::UnsupportedWireVersion,
+                "unsupported repository content wire version",
+                false,
+                None,
+            ));
+        }
+        if request.repository != self.repository || request.snapshot_id != self.snapshot_id {
+            return Err(content_error(
+                QueryErrorCode::InvalidRequest,
+                "repository content request does not match the selected snapshot",
+                false,
+                None,
+            ));
+        }
+        if self.policy.exclusion_for_file(&request.path).is_some() {
+            return Err(content_error(
+                QueryErrorCode::ContentUnavailable,
+                "repository content is excluded by the source policy",
+                false,
+                None,
+            ));
+        }
+        let Some(file) = self.files.get(&request.path) else {
+            return Err(content_error(
+                QueryErrorCode::ContentUnavailable,
+                "repository content is unavailable for the selected snapshot",
+                false,
+                None,
+            ));
+        };
+        if file.content_identity != request.expected_content_identity {
+            return Err(content_error(
+                QueryErrorCode::ContentChanged,
+                "repository content identity does not match the selected snapshot",
+                false,
+                Some(RetrievalAction::RefreshIndex),
+            ));
+        }
+
+        let content = read_descriptor_verified(&self.root, file).map_err(|error| match error {
+            SourceError::ContentChanged => content_error(
+                QueryErrorCode::ContentChanged,
+                "repository content changed after the selected snapshot was published",
+                false,
+                Some(RetrievalAction::RefreshIndex),
+            ),
+            _ => content_error(
+                QueryErrorCode::ContentUnavailable,
+                "repository content could not be read through the confined source boundary",
+                true,
+                None,
+            ),
+        })?;
+
+        let (start, end) = request
+            .span
+            .as_ref()
+            .map_or((0_u64, content.bytes.len() as u64), |span| {
+                (span.start.byte_offset, span.end.byte_offset)
+            });
+        let Ok(start) = usize::try_from(start) else {
+            return Err(invalid_content_span());
+        };
+        let Ok(end) = usize::try_from(end) else {
+            return Err(invalid_content_span());
+        };
+        if start > end || end > content.bytes.len() {
+            return Err(invalid_content_span());
+        }
+        let limit = request.max_bytes.get().min(self.hard_max_bytes.get());
+        let limit = usize::try_from(limit).unwrap_or(usize::MAX);
+        let selected = &content.bytes[start..end];
+        let returned_len = selected.len().min(limit);
+
+        Ok(ContentResponse {
+            wire_version: super::QUERY_WIRE_VERSION,
+            repository: self.repository.clone(),
+            snapshot_id: self.snapshot_id.clone(),
+            path: request.path.clone(),
+            verified_content_identity: file.content_identity.clone(),
+            bytes: selected[..returned_len].to_vec(),
+            truncated: returned_len < selected.len(),
+        })
+    }
+}
+
+fn invalid_content_span() -> QueryError {
+    content_error(
+        QueryErrorCode::InvalidRequest,
+        "repository content span is outside the verified source bytes",
+        false,
+        None,
+    )
+}
+
+fn content_error(
+    code: QueryErrorCode,
+    message: &str,
+    retryable: bool,
+    recommended_action: Option<RetrievalAction>,
+) -> QueryError {
+    QueryError {
+        wire_version: super::QUERY_WIRE_VERSION,
+        code,
+        message: message.to_string(),
+        retryable,
+        recommended_action,
+        details: BTreeMap::new(),
+    }
+}
+
 fn same_manifest_identity(left: &SourceManifest, right: &SourceManifest) -> bool {
     left.revision == right.revision && left.extractor_set_digest == right.extractor_set_digest
 }
@@ -851,6 +1007,13 @@ pub(super) fn read_verified(
         .and_then(|index| manifest.files.get(index))
         .filter(|stored| *stored == file)
         .ok_or(SourceError::FileNotInManifest)?;
+    read_descriptor_verified(root, stored)
+}
+
+fn read_descriptor_verified(
+    root: &SourceRoot,
+    stored: &SourceFileDescriptor,
+) -> Result<SourceContent, SourceError> {
     let file = match root.open_file(&stored.path) {
         Ok(file) => file,
         Err(ConfinedOpenError::Symlink) => return Err(SourceError::ContentChanged),
@@ -1377,6 +1540,37 @@ fn component_matches(pattern: &str, value: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::repository_graph::domain::{
+        RepositoryId, RepositoryNamespace, SourcePosition, SourceSpan,
+    };
+
+    fn test_repository() -> RepositoryRef {
+        RepositoryRef {
+            namespace: RepositoryNamespace::new("local:test").unwrap(),
+            repository_id: RepositoryId::new("root").unwrap(),
+        }
+    }
+
+    fn descriptor(path: &str, bytes: &[u8]) -> SourceFileDescriptor {
+        SourceFileDescriptor {
+            path: RepoPath::new(path).unwrap(),
+            content_identity: sha256_digest(bytes),
+            byte_len: bytes.len() as u64,
+            file_mode: SourceFileMode::Regular,
+        }
+    }
+
+    fn content_request(file: &SourceFileDescriptor) -> ContentRequest {
+        ContentRequest {
+            wire_version: super::super::QUERY_WIRE_VERSION,
+            repository: test_repository(),
+            snapshot_id: SnapshotId::new("snapshot-1").unwrap(),
+            path: file.path.clone(),
+            expected_content_identity: file.content_identity.clone(),
+            span: None,
+            max_bytes: NonZeroU64::new(1024).unwrap(),
+        }
+    }
 
     #[test]
     fn globstar_matches_root_and_nested_paths() {
@@ -1491,5 +1685,99 @@ mod tests {
             account_inspected_bytes(&mut metrics, error.inspected, 6),
             Err(SourceError::TotalBytesLimitExceeded { limit: 6 })
         ));
+    }
+
+    #[test]
+    fn snapshot_content_confines_hash_verifies_and_bounds_spans() {
+        let directory = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(directory.path().join("src")).unwrap();
+        let bytes = b"abcdef";
+        std::fs::write(directory.path().join("src/lib.rs"), bytes).unwrap();
+        let file = descriptor("src/lib.rs", bytes);
+        let reader = LocalSnapshotContent::new(
+            directory.path(),
+            test_repository(),
+            SnapshotId::new("snapshot-1").unwrap(),
+            &SourceConfig::default(),
+            vec![file.clone()],
+            NonZeroU64::new(3).unwrap(),
+        )
+        .unwrap();
+        let mut request = content_request(&file);
+        request.span = Some(SourceSpan {
+            start: SourcePosition {
+                byte_offset: 1,
+                line: Some(1),
+                column: Some(2),
+            },
+            end: SourcePosition {
+                byte_offset: 5,
+                line: Some(1),
+                column: Some(6),
+            },
+        });
+
+        let response = reader.read_verified(&request).unwrap();
+        assert_eq!(response.bytes, b"bcd");
+        assert!(response.truncated);
+
+        std::fs::write(directory.path().join("src/lib.rs"), b"changed").unwrap();
+        assert_eq!(
+            reader.read_verified(&request).unwrap_err().code,
+            QueryErrorCode::ContentChanged
+        );
+    }
+
+    #[test]
+    fn snapshot_content_denies_sensitive_paths_before_reading() {
+        let directory = tempfile::tempdir().unwrap();
+        let file = descriptor(".env", b"SECRET=value");
+        std::fs::write(directory.path().join(".env"), b"SECRET=value").unwrap();
+        let reader = LocalSnapshotContent::new(
+            directory.path(),
+            test_repository(),
+            SnapshotId::new("snapshot-1").unwrap(),
+            &SourceConfig::default(),
+            vec![file.clone()],
+            NonZeroU64::new(1024).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            reader
+                .read_verified(&content_request(&file))
+                .unwrap_err()
+                .code,
+            QueryErrorCode::ContentUnavailable
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn snapshot_content_rejects_symlink_replacement() {
+        use std::os::unix::fs::symlink;
+
+        let directory = tempfile::tempdir().unwrap();
+        let outside = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(outside.path(), b"outside").unwrap();
+        let file = descriptor("link.rs", b"outside");
+        symlink(outside.path(), directory.path().join("link.rs")).unwrap();
+        let reader = LocalSnapshotContent::new(
+            directory.path(),
+            test_repository(),
+            SnapshotId::new("snapshot-1").unwrap(),
+            &SourceConfig::default(),
+            vec![file.clone()],
+            NonZeroU64::new(1024).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            reader
+                .read_verified(&content_request(&file))
+                .unwrap_err()
+                .code,
+            QueryErrorCode::ContentChanged
+        );
     }
 }

--- a/src/repository_graph/source/mod.rs
+++ b/src/repository_graph/source/mod.rs
@@ -682,7 +682,7 @@ impl SnapshotContent for LocalSnapshotContent {
         let limit = request.max_bytes.get().min(self.hard_max_bytes.get());
         let limit = usize::try_from(limit).unwrap_or(usize::MAX);
         let selected = &content.bytes[start..end];
-        let returned_len = selected.len().min(limit);
+        let returned_len = clamp_utf8_truncation(selected, selected.len().min(limit));
 
         Ok(ContentResponse {
             wire_version: super::QUERY_WIRE_VERSION,
@@ -694,6 +694,20 @@ impl SnapshotContent for LocalSnapshotContent {
             truncated: returned_len < selected.len(),
         })
     }
+}
+
+fn clamp_utf8_truncation(bytes: &[u8], requested_len: usize) -> usize {
+    let requested_len = requested_len.min(bytes.len());
+    let Ok(text) = std::str::from_utf8(bytes) else {
+        // Preserve invalid source bytes so the snippet adapter can report the
+        // existing content.non_utf8 diagnostic instead of hiding corruption.
+        return requested_len;
+    };
+    let mut returned_len = requested_len;
+    while !text.is_char_boundary(returned_len) {
+        returned_len -= 1;
+    }
+    returned_len
 }
 
 fn invalid_content_span() -> QueryError {
@@ -1726,6 +1740,33 @@ mod tests {
             reader.read_verified(&request).unwrap_err().code,
             QueryErrorCode::ContentChanged
         );
+    }
+
+    #[test]
+    fn snapshot_content_clamps_byte_limits_to_utf8_boundaries() {
+        let directory = tempfile::tempdir().unwrap();
+        let bytes = "aéz".as_bytes();
+        std::fs::write(directory.path().join("unicode.rs"), bytes).unwrap();
+        let file = descriptor("unicode.rs", bytes);
+
+        for (hard_limit, request_limit) in [(2, 1024), (1024, 2)] {
+            let reader = LocalSnapshotContent::new(
+                directory.path(),
+                test_repository(),
+                SnapshotId::new("snapshot-1").unwrap(),
+                &SourceConfig::default(),
+                vec![file.clone()],
+                NonZeroU64::new(hard_limit).unwrap(),
+            )
+            .unwrap();
+            let mut request = content_request(&file);
+            request.max_bytes = NonZeroU64::new(request_limit).unwrap();
+
+            let response = reader.read_verified(&request).unwrap();
+
+            assert_eq!(std::str::from_utf8(&response.bytes).unwrap(), "a");
+            assert!(response.truncated);
+        }
     }
 
     #[test]

--- a/src/repository_graph_runtime.rs
+++ b/src/repository_graph_runtime.rs
@@ -4,6 +4,8 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     num::NonZeroU64,
     path::Path,
+    sync::{Mutex, OnceLock},
+    time::{Duration, Instant},
 };
 
 use crate::{project, repository_graph};
@@ -31,7 +33,72 @@ use repository_graph::{
 };
 
 pub(crate) const CANONICAL_VIEW: &str = "canonical";
+const FRESHNESS_CACHE_TTL: Duration = Duration::from_secs(1);
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct FreshnessCacheKey {
+    root: std::path::PathBuf,
+    analysis_config_digest: String,
+}
+
+#[derive(Default)]
+struct FreshnessCacheEntry {
+    comparison: Option<FreshnessComparison>,
+    refreshed_at: Option<Instant>,
+    refresh_in_flight: bool,
+}
+
+#[derive(Default)]
+struct FreshnessCache {
+    entries: BTreeMap<FreshnessCacheKey, FreshnessCacheEntry>,
+}
+
+impl FreshnessCache {
+    fn cached_or_begin_refresh(
+        &mut self,
+        key: FreshnessCacheKey,
+        now: Instant,
+    ) -> (Option<FreshnessComparison>, bool) {
+        let entry = self.entries.entry(key).or_default();
+        let expired = entry.refreshed_at.is_none_or(|refreshed_at| {
+            now.saturating_duration_since(refreshed_at) >= FRESHNESS_CACHE_TTL
+        });
+        if expired {
+            if !entry.refresh_in_flight {
+                entry.refresh_in_flight = true;
+                return (None, true);
+            }
+            return (None, false);
+        }
+        (entry.comparison.clone(), false)
+    }
+
+    fn complete(
+        &mut self,
+        key: FreshnessCacheKey,
+        comparison: Option<FreshnessComparison>,
+        now: Instant,
+    ) {
+        let entry = self.entries.entry(key).or_default();
+        entry.comparison = comparison;
+        entry.refreshed_at = Some(now);
+        entry.refresh_in_flight = false;
+    }
+}
+
+fn freshness_cache() -> &'static Mutex<FreshnessCache> {
+    static CACHE: OnceLock<Mutex<FreshnessCache>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(FreshnessCache::default()))
+}
+
+fn with_freshness_cache<T>(operation: impl FnOnce(&mut FreshnessCache) -> T) -> T {
+    let mut cache = freshness_cache()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    operation(&mut cache)
+}
+
+#[derive(Clone)]
 pub(crate) struct LocalGraphContext {
     pub(crate) root: std::path::PathBuf,
     pub(crate) repository: RepositoryRef,
@@ -81,6 +148,36 @@ impl LocalGraphContext {
         Ok(Some(FreshnessComparison::from_manifest(source.manifest())))
     }
 
+    fn cached_freshness_comparison(&self) -> Option<FreshnessComparison> {
+        if !self.config.enabled {
+            return None;
+        }
+        let runtime = tokio::runtime::Handle::try_current().ok()?;
+        let key = FreshnessCacheKey {
+            root: self.root.clone(),
+            analysis_config_digest: self
+                .config
+                .analysis_config_digest()
+                .ok()?
+                .value()
+                .to_string(),
+        };
+        let (comparison, refresh) = with_freshness_cache(|cache| {
+            cache.cached_or_begin_refresh(key.clone(), Instant::now())
+        });
+        if refresh {
+            let context = self.clone();
+            runtime.spawn_blocking(move || {
+                let comparison = context
+                    .discover()
+                    .ok()
+                    .map(|source| FreshnessComparison::from_manifest(source.manifest()));
+                with_freshness_cache(|cache| cache.complete(key, comparison, Instant::now()));
+            });
+        }
+        comparison
+    }
+
     pub(crate) fn scope(&self, budget: QueryBudget) -> Result<repository_graph::query::QueryScope> {
         Ok(repository_graph::query::QueryScope::current(
             self.repository.clone(),
@@ -91,7 +188,7 @@ impl LocalGraphContext {
 
     pub(crate) async fn status(&self) -> Result<StatusResponse> {
         let path = sidecar_path().await?;
-        let comparison = self.freshness_comparison().ok().flatten();
+        let comparison = self.cached_freshness_comparison();
         status_response_at(self, &path, comparison)
     }
 
@@ -108,7 +205,7 @@ impl LocalGraphContext {
             )));
         }
         let path = sidecar_path().await?;
-        let comparison = self.freshness_comparison().ok().flatten();
+        let comparison = self.cached_freshness_comparison();
         Ok(search_response_at(self, &path, comparison, request))
     }
 
@@ -125,7 +222,7 @@ impl LocalGraphContext {
             )));
         }
         let path = sidecar_path().await?;
-        let comparison = self.freshness_comparison().ok().flatten();
+        let comparison = self.cached_freshness_comparison();
         Ok(context_response_at(self, &path, comparison, request))
     }
 
@@ -567,6 +664,37 @@ mod tests {
             },
             config: RepositoryGraphConfig::default(),
         }
+    }
+
+    #[test]
+    fn freshness_cache_never_returns_an_expired_comparison() {
+        let directory = tempfile::tempdir().unwrap();
+        let context = context(directory.path());
+        let source = context.discover().unwrap();
+        let comparison = FreshnessComparison::from_manifest(source.manifest());
+        let key = FreshnessCacheKey {
+            root: directory.path().to_path_buf(),
+            analysis_config_digest: "test-config".to_string(),
+        };
+        let now = Instant::now();
+        let mut cache = FreshnessCache::default();
+
+        let (initial, starts_refresh) = cache.cached_or_begin_refresh(key.clone(), now);
+        assert!(initial.is_none());
+        assert!(starts_refresh);
+        let (while_refreshing, starts_refresh) = cache.cached_or_begin_refresh(key.clone(), now);
+        assert!(while_refreshing.is_none());
+        assert!(!starts_refresh);
+
+        cache.complete(key.clone(), Some(comparison.clone()), now);
+        let (cached, starts_refresh) = cache.cached_or_begin_refresh(key.clone(), now);
+        assert_eq!(cached, Some(comparison));
+        assert!(!starts_refresh);
+
+        let (expired, starts_refresh) =
+            cache.cached_or_begin_refresh(key, now + FRESHNESS_CACHE_TTL);
+        assert!(expired.is_none());
+        assert!(starts_refresh);
     }
 
     #[test]

--- a/src/repository_graph_runtime.rs
+++ b/src/repository_graph_runtime.rs
@@ -1,26 +1,32 @@
 //! Machine-local repository graph runtime adapter shared by CLI and MCP reads.
 
-use std::{collections::BTreeMap, path::Path};
-
-use anyhow::{Context, Result};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    num::NonZeroU64,
+    path::Path,
+};
 
 use crate::{project, repository_graph};
+use anyhow::{Context, Result};
 use repository_graph::{
     QUERY_WIRE_VERSION,
     config::RepositoryGraphConfig,
     domain::{
-        Availability, Freshness, PublishedViewName, QueryBudget, RepositoryId, RepositoryNamespace,
-        RepositoryRef,
+        Availability, DiagnosticCode, DiagnosticLocation, DiagnosticSeverity, Freshness,
+        PublishedViewName, QueryBudget, RepositoryId, RepositoryNamespace, RepositoryRef,
     },
     index::active_extractor_identities,
-    ports::GraphQuery,
+    ports::{GraphQuery, SnapshotContent},
     query::{
-        ContextRequest, ContextResponse, DiagnosticSummary, DiagnosticsEnvelope, FreshnessEnvelope,
-        PageInfo, QueryError, QueryErrorCode, RetrievalAction, SearchRequest, SearchResponse,
-        SnapshotSelector, StatusData, StatusRequest, StatusResponse,
+        ContentRequest, ContextRequest, ContextResponse, ContextSnippet, DiagnosticSummary,
+        DiagnosticsEnvelope, FreshnessEnvelope, PageInfo, QueryDiagnostic, QueryError,
+        QueryErrorCode, RetrievalAction, SearchRequest, SearchResponse, SnapshotSelector,
+        StatusData, StatusRequest, StatusResponse,
     },
-    query_sqlite::{FreshnessComparison, SqliteGraphQuery, default_budget},
-    source::{LocalRepositorySource, SourceDiscoveryContext},
+    query_sqlite::{
+        FreshnessComparison, SqliteGraphQuery, default_budget, snapshot_file_descriptors,
+    },
+    source::{LocalRepositorySource, LocalSnapshotContent, SourceDiscoveryContext},
     sqlite::{OpenQuerySidecarResult, SIDECAR_FILE_NAME, open_for_query_at},
 };
 
@@ -121,6 +127,25 @@ impl LocalGraphContext {
         let path = sidecar_path().await?;
         let comparison = self.freshness_comparison().ok().flatten();
         Ok(context_response_at(self, &path, comparison, request))
+    }
+
+    pub(crate) async fn context_with_snippets(
+        &self,
+        request: &ContextRequest,
+        requested_snippet_bytes: NonZeroU64,
+    ) -> Result<Result<ContextResponse, QueryError>> {
+        let response = match self.context(request).await? {
+            Ok(response) => response,
+            Err(error) => return Ok(Err(error)),
+        };
+        let path = sidecar_path().await?;
+        Ok(attach_snippets_at(
+            self,
+            &path,
+            request,
+            response,
+            requested_snippet_bytes,
+        ))
     }
 }
 
@@ -255,6 +280,175 @@ fn context_response_at(
     }
 }
 
+fn attach_snippets_at(
+    context: &LocalGraphContext,
+    sidecar_path: &Path,
+    request: &ContextRequest,
+    mut response: ContextResponse,
+    requested_snippet_bytes: NonZeroU64,
+) -> Result<ContextResponse, QueryError> {
+    let hard_limit =
+        NonZeroU64::new(context.config.query_limits.max_snippet_bytes).ok_or_else(|| {
+            query_error(
+                QueryErrorCode::InvalidRequest,
+                "repository_graph.query_limits.max_snippet_bytes must be greater than zero",
+                false,
+                None,
+            )
+        })?;
+    let total_limit = requested_snippet_bytes.get().min(hard_limit.get());
+    let sidecar = match open_for_query_at(sidecar_path) {
+        Ok(OpenQuerySidecarResult::Ready(sidecar)) => sidecar,
+        _ => {
+            return Err(query_error(
+                QueryErrorCode::ContentUnavailable,
+                "repository content metadata became unavailable after context assembly",
+                true,
+                None,
+            ));
+        }
+    };
+
+    let paths = response
+        .data
+        .items
+        .iter()
+        .map(|item| item.path.clone())
+        .collect::<BTreeSet<_>>();
+    let files = snapshot_file_descriptors(&sidecar, &response.snapshot_id, &paths)?;
+
+    let content = LocalSnapshotContent::new(
+        &context.root,
+        context.repository.clone(),
+        response.snapshot_id.clone(),
+        &context.config.source,
+        files,
+        hard_limit,
+    )
+    .map_err(|_| {
+        query_error(
+            QueryErrorCode::ContentUnavailable,
+            "repository content boundary could not be initialized",
+            true,
+            None,
+        )
+    })?;
+
+    let evidence = response
+        .data
+        .items
+        .iter()
+        .map(|item| {
+            (
+                item.path.clone(),
+                item.span.clone(),
+                item.content_identity.clone(),
+            )
+        })
+        .collect::<Vec<_>>();
+    let mut seen = BTreeSet::new();
+    let mut remaining = total_limit;
+    let mut omitted_for_budget = false;
+    for (path, span, content_identity) in evidence {
+        let key = serde_json::to_string(&(path.clone(), span.clone(), content_identity.clone()))
+            .expect("context evidence is always serializable");
+        if !seen.insert(key) {
+            continue;
+        }
+        let Some(max_bytes) = NonZeroU64::new(remaining) else {
+            omitted_for_budget = true;
+            break;
+        };
+        match content.read_verified(&ContentRequest {
+            wire_version: QUERY_WIRE_VERSION,
+            repository: response.repository.clone(),
+            snapshot_id: response.snapshot_id.clone(),
+            path: path.clone(),
+            expected_content_identity: content_identity,
+            span: span.clone(),
+            max_bytes,
+        }) {
+            Ok(snippet) => match String::from_utf8(snippet.bytes) {
+                Ok(text) => {
+                    remaining = remaining.saturating_sub(text.len() as u64);
+                    response.data.snippets.push(ContextSnippet {
+                        path,
+                        span,
+                        verified_content_identity: snippet.verified_content_identity,
+                        text,
+                        truncated: snippet.truncated,
+                    });
+                    if snippet.truncated {
+                        omitted_for_budget = true;
+                    }
+                }
+                Err(_) => {
+                    add_content_diagnostic(&mut response, request, "content.non_utf8", path, span)
+                }
+            },
+            Err(error) => add_content_diagnostic(
+                &mut response,
+                request,
+                match error.code {
+                    QueryErrorCode::ContentChanged => "content.changed",
+                    _ => "content.unavailable",
+                },
+                path,
+                span,
+            ),
+        }
+    }
+    if omitted_for_budget {
+        add_content_diagnostic_without_location(
+            &mut response,
+            request,
+            "content.snippets_truncated",
+        );
+    }
+    Ok(response)
+}
+
+fn add_content_diagnostic(
+    response: &mut ContextResponse,
+    request: &ContextRequest,
+    code: &str,
+    path: repository_graph::domain::RepoPath,
+    span: Option<repository_graph::domain::SourceSpan>,
+) {
+    add_bounded_content_diagnostic(
+        response,
+        request,
+        code,
+        Some(DiagnosticLocation { path, span }),
+    );
+}
+
+fn add_content_diagnostic_without_location(
+    response: &mut ContextResponse,
+    request: &ContextRequest,
+    code: &str,
+) {
+    add_bounded_content_diagnostic(response, request, code, None);
+}
+
+fn add_bounded_content_diagnostic(
+    response: &mut ContextResponse,
+    request: &ContextRequest,
+    code: &str,
+    location: Option<DiagnosticLocation>,
+) {
+    response.diagnostics.summary.warning += 1;
+    if response.diagnostics.items.len() < request.scope.budget.max_diagnostics.get() as usize {
+        response.diagnostics.items.push(QueryDiagnostic {
+            severity: DiagnosticSeverity::Warning,
+            code: DiagnosticCode::new(code).expect("static content diagnostic code is canonical"),
+            location,
+        });
+    } else {
+        response.diagnostics.truncated = true;
+    }
+}
+
 fn unavailable_status(
     repository: RepositoryRef,
     availability: Availability,
@@ -311,6 +505,48 @@ fn query_error(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn indexed_context(root: &Path, sidecar_path: &Path) -> (LocalGraphContext, ContextRequest) {
+        let mut context = context(root);
+        context.config.enabled = true;
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/lib.rs"), b"pub struct RuntimeTaskContext;\n").unwrap();
+        let source = context.discover().unwrap();
+        let mut sidecar = match repository_graph::sqlite::open_for_build_at(sidecar_path).unwrap() {
+            repository_graph::sqlite::OpenSidecarResult::Ready(sidecar) => sidecar,
+            repository_graph::sqlite::OpenSidecarResult::RequiresRebuild(_) => {
+                panic!("new sidecar unexpectedly requires rebuild")
+            }
+        };
+        repository_graph::index::IndexCoordinator::new(&mut sidecar)
+            .index(
+                &source,
+                &context.config,
+                repository_graph::index::IndexRequest {
+                    build_id: repository_graph::domain::BuildId::new("build-1").unwrap(),
+                    view_name: PublishedViewName::new(CANONICAL_VIEW).unwrap(),
+                    force_full: false,
+                },
+            )
+            .unwrap();
+        drop(sidecar);
+        let request = ContextRequest {
+            scope: context
+                .scope(default_budget(&context.config.query_limits).unwrap())
+                .unwrap(),
+            seeds: vec![repository_graph::query::ContextSeed::Path(
+                repository_graph::domain::RepoPath::new("src/lib.rs").unwrap(),
+            )],
+            policy: repository_graph::query::ContextPolicy {
+                direction: repository_graph::query::EdgeDirection::Both,
+                edge_kinds: vec![],
+                include_unresolved: false,
+                include_external: false,
+            },
+            page: repository_graph::query::PageRequest { cursor: None },
+        };
+        (context, request)
+    }
 
     fn context(root: &Path) -> LocalGraphContext {
         LocalGraphContext {
@@ -393,6 +629,63 @@ mod tests {
         assert_eq!(
             status.data.recommended_action,
             Some(RetrievalAction::Rebuild)
+        );
+    }
+
+    #[test]
+    fn context_snippets_are_deduplicated_hash_verified_and_stale_safe() {
+        let directory = tempfile::tempdir().unwrap();
+        let sidecar = directory.path().join(SIDECAR_FILE_NAME);
+        let (context, request) = indexed_context(directory.path(), &sidecar);
+        let response = context_response_at(&context, &sidecar, None, &request).unwrap();
+
+        let enriched = attach_snippets_at(
+            &context,
+            &sidecar,
+            &request,
+            response.clone(),
+            NonZeroU64::new(1024).unwrap(),
+        )
+        .unwrap();
+        assert!(!enriched.data.snippets.is_empty());
+        assert_eq!(enriched.data.items, response.data.items);
+        assert_eq!(enriched.page, response.page);
+        assert!(
+            enriched
+                .data
+                .snippets
+                .iter()
+                .all(|snippet| snippet.text.contains("RuntimeTaskContext"))
+        );
+        let unique = enriched
+            .data
+            .snippets
+            .iter()
+            .map(|snippet| serde_json::to_string(&(snippet.path.clone(), snippet.span.clone())))
+            .collect::<Result<BTreeSet<_>, _>>()
+            .unwrap();
+        assert_eq!(unique.len(), enriched.data.snippets.len());
+
+        std::fs::write(
+            directory.path().join("src/lib.rs"),
+            b"pub struct Changed;\n",
+        )
+        .unwrap();
+        let stale = attach_snippets_at(
+            &context,
+            &sidecar,
+            &request,
+            response,
+            NonZeroU64::new(1024).unwrap(),
+        )
+        .unwrap();
+        assert!(stale.data.snippets.is_empty());
+        assert!(
+            stale
+                .diagnostics
+                .items
+                .iter()
+                .any(|diagnostic| diagnostic.code.as_str() == "content.changed")
         );
     }
 }

--- a/src/repository_graph_runtime.rs
+++ b/src/repository_graph_runtime.rs
@@ -297,6 +297,12 @@ fn attach_snippets_at(
             )
         })?;
     let total_limit = requested_snippet_bytes.get().min(hard_limit.get());
+    let max_diagnostics = request
+        .scope
+        .budget
+        .max_diagnostics
+        .get()
+        .min(context.config.query_limits.max_diagnostics) as usize;
     let sidecar = match open_for_query_at(sidecar_path) {
         Ok(OpenQuerySidecarResult::Ready(sidecar)) => sidecar,
         _ => {
@@ -382,13 +388,17 @@ fn attach_snippets_at(
                         omitted_for_budget = true;
                     }
                 }
-                Err(_) => {
-                    add_content_diagnostic(&mut response, request, "content.non_utf8", path, span)
-                }
+                Err(_) => add_content_diagnostic(
+                    &mut response,
+                    max_diagnostics,
+                    "content.non_utf8",
+                    path,
+                    span,
+                ),
             },
             Err(error) => add_content_diagnostic(
                 &mut response,
-                request,
+                max_diagnostics,
                 match error.code {
                     QueryErrorCode::ContentChanged => "content.changed",
                     _ => "content.unavailable",
@@ -401,7 +411,7 @@ fn attach_snippets_at(
     if omitted_for_budget {
         add_content_diagnostic_without_location(
             &mut response,
-            request,
+            max_diagnostics,
             "content.snippets_truncated",
         );
     }
@@ -410,14 +420,14 @@ fn attach_snippets_at(
 
 fn add_content_diagnostic(
     response: &mut ContextResponse,
-    request: &ContextRequest,
+    max_diagnostics: usize,
     code: &str,
     path: repository_graph::domain::RepoPath,
     span: Option<repository_graph::domain::SourceSpan>,
 ) {
     add_bounded_content_diagnostic(
         response,
-        request,
+        max_diagnostics,
         code,
         Some(DiagnosticLocation { path, span }),
     );
@@ -425,20 +435,20 @@ fn add_content_diagnostic(
 
 fn add_content_diagnostic_without_location(
     response: &mut ContextResponse,
-    request: &ContextRequest,
+    max_diagnostics: usize,
     code: &str,
 ) {
-    add_bounded_content_diagnostic(response, request, code, None);
+    add_bounded_content_diagnostic(response, max_diagnostics, code, None);
 }
 
 fn add_bounded_content_diagnostic(
     response: &mut ContextResponse,
-    request: &ContextRequest,
+    max_diagnostics: usize,
     code: &str,
     location: Option<DiagnosticLocation>,
 ) {
     response.diagnostics.summary.warning += 1;
-    if response.diagnostics.items.len() < request.scope.budget.max_diagnostics.get() as usize {
+    if response.diagnostics.items.len() < max_diagnostics {
         response.diagnostics.items.push(QueryDiagnostic {
             severity: DiagnosticSeverity::Warning,
             code: DiagnosticCode::new(code).expect("static content diagnostic code is canonical"),
@@ -636,7 +646,7 @@ mod tests {
     fn context_snippets_are_deduplicated_hash_verified_and_stale_safe() {
         let directory = tempfile::tempdir().unwrap();
         let sidecar = directory.path().join(SIDECAR_FILE_NAME);
-        let (context, request) = indexed_context(directory.path(), &sidecar);
+        let (mut context, request) = indexed_context(directory.path(), &sidecar);
         let response = context_response_at(&context, &sidecar, None, &request).unwrap();
 
         let enriched = attach_snippets_at(
@@ -671,6 +681,7 @@ mod tests {
             b"pub struct Changed;\n",
         )
         .unwrap();
+        context.config.query_limits.max_diagnostics = 1;
         let stale = attach_snippets_at(
             &context,
             &sidecar,
@@ -680,6 +691,9 @@ mod tests {
         )
         .unwrap();
         assert!(stale.data.snippets.is_empty());
+        assert_eq!(stale.diagnostics.items.len(), 1);
+        assert!(stale.diagnostics.summary.warning > 1);
+        assert!(stale.diagnostics.truncated);
         assert!(
             stale
                 .diagnostics

--- a/src/repository_graph_runtime.rs
+++ b/src/repository_graph_runtime.rs
@@ -4,8 +4,6 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     num::NonZeroU64,
     path::Path,
-    sync::{Mutex, OnceLock},
-    time::{Duration, Instant},
 };
 
 use crate::{project, repository_graph};
@@ -33,72 +31,7 @@ use repository_graph::{
 };
 
 pub(crate) const CANONICAL_VIEW: &str = "canonical";
-const FRESHNESS_CACHE_TTL: Duration = Duration::from_secs(1);
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-struct FreshnessCacheKey {
-    root: std::path::PathBuf,
-    analysis_config_digest: String,
-}
-
-#[derive(Default)]
-struct FreshnessCacheEntry {
-    comparison: Option<FreshnessComparison>,
-    refreshed_at: Option<Instant>,
-    refresh_in_flight: bool,
-}
-
-#[derive(Default)]
-struct FreshnessCache {
-    entries: BTreeMap<FreshnessCacheKey, FreshnessCacheEntry>,
-}
-
-impl FreshnessCache {
-    fn cached_or_begin_refresh(
-        &mut self,
-        key: FreshnessCacheKey,
-        now: Instant,
-    ) -> (Option<FreshnessComparison>, bool) {
-        let entry = self.entries.entry(key).or_default();
-        let expired = entry.refreshed_at.is_none_or(|refreshed_at| {
-            now.saturating_duration_since(refreshed_at) >= FRESHNESS_CACHE_TTL
-        });
-        if expired {
-            if !entry.refresh_in_flight {
-                entry.refresh_in_flight = true;
-                return (None, true);
-            }
-            return (None, false);
-        }
-        (entry.comparison.clone(), false)
-    }
-
-    fn complete(
-        &mut self,
-        key: FreshnessCacheKey,
-        comparison: Option<FreshnessComparison>,
-        now: Instant,
-    ) {
-        let entry = self.entries.entry(key).or_default();
-        entry.comparison = comparison;
-        entry.refreshed_at = Some(now);
-        entry.refresh_in_flight = false;
-    }
-}
-
-fn freshness_cache() -> &'static Mutex<FreshnessCache> {
-    static CACHE: OnceLock<Mutex<FreshnessCache>> = OnceLock::new();
-    CACHE.get_or_init(|| Mutex::new(FreshnessCache::default()))
-}
-
-fn with_freshness_cache<T>(operation: impl FnOnce(&mut FreshnessCache) -> T) -> T {
-    let mut cache = freshness_cache()
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    operation(&mut cache)
-}
-
-#[derive(Clone)]
 pub(crate) struct LocalGraphContext {
     pub(crate) root: std::path::PathBuf,
     pub(crate) repository: RepositoryRef,
@@ -148,36 +81,6 @@ impl LocalGraphContext {
         Ok(Some(FreshnessComparison::from_manifest(source.manifest())))
     }
 
-    fn cached_freshness_comparison(&self) -> Option<FreshnessComparison> {
-        if !self.config.enabled {
-            return None;
-        }
-        let runtime = tokio::runtime::Handle::try_current().ok()?;
-        let key = FreshnessCacheKey {
-            root: self.root.clone(),
-            analysis_config_digest: self
-                .config
-                .analysis_config_digest()
-                .ok()?
-                .value()
-                .to_string(),
-        };
-        let (comparison, refresh) = with_freshness_cache(|cache| {
-            cache.cached_or_begin_refresh(key.clone(), Instant::now())
-        });
-        if refresh {
-            let context = self.clone();
-            runtime.spawn_blocking(move || {
-                let comparison = context
-                    .discover()
-                    .ok()
-                    .map(|source| FreshnessComparison::from_manifest(source.manifest()));
-                with_freshness_cache(|cache| cache.complete(key, comparison, Instant::now()));
-            });
-        }
-        comparison
-    }
-
     pub(crate) fn scope(&self, budget: QueryBudget) -> Result<repository_graph::query::QueryScope> {
         Ok(repository_graph::query::QueryScope::current(
             self.repository.clone(),
@@ -188,8 +91,11 @@ impl LocalGraphContext {
 
     pub(crate) async fn status(&self) -> Result<StatusResponse> {
         let path = sidecar_path().await?;
-        let comparison = self.cached_freshness_comparison();
-        status_response_at(self, &path, comparison)
+        // Discovering the current manifest can walk and hash the repository.
+        // MCP retrieval must stay latency-bounded, so without a reliable source
+        // mutation token it reports freshness as unknown rather than stale data
+        // as fresh. The local CLI uses freshness_comparison() for exact checks.
+        status_response_at(self, &path, None)
     }
 
     pub(crate) async fn search(
@@ -205,8 +111,7 @@ impl LocalGraphContext {
             )));
         }
         let path = sidecar_path().await?;
-        let comparison = self.cached_freshness_comparison();
-        Ok(search_response_at(self, &path, comparison, request))
+        Ok(search_response_at(self, &path, None, request))
     }
 
     pub(crate) async fn context(
@@ -222,8 +127,7 @@ impl LocalGraphContext {
             )));
         }
         let path = sidecar_path().await?;
-        let comparison = self.cached_freshness_comparison();
-        Ok(context_response_at(self, &path, comparison, request))
+        Ok(context_response_at(self, &path, None, request))
     }
 
     pub(crate) async fn context_with_snippets(
@@ -667,37 +571,6 @@ mod tests {
     }
 
     #[test]
-    fn freshness_cache_never_returns_an_expired_comparison() {
-        let directory = tempfile::tempdir().unwrap();
-        let context = context(directory.path());
-        let source = context.discover().unwrap();
-        let comparison = FreshnessComparison::from_manifest(source.manifest());
-        let key = FreshnessCacheKey {
-            root: directory.path().to_path_buf(),
-            analysis_config_digest: "test-config".to_string(),
-        };
-        let now = Instant::now();
-        let mut cache = FreshnessCache::default();
-
-        let (initial, starts_refresh) = cache.cached_or_begin_refresh(key.clone(), now);
-        assert!(initial.is_none());
-        assert!(starts_refresh);
-        let (while_refreshing, starts_refresh) = cache.cached_or_begin_refresh(key.clone(), now);
-        assert!(while_refreshing.is_none());
-        assert!(!starts_refresh);
-
-        cache.complete(key.clone(), Some(comparison.clone()), now);
-        let (cached, starts_refresh) = cache.cached_or_begin_refresh(key.clone(), now);
-        assert_eq!(cached, Some(comparison));
-        assert!(!starts_refresh);
-
-        let (expired, starts_refresh) =
-            cache.cached_or_begin_refresh(key, now + FRESHNESS_CACHE_TTL);
-        assert!(expired.is_none());
-        assert!(starts_refresh);
-    }
-
-    #[test]
     fn absent_status_search_and_context_are_read_only_and_actionable() {
         let directory = tempfile::tempdir().unwrap();
         let sidecar = directory.path().join(SIDECAR_FILE_NAME);
@@ -768,6 +641,23 @@ mod tests {
             status.data.recommended_action,
             Some(RetrievalAction::Rebuild)
         );
+    }
+
+    #[test]
+    fn mcp_runtime_does_not_label_changed_source_as_fresh_without_revalidation() {
+        let directory = tempfile::tempdir().unwrap();
+        let sidecar = directory.path().join(SIDECAR_FILE_NAME);
+        let (context, request) = indexed_context(directory.path(), &sidecar);
+        std::fs::write(
+            directory.path().join("src/lib.rs"),
+            b"pub struct ChangedAfterIndex;\n",
+        )
+        .unwrap();
+
+        let response = context_response_at(&context, &sidecar, None, &request).unwrap();
+
+        assert_eq!(response.freshness.freshness, Freshness::Unknown);
+        assert_eq!(response.freshness.reason_codes, ["source_not_compared"]);
     }
 
     #[test]

--- a/src/repository_graph_runtime.rs
+++ b/src/repository_graph_runtime.rs
@@ -15,9 +15,9 @@ use repository_graph::{
     index::active_extractor_identities,
     ports::GraphQuery,
     query::{
-        DiagnosticSummary, DiagnosticsEnvelope, FreshnessEnvelope, PageInfo, QueryError,
-        QueryErrorCode, RetrievalAction, SearchRequest, SearchResponse, SnapshotSelector,
-        StatusData, StatusRequest, StatusResponse,
+        ContextRequest, ContextResponse, DiagnosticSummary, DiagnosticsEnvelope, FreshnessEnvelope,
+        PageInfo, QueryError, QueryErrorCode, RetrievalAction, SearchRequest, SearchResponse,
+        SnapshotSelector, StatusData, StatusRequest, StatusResponse,
     },
     query_sqlite::{FreshnessComparison, SqliteGraphQuery, default_budget},
     source::{LocalRepositorySource, SourceDiscoveryContext},
@@ -105,6 +105,23 @@ impl LocalGraphContext {
         let comparison = self.freshness_comparison().ok().flatten();
         Ok(search_response_at(self, &path, comparison, request))
     }
+
+    pub(crate) async fn context(
+        &self,
+        request: &ContextRequest,
+    ) -> Result<Result<ContextResponse, QueryError>> {
+        if !self.config.enabled {
+            return Ok(Err(query_error(
+                QueryErrorCode::InvalidRequest,
+                "repository graph is disabled; enable it before assembling context",
+                false,
+                None,
+            )));
+        }
+        let path = sidecar_path().await?;
+        let comparison = self.freshness_comparison().ok().flatten();
+        Ok(context_response_at(self, &path, comparison, request))
+    }
 }
 
 pub(crate) async fn sidecar_path() -> Result<std::path::PathBuf> {
@@ -171,6 +188,46 @@ fn search_response_at(
             freshness_comparison,
         )
         .search(request),
+        Ok(OpenQuerySidecarResult::Absent) => Err(query_error(
+            QueryErrorCode::NotBuilt,
+            "repository graph is not built; run `ferrus graph index`",
+            false,
+            Some(RetrievalAction::Index),
+        )),
+        Ok(OpenQuerySidecarResult::NeedsMigration { .. }) => Err(query_error(
+            QueryErrorCode::Incompatible,
+            "repository graph storage needs migration; run `ferrus graph index`",
+            false,
+            Some(RetrievalAction::Index),
+        )),
+        Ok(OpenQuerySidecarResult::RequiresRebuild(_)) => Err(query_error(
+            QueryErrorCode::Incompatible,
+            "repository graph storage is incompatible; rebuild the derived index",
+            false,
+            Some(RetrievalAction::Rebuild),
+        )),
+        Err(_) => Err(query_error(
+            QueryErrorCode::BackendUnavailable,
+            "repository graph storage is unavailable or inconsistent",
+            true,
+            Some(RetrievalAction::Rebuild),
+        )),
+    }
+}
+
+fn context_response_at(
+    context: &LocalGraphContext,
+    sidecar_path: &Path,
+    freshness_comparison: Option<FreshnessComparison>,
+    request: &ContextRequest,
+) -> Result<ContextResponse, QueryError> {
+    match open_for_query_at(sidecar_path) {
+        Ok(OpenQuerySidecarResult::Ready(sidecar)) => SqliteGraphQuery::new(
+            &sidecar,
+            context.config.query_limits.clone(),
+            freshness_comparison,
+        )
+        .context(request),
         Ok(OpenQuerySidecarResult::Absent) => Err(query_error(
             QueryErrorCode::NotBuilt,
             "repository graph is not built; run `ferrus graph index`",
@@ -267,7 +324,7 @@ mod tests {
     }
 
     #[test]
-    fn absent_status_and_search_are_read_only_and_actionable() {
+    fn absent_status_search_and_context_are_read_only_and_actionable() {
         let directory = tempfile::tempdir().unwrap();
         let sidecar = directory.path().join(SIDECAR_FILE_NAME);
         let context = context(directory.path());
@@ -288,11 +345,37 @@ mod tests {
             },
         )
         .unwrap_err();
+        let context_response = context_response_at(
+            &context,
+            &sidecar,
+            None,
+            &ContextRequest {
+                scope: context
+                    .scope(default_budget(&context.config.query_limits).unwrap())
+                    .unwrap(),
+                seeds: vec![repository_graph::query::ContextSeed::Path(
+                    repository_graph::domain::RepoPath::new("src/lib.rs").unwrap(),
+                )],
+                policy: repository_graph::query::ContextPolicy {
+                    direction: repository_graph::query::EdgeDirection::Both,
+                    edge_kinds: vec![],
+                    include_unresolved: false,
+                    include_external: false,
+                },
+                page: repository_graph::query::PageRequest { cursor: None },
+            },
+        )
+        .unwrap_err();
 
         assert_eq!(status.data.availability, Availability::NotBuilt);
         assert_eq!(status.data.recommended_action, Some(RetrievalAction::Index));
         assert_eq!(search.code, QueryErrorCode::NotBuilt);
         assert_eq!(search.recommended_action, Some(RetrievalAction::Index));
+        assert_eq!(context_response.code, QueryErrorCode::NotBuilt);
+        assert_eq!(
+            context_response.recommended_action,
+            Some(RetrievalAction::Index)
+        );
         assert!(!sidecar.exists());
     }
 

--- a/src/repository_graph_runtime.rs
+++ b/src/repository_graph_runtime.rs
@@ -1,0 +1,315 @@
+//! Machine-local repository graph runtime adapter shared by CLI and MCP reads.
+
+use std::{collections::BTreeMap, path::Path};
+
+use anyhow::{Context, Result};
+
+use crate::{project, repository_graph};
+use repository_graph::{
+    QUERY_WIRE_VERSION,
+    config::RepositoryGraphConfig,
+    domain::{
+        Availability, Freshness, PublishedViewName, QueryBudget, RepositoryId, RepositoryNamespace,
+        RepositoryRef,
+    },
+    index::active_extractor_identities,
+    ports::GraphQuery,
+    query::{
+        DiagnosticSummary, DiagnosticsEnvelope, FreshnessEnvelope, PageInfo, QueryError,
+        QueryErrorCode, RetrievalAction, SearchRequest, SearchResponse, SnapshotSelector,
+        StatusData, StatusRequest, StatusResponse,
+    },
+    query_sqlite::{FreshnessComparison, SqliteGraphQuery, default_budget},
+    source::{LocalRepositorySource, SourceDiscoveryContext},
+    sqlite::{OpenQuerySidecarResult, SIDECAR_FILE_NAME, open_for_query_at},
+};
+
+pub(crate) const CANONICAL_VIEW: &str = "canonical";
+
+pub(crate) struct LocalGraphContext {
+    pub(crate) root: std::path::PathBuf,
+    pub(crate) repository: RepositoryRef,
+    pub(crate) config: RepositoryGraphConfig,
+}
+
+impl LocalGraphContext {
+    pub(crate) async fn load(require_enabled: bool) -> Result<Self> {
+        let root = project::canonical_project_root().await?;
+        let contents = tokio::fs::read_to_string(root.join("ferrus.toml"))
+            .await
+            .context("ferrus.toml not found — run ferrus init first")?;
+        let config = RepositoryGraphConfig::from_ferrus_toml(&contents)
+            .context("Invalid [repository_graph] configuration")?;
+        if require_enabled && !config.enabled {
+            anyhow::bail!(
+                "repository graph is disabled; set repository_graph.enabled = true in ferrus.toml"
+            );
+        }
+        let project_id = project::current_project_id().await?;
+        Ok(Self {
+            root,
+            repository: RepositoryRef {
+                namespace: RepositoryNamespace::new(format!("local:{project_id}"))?,
+                repository_id: RepositoryId::new("root")?,
+            },
+            config,
+        })
+    }
+
+    pub(crate) fn discover(&self) -> Result<LocalRepositorySource> {
+        let identities = active_extractor_identities(&self.config)?;
+        let context = SourceDiscoveryContext::from_config(
+            self.repository.clone(),
+            &self.config,
+            &identities,
+        )?;
+        LocalRepositorySource::discover(&self.root, context)
+            .context("Failed to discover the canonical repository source")
+    }
+
+    pub(crate) fn freshness_comparison(&self) -> Result<Option<FreshnessComparison>> {
+        if !self.config.enabled {
+            return Ok(None);
+        }
+        let source = self.discover()?;
+        Ok(Some(FreshnessComparison::from_manifest(source.manifest())))
+    }
+
+    pub(crate) fn scope(&self, budget: QueryBudget) -> Result<repository_graph::query::QueryScope> {
+        Ok(repository_graph::query::QueryScope::current(
+            self.repository.clone(),
+            SnapshotSelector::Published(PublishedViewName::new(CANONICAL_VIEW)?),
+            budget,
+        ))
+    }
+
+    pub(crate) async fn status(&self) -> Result<StatusResponse> {
+        let path = sidecar_path().await?;
+        let comparison = self.freshness_comparison().ok().flatten();
+        status_response_at(self, &path, comparison)
+    }
+
+    pub(crate) async fn search(
+        &self,
+        request: &SearchRequest,
+    ) -> Result<Result<SearchResponse, QueryError>> {
+        if !self.config.enabled {
+            return Ok(Err(query_error(
+                QueryErrorCode::InvalidRequest,
+                "repository graph is disabled; enable it before searching",
+                false,
+                None,
+            )));
+        }
+        let path = sidecar_path().await?;
+        let comparison = self.freshness_comparison().ok().flatten();
+        Ok(search_response_at(self, &path, comparison, request))
+    }
+}
+
+pub(crate) async fn sidecar_path() -> Result<std::path::PathBuf> {
+    Ok(project::current_project_data_dir()
+        .await?
+        .join(SIDECAR_FILE_NAME))
+}
+
+pub(crate) fn status_response_at(
+    context: &LocalGraphContext,
+    sidecar_path: &Path,
+    freshness_comparison: Option<FreshnessComparison>,
+) -> Result<StatusResponse> {
+    match open_for_query_at(sidecar_path) {
+        Ok(OpenQuerySidecarResult::Ready(sidecar)) => {
+            let query = SqliteGraphQuery::new(
+                &sidecar,
+                context.config.query_limits.clone(),
+                freshness_comparison,
+            );
+            Ok(query.status(&StatusRequest {
+                scope: context.scope(default_budget(&context.config.query_limits)?)?,
+            })?)
+        }
+        Ok(OpenQuerySidecarResult::Absent) => unavailable_status(
+            context.repository.clone(),
+            Availability::NotBuilt,
+            "not_built",
+            RetrievalAction::Index,
+        ),
+        Ok(OpenQuerySidecarResult::NeedsMigration {
+            found_schema_version,
+        }) => unavailable_status(
+            context.repository.clone(),
+            Availability::Incompatible,
+            &format!("schema_{found_schema_version}_needs_migration"),
+            RetrievalAction::Index,
+        ),
+        Ok(OpenQuerySidecarResult::RequiresRebuild(_)) => unavailable_status(
+            context.repository.clone(),
+            Availability::Incompatible,
+            "incompatible_schema",
+            RetrievalAction::Rebuild,
+        ),
+        Err(_) => unavailable_status(
+            context.repository.clone(),
+            Availability::Incompatible,
+            "sidecar_unreadable",
+            RetrievalAction::Rebuild,
+        ),
+    }
+}
+
+fn search_response_at(
+    context: &LocalGraphContext,
+    sidecar_path: &Path,
+    freshness_comparison: Option<FreshnessComparison>,
+    request: &SearchRequest,
+) -> Result<SearchResponse, QueryError> {
+    match open_for_query_at(sidecar_path) {
+        Ok(OpenQuerySidecarResult::Ready(sidecar)) => SqliteGraphQuery::new(
+            &sidecar,
+            context.config.query_limits.clone(),
+            freshness_comparison,
+        )
+        .search(request),
+        Ok(OpenQuerySidecarResult::Absent) => Err(query_error(
+            QueryErrorCode::NotBuilt,
+            "repository graph is not built; run `ferrus graph index`",
+            false,
+            Some(RetrievalAction::Index),
+        )),
+        Ok(OpenQuerySidecarResult::NeedsMigration { .. }) => Err(query_error(
+            QueryErrorCode::Incompatible,
+            "repository graph storage needs migration; run `ferrus graph index`",
+            false,
+            Some(RetrievalAction::Index),
+        )),
+        Ok(OpenQuerySidecarResult::RequiresRebuild(_)) => Err(query_error(
+            QueryErrorCode::Incompatible,
+            "repository graph storage is incompatible; rebuild the derived index",
+            false,
+            Some(RetrievalAction::Rebuild),
+        )),
+        Err(_) => Err(query_error(
+            QueryErrorCode::BackendUnavailable,
+            "repository graph storage is unavailable or inconsistent",
+            true,
+            Some(RetrievalAction::Rebuild),
+        )),
+    }
+}
+
+fn unavailable_status(
+    repository: RepositoryRef,
+    availability: Availability,
+    reason: &str,
+    action: RetrievalAction,
+) -> Result<StatusResponse> {
+    Ok(StatusResponse {
+        wire_version: QUERY_WIRE_VERSION,
+        repository,
+        snapshot_id: None,
+        source_revision: None,
+        freshness: FreshnessEnvelope {
+            freshness: Freshness::NotApplicable,
+            compared_manifest: None,
+            reason_codes: vec![reason.to_string()],
+        },
+        diagnostics: DiagnosticsEnvelope {
+            summary: DiagnosticSummary::default(),
+            items: vec![],
+            truncated: false,
+        },
+        page: PageInfo {
+            next_cursor: None,
+            truncation: None,
+        },
+        data: StatusData {
+            availability,
+            build_state: None,
+            build_id: None,
+            published_view: Some(PublishedViewName::new(CANONICAL_VIEW)?),
+            graph_model_version: None,
+            statistics: None,
+            recommended_action: Some(action),
+        },
+    })
+}
+
+fn query_error(
+    code: QueryErrorCode,
+    message: &str,
+    retryable: bool,
+    recommended_action: Option<RetrievalAction>,
+) -> QueryError {
+    QueryError {
+        wire_version: QUERY_WIRE_VERSION,
+        code,
+        message: message.to_string(),
+        retryable,
+        recommended_action,
+        details: BTreeMap::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn context(root: &Path) -> LocalGraphContext {
+        LocalGraphContext {
+            root: root.to_path_buf(),
+            repository: RepositoryRef {
+                namespace: RepositoryNamespace::new("local:test").unwrap(),
+                repository_id: RepositoryId::new("root").unwrap(),
+            },
+            config: RepositoryGraphConfig::default(),
+        }
+    }
+
+    #[test]
+    fn absent_status_and_search_are_read_only_and_actionable() {
+        let directory = tempfile::tempdir().unwrap();
+        let sidecar = directory.path().join(SIDECAR_FILE_NAME);
+        let context = context(directory.path());
+
+        let status = status_response_at(&context, &sidecar, None).unwrap();
+        let search = search_response_at(
+            &context,
+            &sidecar,
+            None,
+            &SearchRequest {
+                scope: context
+                    .scope(default_budget(&context.config.query_limits).unwrap())
+                    .unwrap(),
+                text: "RuntimeTaskContext".to_string(),
+                node_kinds: vec![],
+                paths: vec![],
+                page: repository_graph::query::PageRequest { cursor: None },
+            },
+        )
+        .unwrap_err();
+
+        assert_eq!(status.data.availability, Availability::NotBuilt);
+        assert_eq!(status.data.recommended_action, Some(RetrievalAction::Index));
+        assert_eq!(search.code, QueryErrorCode::NotBuilt);
+        assert_eq!(search.recommended_action, Some(RetrievalAction::Index));
+        assert!(!sidecar.exists());
+    }
+
+    #[test]
+    fn unreadable_sidecar_is_distinct_from_a_missing_index() {
+        let directory = tempfile::tempdir().unwrap();
+        let sidecar = directory.path().join(SIDECAR_FILE_NAME);
+        std::fs::write(&sidecar, b"not a sqlite database").unwrap();
+        let context = context(directory.path());
+
+        let status = status_response_at(&context, &sidecar, None).unwrap();
+
+        assert_eq!(status.data.availability, Availability::Incompatible);
+        assert_eq!(status.freshness.reason_codes, ["sidecar_unreadable"]);
+        assert_eq!(
+            status.data.recommended_action,
+            Some(RetrievalAction::Rebuild)
+        );
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -175,6 +175,11 @@ pub async fn start(role: Option<Role>, agent_name: String, agent_index: u32) -> 
             .with_input_schema(|_| {
                 ToolSchema::from_json_str(tools::repository_search::INPUT_SCHEMA)
             });
+        app.map_tool("repository_context", tools::repository_context::handler)
+            .with_description(tools::repository_context::DESCRIPTION)
+            .with_input_schema(|_| {
+                ToolSchema::from_json_str(tools::repository_context::INPUT_SCHEMA)
+            });
     }
 
     // Resources
@@ -321,14 +326,14 @@ mod tests {
         assert!(!(all_roles || executor_role || task_scoped_supervisor));
         let definition_tools = 2usize;
         let review_and_consult_tools = 6usize;
-        let repository_read_tools = 2usize;
+        let repository_read_tools = 3usize;
         let shared_human_tools = 2usize;
         assert_eq!(
             definition_tools
                 + review_and_consult_tools
                 + repository_read_tools
                 + shared_human_tools,
-            12
+            13
         );
     }
 
@@ -349,9 +354,9 @@ mod tests {
         ));
         assert!(!supervisor_review_tools_visible(archive_scoped_supervisor));
         let archive_tool = 1usize;
-        let repository_read_tools = 2usize;
+        let repository_read_tools = 3usize;
         let shared_human_tools = 2usize;
-        assert_eq!(archive_tool + repository_read_tools + shared_human_tools, 5);
+        assert_eq!(archive_tool + repository_read_tools + shared_human_tools, 6);
     }
 
     #[test]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -164,6 +164,19 @@ pub async fn start(role: Option<Role>, agent_name: String, agent_index: u32) -> 
             .with_description(tools::wait_for_consult::DESCRIPTION);
     }
 
+    if repository_retrieval_tools_visible(all_roles, supervisor_role, executor_role) {
+        app.map_tool(
+            "repository_graph_status",
+            tools::repository_graph_status::handler,
+        )
+        .with_description(tools::repository_graph_status::DESCRIPTION);
+        app.map_tool("repository_search", tools::repository_search::handler)
+            .with_description(tools::repository_search::DESCRIPTION)
+            .with_input_schema(|_| {
+                ToolSchema::from_json_str(tools::repository_search::INPUT_SCHEMA)
+            });
+    }
+
     // Resources
     app.add_resource("ferrus://task", "Task");
     app.add_resource("ferrus://task_template", "Task Template");
@@ -248,6 +261,14 @@ fn supervisor_review_tools_visible(archive_scoped_supervisor: bool) -> bool {
     !archive_scoped_supervisor
 }
 
+fn repository_retrieval_tools_visible(
+    all_roles: bool,
+    supervisor_role: bool,
+    executor_role: bool,
+) -> bool {
+    all_roles || supervisor_role || executor_role
+}
+
 fn supervisor_task_scope_from_agent_id(agent_id: &str) -> Option<&str> {
     let mut parts = agent_id.split(':');
     let role = parts.next()?;
@@ -280,7 +301,7 @@ mod tests {
     }
 
     #[test]
-    fn interactive_supervisor_mapping_fits_one_tool_page_without_heartbeat() {
+    fn interactive_supervisor_mapping_includes_repository_reads_without_heartbeat() {
         let all_roles = false;
         let executor_role = false;
         let archive_scoped_supervisor = false;
@@ -300,10 +321,14 @@ mod tests {
         assert!(!(all_roles || executor_role || task_scoped_supervisor));
         let definition_tools = 2usize;
         let review_and_consult_tools = 6usize;
+        let repository_read_tools = 2usize;
         let shared_human_tools = 2usize;
         assert_eq!(
-            definition_tools + review_and_consult_tools + shared_human_tools,
-            10
+            definition_tools
+                + review_and_consult_tools
+                + repository_read_tools
+                + shared_human_tools,
+            12
         );
     }
 
@@ -324,8 +349,9 @@ mod tests {
         ));
         assert!(!supervisor_review_tools_visible(archive_scoped_supervisor));
         let archive_tool = 1usize;
+        let repository_read_tools = 2usize;
         let shared_human_tools = 2usize;
-        assert_eq!(archive_tool + shared_human_tools, 3);
+        assert_eq!(archive_tool + repository_read_tools + shared_human_tools, 5);
     }
 
     #[test]
@@ -359,5 +385,13 @@ mod tests {
         let all_roles = true;
         let executor_role = false;
         assert!(all_roles || executor_role || task_scoped_supervisor);
+    }
+
+    #[test]
+    fn repository_reads_are_visible_to_every_server_role() {
+        assert!(repository_retrieval_tools_visible(true, false, false));
+        assert!(repository_retrieval_tools_visible(false, true, false));
+        assert!(repository_retrieval_tools_visible(false, false, true));
+        assert!(!repository_retrieval_tools_visible(false, false, false));
     }
 }

--- a/src/server/tools/mod.rs
+++ b/src/server/tools/mod.rs
@@ -10,6 +10,8 @@ pub mod create_task;
 pub mod enqueue_task;
 pub mod heartbeat;
 pub mod reject;
+pub mod repository_graph_status;
+pub mod repository_search;
 pub mod reset;
 pub mod respond_consult;
 pub mod review_pending;
@@ -93,6 +95,25 @@ mod tests {
         )
         .await
         .unwrap();
+        let metadata = crate::project::ProjectMetadata {
+            id: "test-project".to_string(),
+            name: "test".to_string(),
+            workspace_dir: dir.path().to_string_lossy().into_owned(),
+            ferrus_dir: dir.path().join(".ferrus").to_string_lossy().into_owned(),
+            vcs: None,
+            origin_repo: None,
+            default_branch: None,
+            current_head: None,
+            created_at: "2026-07-18T00:00:00Z".to_string(),
+            last_opened_at: "2026-07-18T00:00:00Z".to_string(),
+            version: 1,
+        };
+        tokio::fs::write(
+            data_dir.join("project.toml"),
+            toml::to_string_pretty(&metadata).unwrap(),
+        )
+        .await
+        .unwrap();
         (dir, previous)
     }
 
@@ -111,6 +132,7 @@ mod tests {
             ("create_task", create_task::INPUT_SCHEMA),
             ("enqueue_task", enqueue_task::INPUT_SCHEMA),
             ("reject", reject::INPUT_SCHEMA),
+            ("repository_search", repository_search::INPUT_SCHEMA),
             ("respond_consult", respond_consult::INPUT_SCHEMA),
             ("submit", submit::INPUT_SCHEMA),
         ] {
@@ -141,6 +163,41 @@ mod tests {
         ensure_lease_owner_or_reclaim("executor:codex:2", 60)
             .await
             .unwrap();
+
+        teardown(previous);
+    }
+
+    #[tokio::test]
+    async fn repository_reads_require_no_task_lease_and_do_not_touch_runtime_state() {
+        let _guard = crate::test_support::cwd_lock().lock().unwrap();
+        let (_dir, previous) = setup_runtime_project().await;
+        tokio::fs::write("ferrus.toml", "[repository_graph]\nenabled = true\n")
+            .await
+            .unwrap();
+        let data_dir = crate::project::current_project_data_dir().await.unwrap();
+        let runtime_db = data_dir.join("ferrus.db");
+        let sentinel = b"not a runtime database; repository reads must ignore it";
+        tokio::fs::write(&runtime_db, sentinel).await.unwrap();
+
+        let status = repository_graph_status::run().await.unwrap();
+        let search = repository_search::handler(serde_json::json!({
+            "query": "RuntimeTaskContext",
+            "max_results": 5
+        }))
+        .await
+        .unwrap();
+
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&status).unwrap()["data"]["availability"],
+            "not_built"
+        );
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&search).unwrap()["code"],
+            "not_built"
+        );
+        assert_eq!(tokio::fs::read(&runtime_db).await.unwrap(), sentinel);
+        assert!(!data_dir.join("repo-graph.db").exists());
+        assert!(!std::path::Path::new(".ferrus/tasks").exists());
 
         teardown(previous);
     }

--- a/src/server/tools/mod.rs
+++ b/src/server/tools/mod.rs
@@ -10,7 +10,9 @@ pub mod create_task;
 pub mod enqueue_task;
 pub mod heartbeat;
 pub mod reject;
+pub mod repository_context;
 pub mod repository_graph_status;
+mod repository_query_telemetry;
 pub mod repository_search;
 pub mod reset;
 pub mod respond_consult;
@@ -132,6 +134,7 @@ mod tests {
             ("create_task", create_task::INPUT_SCHEMA),
             ("enqueue_task", enqueue_task::INPUT_SCHEMA),
             ("reject", reject::INPUT_SCHEMA),
+            ("repository_context", repository_context::INPUT_SCHEMA),
             ("repository_search", repository_search::INPUT_SCHEMA),
             ("respond_consult", respond_consult::INPUT_SCHEMA),
             ("submit", submit::INPUT_SCHEMA),
@@ -186,6 +189,12 @@ mod tests {
         }))
         .await
         .unwrap();
+        let context = repository_context::handler(serde_json::json!({
+            "seeds": [{"type": "path", "value": "src/lib.rs"}],
+            "max_results": 5
+        }))
+        .await
+        .unwrap();
 
         assert_eq!(
             serde_json::from_str::<serde_json::Value>(&status).unwrap()["data"]["availability"],
@@ -193,6 +202,10 @@ mod tests {
         );
         assert_eq!(
             serde_json::from_str::<serde_json::Value>(&search).unwrap()["code"],
+            "not_built"
+        );
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&context).unwrap()["code"],
             "not_built"
         );
         assert_eq!(tokio::fs::read(&runtime_db).await.unwrap(), sentinel);

--- a/src/server/tools/repository_context.rs
+++ b/src/server/tools/repository_context.rs
@@ -1,0 +1,414 @@
+use std::{
+    collections::BTreeMap,
+    num::{NonZeroU32, NonZeroU64},
+    time::Instant,
+};
+
+use anyhow::{Context, Result};
+use neva::prelude::*;
+use serde::Deserialize;
+
+use crate::{
+    repository_graph::{
+        QUERY_WIRE_VERSION,
+        config::QueryLimitsConfig,
+        domain::{NodeId, PageCursor, QueryBudget, RepoPath, SemanticKey},
+        query::{
+            ContextPolicy, ContextRequest, ContextSeed, EdgeDirection, PageRequest, QueryError,
+            QueryErrorCode,
+        },
+    },
+    repository_graph_runtime::LocalGraphContext,
+};
+
+use super::{repository_query_telemetry, tool_err};
+
+const MAX_SEEDS: usize = 32;
+const MAX_SEED_BYTES: usize = 512;
+const MAX_EDGE_KINDS: usize = 32;
+const MAX_EDGE_KIND_BYTES: usize = 128;
+const MAX_CURSOR_BYTES: usize = 16 * 1024;
+
+pub const DESCRIPTION: &str = "Assemble deterministic, bounded repository context from one or more \
+     node, semantic-key, or repository-relative path seeds. Ranking favors exact evidence, \
+     containment, declarations, and resolved dependencies; optional snippets are read only through \
+     the hash-verified snapshot content boundary. Results explain why each fact was selected, label \
+     freshness and resolution confidence, and support snapshot-bound continuation. Call \
+     repository_graph_status first when availability is unknown. This read-only tool requires no \
+     task lease and never changes task or run state. A missing relationship means only that it is \
+     not known by this index, not that the relationship does not exist.";
+
+pub const INPUT_SCHEMA: &str = r#"{
+    "type": "object",
+    "properties": {
+        "input": {
+            "type": "object",
+            "description": "Bounded repository context request",
+            "properties": {
+                "seeds": {
+                    "type": "array",
+                    "minItems": 1,
+                    "maxItems": 32,
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "type": { "type": "string", "enum": ["node", "symbol", "path"] },
+                            "value": { "type": "string", "minLength": 1, "maxLength": 512 }
+                        },
+                        "required": ["type", "value"],
+                        "additionalProperties": false
+                    }
+                },
+                "direction": {
+                    "type": "string",
+                    "enum": ["outgoing", "incoming", "both"],
+                    "description": "Relationship traversal direction"
+                },
+                "edge_kinds": {
+                    "type": "array",
+                    "maxItems": 32,
+                    "items": { "type": "string", "minLength": 1, "maxLength": 128 },
+                    "description": "Optional exact relationship-kind filters"
+                },
+                "include_unresolved": {
+                    "type": "boolean",
+                    "description": "Include explicitly unresolved facts"
+                },
+                "include_external": {
+                    "type": "boolean",
+                    "description": "Include facts whose target is outside this repository"
+                },
+                "include_snippets": {
+                    "type": "boolean",
+                    "description": "Attach deduplicated hash-verified UTF-8 source excerpts"
+                },
+                "max_snippet_bytes": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Aggregate snippet byte cap; the configured server cap wins"
+                },
+                "max_results": { "type": "integer", "minimum": 1 },
+                "max_bytes": { "type": "integer", "minimum": 1 },
+                "max_depth": { "type": "integer", "minimum": 1 },
+                "max_duration_ms": { "type": "integer", "minimum": 1 },
+                "max_diagnostics": { "type": "integer", "minimum": 1 },
+                "cursor": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 16384,
+                    "description": "Opaque cursor from the same context policy and snapshot"
+                }
+            },
+            "required": ["seeds"],
+            "additionalProperties": false
+        }
+    },
+    "required": ["input"],
+    "additionalProperties": false
+}"#;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RepositoryContextInput {
+    seeds: Vec<RepositoryContextSeedInput>,
+    #[serde(default)]
+    direction: EdgeDirection,
+    #[serde(default)]
+    edge_kinds: Vec<String>,
+    #[serde(default)]
+    include_unresolved: bool,
+    #[serde(default)]
+    include_external: bool,
+    #[serde(default)]
+    include_snippets: bool,
+    max_snippet_bytes: Option<u64>,
+    max_results: Option<u32>,
+    max_bytes: Option<u64>,
+    max_depth: Option<u32>,
+    max_duration_ms: Option<u64>,
+    max_diagnostics: Option<u32>,
+    cursor: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", content = "value", rename_all = "snake_case")]
+enum RepositoryContextSeedInput {
+    Node(String),
+    Symbol(String),
+    Path(String),
+}
+
+pub async fn handler(input: serde_json::Value) -> Result<String, Error> {
+    let input = match parse_input(input) {
+        Ok(input) => input,
+        Err(error) => return serialize_invalid_request(&error).map_err(tool_err),
+    };
+    run(input).await.map_err(tool_err)
+}
+
+async fn run(input: RepositoryContextInput) -> Result<String> {
+    let started = Instant::now();
+    let context = LocalGraphContext::load(false).await?;
+    let include_snippets = input.include_snippets;
+    let requested_snippet_bytes = input.max_snippet_bytes;
+    let request = match context_request(&context, input) {
+        Ok(request) => request,
+        Err(error) => return serialize_invalid_request(&error),
+    };
+    let response = if include_snippets {
+        let max_snippet_bytes = NonZeroU64::new(
+            requested_snippet_bytes.unwrap_or(context.config.query_limits.max_snippet_bytes),
+        )
+        .context("repository_context max_snippet_bytes must be greater than zero")?;
+        context
+            .context_with_snippets(&request, max_snippet_bytes)
+            .await?
+    } else {
+        context.context(&request).await?
+    };
+    let serialized = match &response {
+        Ok(response) => serde_json::to_string(response)?,
+        Err(error) => serde_json::to_string(error)?,
+    };
+    repository_query_telemetry::context(&context.config, started, &response, serialized.len());
+    Ok(serialized)
+}
+
+fn parse_input(input: serde_json::Value) -> Result<RepositoryContextInput> {
+    let input: RepositoryContextInput = serde_json::from_value(input)
+        .context("repository_context expects an input object matching its schema")?;
+    if input.seeds.is_empty() || input.seeds.len() > MAX_SEEDS {
+        anyhow::bail!("repository_context requires 1..={MAX_SEEDS} seeds");
+    }
+    if input
+        .seeds
+        .iter()
+        .any(|seed| seed_value(seed).trim().is_empty())
+    {
+        anyhow::bail!("repository_context seeds must not be empty");
+    }
+    if input
+        .seeds
+        .iter()
+        .any(|seed| seed_value(seed).len() > MAX_SEED_BYTES)
+    {
+        anyhow::bail!("repository_context seeds exceed {MAX_SEED_BYTES} bytes");
+    }
+    if input.edge_kinds.len() > MAX_EDGE_KINDS {
+        anyhow::bail!("repository_context edge_kinds exceeds {MAX_EDGE_KINDS} entries");
+    }
+    if input.edge_kinds.iter().any(|kind| kind.trim().is_empty()) {
+        anyhow::bail!("repository_context edge_kinds must not contain empty entries");
+    }
+    if input
+        .edge_kinds
+        .iter()
+        .any(|kind| kind.len() > MAX_EDGE_KIND_BYTES)
+    {
+        anyhow::bail!("repository_context edge_kinds exceed {MAX_EDGE_KIND_BYTES} bytes");
+    }
+    if input
+        .cursor
+        .as_ref()
+        .is_some_and(|cursor| cursor.len() > MAX_CURSOR_BYTES)
+    {
+        anyhow::bail!("repository_context cursor exceeds {MAX_CURSOR_BYTES} bytes");
+    }
+    if input.max_snippet_bytes == Some(0) {
+        anyhow::bail!("repository_context max_snippet_bytes must be greater than zero");
+    }
+    Ok(input)
+}
+
+fn seed_value(seed: &RepositoryContextSeedInput) -> &str {
+    match seed {
+        RepositoryContextSeedInput::Node(value)
+        | RepositoryContextSeedInput::Symbol(value)
+        | RepositoryContextSeedInput::Path(value) => value,
+    }
+}
+
+fn context_request(
+    context: &LocalGraphContext,
+    input: RepositoryContextInput,
+) -> Result<ContextRequest> {
+    let budget = requested_budget(&context.config.query_limits, &input)?;
+    let seeds = input
+        .seeds
+        .into_iter()
+        .map(|seed| match seed {
+            RepositoryContextSeedInput::Node(value) => NodeId::new(value.trim())
+                .map(ContextSeed::Node)
+                .map_err(Into::into),
+            RepositoryContextSeedInput::Symbol(value) => SemanticKey::new(value.trim())
+                .map(ContextSeed::Symbol)
+                .map_err(Into::into),
+            RepositoryContextSeedInput::Path(value) => RepoPath::new(value.trim())
+                .map(ContextSeed::Path)
+                .map_err(Into::into),
+        })
+        .collect::<Result<Vec<_>>>()?;
+    Ok(ContextRequest {
+        scope: context.scope(budget)?,
+        seeds,
+        policy: ContextPolicy {
+            direction: input.direction,
+            edge_kinds: input
+                .edge_kinds
+                .into_iter()
+                .map(|kind| kind.trim().to_string())
+                .collect(),
+            include_unresolved: input.include_unresolved,
+            include_external: input.include_external,
+        },
+        page: PageRequest {
+            cursor: input
+                .cursor
+                .map(|cursor| PageCursor::new(cursor.trim().to_string()))
+                .transpose()?,
+        },
+    })
+}
+
+fn requested_budget(
+    limits: &QueryLimitsConfig,
+    input: &RepositoryContextInput,
+) -> Result<QueryBudget> {
+    Ok(QueryBudget::new(
+        NonZeroU32::new(input.max_results.unwrap_or(limits.max_results))
+            .context("repository_context max_results must be greater than zero")?,
+        NonZeroU64::new(input.max_bytes.unwrap_or(limits.max_bytes))
+            .context("repository_context max_bytes must be greater than zero")?,
+        NonZeroU32::new(input.max_depth.unwrap_or(limits.max_depth))
+            .context("repository_context max_depth must be greater than zero")?,
+        NonZeroU64::new(input.max_duration_ms.unwrap_or(limits.max_duration_ms))
+            .context("repository_context max_duration_ms must be greater than zero")?,
+        NonZeroU32::new(input.max_diagnostics.unwrap_or(limits.max_diagnostics))
+            .context("repository_context max_diagnostics must be greater than zero")?,
+    ))
+}
+
+fn serialize_invalid_request(error: &anyhow::Error) -> Result<String> {
+    Ok(serde_json::to_string(&QueryError {
+        wire_version: QUERY_WIRE_VERSION,
+        code: QueryErrorCode::InvalidRequest,
+        message: error.to_string(),
+        retryable: false,
+        recommended_action: None,
+        details: BTreeMap::new(),
+    })?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use neva::types::CallToolRequestParams;
+    use std::collections::HashMap;
+
+    fn local_context() -> LocalGraphContext {
+        let directory = tempfile::tempdir().unwrap().keep();
+        LocalGraphContext {
+            root: directory,
+            repository: crate::repository_graph::domain::RepositoryRef {
+                namespace: crate::repository_graph::domain::RepositoryNamespace::new("local:test")
+                    .unwrap(),
+                repository_id: crate::repository_graph::domain::RepositoryId::new("root").unwrap(),
+            },
+            config: crate::repository_graph::config::RepositoryGraphConfig::default(),
+        }
+    }
+
+    #[test]
+    fn schema_is_bounded_and_rejects_unknown_fields() {
+        let schema: serde_json::Value = serde_json::from_str(INPUT_SCHEMA).unwrap();
+        let input = &schema["properties"]["input"];
+        assert_eq!(input["additionalProperties"], false);
+        assert_eq!(input["properties"]["seeds"]["maxItems"], 32);
+        assert_eq!(input["properties"]["edge_kinds"]["maxItems"], 32);
+        assert!(
+            parse_input(serde_json::json!({
+                "seeds": [{"type": "path", "value": "src/lib.rs"}],
+                "unknown": true
+            }))
+            .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn boundary_validation_returns_a_versioned_query_error() {
+        let response = handler(serde_json::json!({"seeds": []})).await.unwrap();
+        let response: QueryError = serde_json::from_str(&response).unwrap();
+        assert_eq!(response.wire_version, QUERY_WIRE_VERSION);
+        assert_eq!(response.code, QueryErrorCode::InvalidRequest);
+    }
+
+    #[test]
+    fn neva_extracts_wrapped_context_input_as_one_argument() {
+        let params = CallToolRequestParams {
+            name: "repository_context".to_string(),
+            args: Some(HashMap::from([(
+                "input".to_string(),
+                serde_json::json!({
+                    "seeds": [{"type": "symbol", "value": "crate::RuntimeTaskContext"}],
+                    "include_snippets": true
+                }),
+            )])),
+            meta: None,
+        };
+        let (input,): (serde_json::Value,) = params.try_into().unwrap();
+        let input = parse_input(input).unwrap();
+        assert!(input.include_snippets);
+        assert_eq!(input.seeds.len(), 1);
+    }
+
+    #[test]
+    fn request_preserves_typed_seeds_policy_cursor_and_budgets() {
+        let context = local_context();
+        let input = parse_input(serde_json::json!({
+            "seeds": [
+                {"type": "path", "value": "src/lib.rs"},
+                {"type": "node", "value": "node:main"}
+            ],
+            "direction": "incoming",
+            "edge_kinds": [" imports "],
+            "include_external": true,
+            "max_results": 7,
+            "max_bytes": 4096,
+            "max_depth": 2,
+            "max_duration_ms": 50,
+            "max_diagnostics": 3,
+            "cursor": "opaque"
+        }))
+        .unwrap();
+        let request = context_request(&context, input).unwrap();
+        assert_eq!(request.seeds.len(), 2);
+        assert_eq!(request.policy.direction, EdgeDirection::Incoming);
+        assert_eq!(request.policy.edge_kinds, ["imports"]);
+        assert!(request.policy.include_external);
+        assert_eq!(request.scope.budget.max_results.get(), 7);
+        assert_eq!(request.scope.budget.max_depth.get(), 2);
+        assert_eq!(request.page.cursor.unwrap().as_str(), "opaque");
+    }
+
+    #[test]
+    fn invalid_paths_oversized_collections_and_zero_budgets_are_rejected() {
+        let context = local_context();
+        let invalid_path = parse_input(serde_json::json!({
+            "seeds": [{"type": "path", "value": "../secret"}]
+        }))
+        .unwrap();
+        assert!(context_request(&context, invalid_path).is_err());
+
+        let empty_seed = parse_input(serde_json::json!({
+            "seeds": [{"type": "symbol", "value": " "}]
+        }));
+        assert!(empty_seed.is_err());
+
+        let zero_budget = parse_input(serde_json::json!({
+            "seeds": [{"type": "node", "value": "node:main"}],
+            "max_depth": 0
+        }))
+        .unwrap();
+        assert!(context_request(&context, zero_budget).is_err());
+    }
+}

--- a/src/server/tools/repository_graph_status.rs
+++ b/src/server/tools/repository_graph_status.rs
@@ -1,9 +1,10 @@
 use anyhow::Result;
 use neva::prelude::*;
+use std::time::Instant;
 
 use crate::repository_graph_runtime::LocalGraphContext;
 
-use super::tool_err;
+use super::{repository_query_telemetry, tool_err};
 
 pub const DESCRIPTION: &str = "Read the canonical repository graph status without claiming a task \
      lease or changing Ferrus runtime state. Reports distinct not-built, building, failed, \
@@ -15,6 +16,10 @@ pub async fn handler() -> Result<String, Error> {
 }
 
 pub(super) async fn run() -> Result<String> {
+    let started = Instant::now();
     let context = LocalGraphContext::load(false).await?;
-    Ok(serde_json::to_string(&context.status().await?)?)
+    let response = context.status().await?;
+    let serialized = serde_json::to_string(&response)?;
+    repository_query_telemetry::status(&context.config, started, &response, serialized.len());
+    Ok(serialized)
 }

--- a/src/server/tools/repository_graph_status.rs
+++ b/src/server/tools/repository_graph_status.rs
@@ -1,0 +1,20 @@
+use anyhow::Result;
+use neva::prelude::*;
+
+use crate::repository_graph_runtime::LocalGraphContext;
+
+use super::tool_err;
+
+pub const DESCRIPTION: &str = "Read the canonical repository graph status without claiming a task \
+     lease or changing Ferrus runtime state. Reports distinct not-built, building, failed, \
+     incompatible, stale, and fresh states with an operator action when one is needed. Call this \
+     before repository_search when graph availability is unknown.";
+
+pub async fn handler() -> Result<String, Error> {
+    run().await.map_err(tool_err)
+}
+
+pub(super) async fn run() -> Result<String> {
+    let context = LocalGraphContext::load(false).await?;
+    Ok(serde_json::to_string(&context.status().await?)?)
+}

--- a/src/server/tools/repository_query_telemetry.rs
+++ b/src/server/tools/repository_query_telemetry.rs
@@ -1,0 +1,162 @@
+use std::time::Instant;
+
+use serde::Serialize;
+
+use crate::repository_graph::{
+    config::RepositoryGraphConfig,
+    domain::Freshness,
+    query::{
+        ContextResponse, QueryError, QueryErrorCode, SearchResponse, StatusResponse,
+        TruncationReason,
+    },
+};
+
+/// Privacy-safe retrieval metric. Request text, filters, repository paths,
+/// snippets, and source bodies are deliberately not representable here.
+#[derive(Debug, Serialize)]
+struct RepositoryQueryMetric<'a> {
+    tool: &'static str,
+    snapshot: Option<&'a str>,
+    freshness: Option<Freshness>,
+    duration_ms: u64,
+    result_count: u64,
+    response_bytes: u64,
+    truncation: Option<TruncationReason>,
+    diagnostics_count: u64,
+    error_category: Option<QueryErrorCode>,
+}
+
+pub(super) fn status(
+    config: &RepositoryGraphConfig,
+    started: Instant,
+    response: &StatusResponse,
+    response_bytes: usize,
+) {
+    emit(
+        config,
+        RepositoryQueryMetric {
+            tool: "repository_graph_status",
+            snapshot: response.snapshot_id.as_ref().map(|id| id.as_str()),
+            freshness: Some(response.freshness.freshness),
+            duration_ms: elapsed_ms(started),
+            result_count: response.data.statistics.is_some() as u64,
+            response_bytes: response_bytes as u64,
+            truncation: response.page.truncation.as_ref().map(|value| value.reason),
+            diagnostics_count: diagnostic_count(&response.diagnostics.summary),
+            error_category: None,
+        },
+    );
+}
+
+pub(super) fn search(
+    config: &RepositoryGraphConfig,
+    started: Instant,
+    response: &Result<SearchResponse, QueryError>,
+    response_bytes: usize,
+) {
+    let metric = match response {
+        Ok(response) => RepositoryQueryMetric {
+            tool: "repository_search",
+            snapshot: Some(response.snapshot_id.as_str()),
+            freshness: Some(response.freshness.freshness),
+            duration_ms: elapsed_ms(started),
+            result_count: response.data.hits.len() as u64,
+            response_bytes: response_bytes as u64,
+            truncation: response.page.truncation.as_ref().map(|value| value.reason),
+            diagnostics_count: diagnostic_count(&response.diagnostics.summary),
+            error_category: None,
+        },
+        Err(error) => error_metric("repository_search", started, error, response_bytes),
+    };
+    emit(config, metric);
+}
+
+pub(super) fn context(
+    config: &RepositoryGraphConfig,
+    started: Instant,
+    response: &Result<ContextResponse, QueryError>,
+    response_bytes: usize,
+) {
+    let metric = match response {
+        Ok(response) => RepositoryQueryMetric {
+            tool: "repository_context",
+            snapshot: Some(response.snapshot_id.as_str()),
+            freshness: Some(response.freshness.freshness),
+            duration_ms: elapsed_ms(started),
+            result_count: response.data.items.len() as u64,
+            response_bytes: response_bytes as u64,
+            truncation: response.page.truncation.as_ref().map(|value| value.reason),
+            diagnostics_count: diagnostic_count(&response.diagnostics.summary),
+            error_category: None,
+        },
+        Err(error) => error_metric("repository_context", started, error, response_bytes),
+    };
+    emit(config, metric);
+}
+
+fn error_metric<'a>(
+    tool: &'static str,
+    started: Instant,
+    error: &'a QueryError,
+    response_bytes: usize,
+) -> RepositoryQueryMetric<'a> {
+    RepositoryQueryMetric {
+        tool,
+        snapshot: None,
+        freshness: None,
+        duration_ms: elapsed_ms(started),
+        result_count: 0,
+        response_bytes: response_bytes as u64,
+        truncation: None,
+        diagnostics_count: 0,
+        error_category: Some(error.code),
+    }
+}
+
+fn diagnostic_count(summary: &crate::repository_graph::query::DiagnosticSummary) -> u64 {
+    summary.info + summary.warning + summary.error
+}
+
+fn elapsed_ms(started: Instant) -> u64 {
+    u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX)
+}
+
+fn emit(config: &RepositoryGraphConfig, metric: RepositoryQueryMetric<'_>) {
+    if !config.telemetry.enabled {
+        return;
+    }
+    let encoded = serde_json::to_string(&metric)
+        .expect("privacy-safe repository query metrics are always serializable");
+    tracing::info!(
+        target: "ferrus::repository_graph::query",
+        metric = %encoded,
+        "repository graph query"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metric_shape_cannot_contain_queries_paths_or_source_content() {
+        let metric = RepositoryQueryMetric {
+            tool: "repository_search",
+            snapshot: Some("snapshot-1"),
+            freshness: Some(Freshness::Fresh),
+            duration_ms: 12,
+            result_count: 3,
+            response_bytes: 400,
+            truncation: None,
+            diagnostics_count: 1,
+            error_category: None,
+        };
+
+        let value = serde_json::to_value(metric).unwrap();
+        let object = value.as_object().unwrap();
+        assert_eq!(object.len(), 9);
+        for forbidden in ["query", "text", "path", "snippet", "source"] {
+            assert!(!object.contains_key(forbidden));
+        }
+    }
+}

--- a/src/server/tools/repository_search.rs
+++ b/src/server/tools/repository_search.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::BTreeMap,
     num::{NonZeroU32, NonZeroU64},
+    time::Instant,
 };
 
 use anyhow::{Context, Result};
@@ -17,7 +18,7 @@ use crate::{
     repository_graph_runtime::LocalGraphContext,
 };
 
-use super::tool_err;
+use super::{repository_query_telemetry, tool_err};
 
 const MAX_QUERY_BYTES: usize = 512;
 const MAX_FILTERS: usize = 32;
@@ -115,15 +116,19 @@ pub async fn handler(input: serde_json::Value) -> Result<String, Error> {
 }
 
 async fn run(input: RepositorySearchInput) -> Result<String> {
+    let started = Instant::now();
     let context = LocalGraphContext::load(false).await?;
     let request = match search_request(&context, input) {
         Ok(request) => request,
         Err(error) => return serialize_invalid_request(&error),
     };
-    match context.search(&request).await? {
-        Ok(response) => Ok(serde_json::to_string(&response)?),
-        Err(error) => Ok(serde_json::to_string(&error)?),
-    }
+    let response = context.search(&request).await?;
+    let serialized = match &response {
+        Ok(response) => serde_json::to_string(response)?,
+        Err(error) => serde_json::to_string(error)?,
+    };
+    repository_query_telemetry::search(&context.config, started, &response, serialized.len());
+    Ok(serialized)
 }
 
 fn serialize_invalid_request(error: &anyhow::Error) -> Result<String> {

--- a/src/server/tools/repository_search.rs
+++ b/src/server/tools/repository_search.rs
@@ -1,0 +1,334 @@
+use std::{
+    collections::BTreeMap,
+    num::{NonZeroU32, NonZeroU64},
+};
+
+use anyhow::{Context, Result};
+use neva::prelude::*;
+use serde::Deserialize;
+
+use crate::{
+    repository_graph::{
+        QUERY_WIRE_VERSION,
+        config::QueryLimitsConfig,
+        domain::{PageCursor, QueryBudget, RepoPath},
+        query::{PageRequest, QueryError, QueryErrorCode, SearchRequest},
+    },
+    repository_graph_runtime::LocalGraphContext,
+};
+
+use super::tool_err;
+
+const MAX_QUERY_BYTES: usize = 512;
+const MAX_FILTERS: usize = 32;
+const MAX_FILTER_BYTES: usize = 512;
+const MAX_CURSOR_BYTES: usize = 16 * 1024;
+
+pub const DESCRIPTION: &str = "Search the published repository graph using exact path, semantic-key, \
+     normalized-name, and bounded textual matches. Supports node-kind and repository-relative path \
+     filters plus snapshot-bound continuation cursors. Results are deterministic, evidence-backed, \
+     freshness-labeled, and capped by server limits. This read-only tool requires no task lease and \
+     never changes task or run state. An absent relationship means only that it is not known by this \
+     index, not that the relationship does not exist.";
+
+pub const INPUT_SCHEMA: &str = r#"{
+    "type": "object",
+    "properties": {
+        "input": {
+            "type": "object",
+            "description": "Bounded repository graph search request",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 512,
+                    "description": "Name, semantic key, or repository-relative path to find"
+                },
+                "kinds": {
+                    "type": "array",
+                    "maxItems": 32,
+                    "items": { "type": "string", "minLength": 1, "maxLength": 512 },
+                    "description": "Optional exact node-kind filters"
+                },
+                "paths": {
+                    "type": "array",
+                    "maxItems": 32,
+                    "items": { "type": "string", "minLength": 1, "maxLength": 512 },
+                    "description": "Optional repository-relative path-prefix filters"
+                },
+                "max_results": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Requested result cap; the configured server cap wins"
+                },
+                "max_bytes": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Requested response byte cap; the configured server cap wins"
+                },
+                "max_duration_ms": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Requested query duration cap; the configured server cap wins"
+                },
+                "max_diagnostics": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Requested diagnostic cap; the configured server cap wins"
+                },
+                "cursor": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 16384,
+                    "description": "Opaque continuation cursor from the same search and snapshot"
+                }
+            },
+            "required": ["query"],
+            "additionalProperties": false
+        }
+    },
+    "required": ["input"],
+    "additionalProperties": false
+}"#;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RepositorySearchInput {
+    query: String,
+    #[serde(default)]
+    kinds: Vec<String>,
+    #[serde(default)]
+    paths: Vec<String>,
+    max_results: Option<u32>,
+    max_bytes: Option<u64>,
+    max_duration_ms: Option<u64>,
+    max_diagnostics: Option<u32>,
+    cursor: Option<String>,
+}
+
+pub async fn handler(input: serde_json::Value) -> Result<String, Error> {
+    let input = match parse_input(input) {
+        Ok(input) => input,
+        Err(error) => return serialize_invalid_request(&error).map_err(tool_err),
+    };
+    run(input).await.map_err(tool_err)
+}
+
+async fn run(input: RepositorySearchInput) -> Result<String> {
+    let context = LocalGraphContext::load(false).await?;
+    let request = match search_request(&context, input) {
+        Ok(request) => request,
+        Err(error) => return serialize_invalid_request(&error),
+    };
+    match context.search(&request).await? {
+        Ok(response) => Ok(serde_json::to_string(&response)?),
+        Err(error) => Ok(serde_json::to_string(&error)?),
+    }
+}
+
+fn serialize_invalid_request(error: &anyhow::Error) -> Result<String> {
+    Ok(serde_json::to_string(&QueryError {
+        wire_version: QUERY_WIRE_VERSION,
+        code: QueryErrorCode::InvalidRequest,
+        message: error.to_string(),
+        retryable: false,
+        recommended_action: None,
+        details: BTreeMap::new(),
+    })?)
+}
+
+fn parse_input(input: serde_json::Value) -> Result<RepositorySearchInput> {
+    let input: RepositorySearchInput = serde_json::from_value(input)
+        .context("repository_search expects an input object matching its schema")?;
+    if input.query.trim().is_empty() {
+        anyhow::bail!("repository_search query must not be empty");
+    }
+    if input.query.len() > MAX_QUERY_BYTES {
+        anyhow::bail!("repository_search query exceeds {MAX_QUERY_BYTES} bytes");
+    }
+    validate_filters("kinds", &input.kinds)?;
+    validate_filters("paths", &input.paths)?;
+    if input
+        .cursor
+        .as_ref()
+        .is_some_and(|cursor| cursor.len() > MAX_CURSOR_BYTES)
+    {
+        anyhow::bail!("repository_search cursor exceeds {MAX_CURSOR_BYTES} bytes");
+    }
+    Ok(input)
+}
+
+fn validate_filters(name: &str, values: &[String]) -> Result<()> {
+    if values.len() > MAX_FILTERS {
+        anyhow::bail!("repository_search {name} exceeds {MAX_FILTERS} entries");
+    }
+    if values.iter().any(|value| value.trim().is_empty()) {
+        anyhow::bail!("repository_search {name} must not contain empty entries");
+    }
+    if values.iter().any(|value| value.len() > MAX_FILTER_BYTES) {
+        anyhow::bail!("repository_search {name} entries exceed {MAX_FILTER_BYTES} bytes");
+    }
+    Ok(())
+}
+
+fn search_request(
+    context: &LocalGraphContext,
+    input: RepositorySearchInput,
+) -> Result<SearchRequest> {
+    let budget = requested_budget(&context.config.query_limits, &input)?;
+    Ok(SearchRequest {
+        scope: context.scope(budget)?,
+        text: input.query.trim().to_string(),
+        node_kinds: input
+            .kinds
+            .into_iter()
+            .map(|kind| kind.trim().to_string())
+            .collect(),
+        paths: input
+            .paths
+            .into_iter()
+            .map(|path| RepoPath::new(path.trim()))
+            .collect::<Result<Vec<_>, _>>()
+            .context("repository_search paths must be confined repository-relative paths")?,
+        page: PageRequest {
+            cursor: input
+                .cursor
+                .map(|cursor| PageCursor::new(cursor.trim().to_string()))
+                .transpose()?,
+        },
+    })
+}
+
+fn requested_budget(
+    limits: &QueryLimitsConfig,
+    input: &RepositorySearchInput,
+) -> Result<QueryBudget> {
+    Ok(QueryBudget::new(
+        NonZeroU32::new(input.max_results.unwrap_or(limits.max_results))
+            .context("repository_search max_results must be greater than zero")?,
+        NonZeroU64::new(input.max_bytes.unwrap_or(limits.max_bytes))
+            .context("repository_search max_bytes must be greater than zero")?,
+        NonZeroU32::new(limits.max_depth)
+            .context("repository_graph.query_limits.max_depth must be greater than zero")?,
+        NonZeroU64::new(input.max_duration_ms.unwrap_or(limits.max_duration_ms))
+            .context("repository_search max_duration_ms must be greater than zero")?,
+        NonZeroU32::new(input.max_diagnostics.unwrap_or(limits.max_diagnostics))
+            .context("repository_search max_diagnostics must be greater than zero")?,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use neva::types::CallToolRequestParams;
+    use std::collections::HashMap;
+
+    #[test]
+    fn schema_is_bounded_and_rejects_unknown_fields() {
+        let schema: serde_json::Value = serde_json::from_str(INPUT_SCHEMA).unwrap();
+        let input = &schema["properties"]["input"];
+        assert_eq!(input["additionalProperties"], false);
+        assert_eq!(input["properties"]["query"]["maxLength"], 512);
+        assert_eq!(input["properties"]["kinds"]["maxItems"], 32);
+        assert_eq!(input["properties"]["paths"]["maxItems"], 32);
+
+        assert!(parse_input(serde_json::json!({"query": "main", "unknown": true})).is_err());
+    }
+
+    #[tokio::test]
+    async fn boundary_validation_returns_a_versioned_query_error() {
+        let response = handler(serde_json::json!({"query": "   "})).await.unwrap();
+        let response: QueryError = serde_json::from_str(&response).unwrap();
+
+        assert_eq!(response.wire_version, QUERY_WIRE_VERSION);
+        assert_eq!(response.code, QueryErrorCode::InvalidRequest);
+        assert!(!response.retryable);
+    }
+
+    #[test]
+    fn neva_extracts_wrapped_search_input_as_one_argument() {
+        let params = CallToolRequestParams {
+            name: "repository_search".to_string(),
+            args: Some(HashMap::from([(
+                "input".to_string(),
+                serde_json::json!({
+                    "query": "RuntimeTaskContext",
+                    "kinds": ["rust.struct"],
+                    "paths": ["src"]
+                }),
+            )])),
+            meta: None,
+        };
+
+        let (input,): (serde_json::Value,) = params.try_into().unwrap();
+        let input = parse_input(input).unwrap();
+
+        assert_eq!(input.query, "RuntimeTaskContext");
+        assert_eq!(input.kinds, ["rust.struct"]);
+        assert_eq!(input.paths, ["src"]);
+    }
+
+    #[test]
+    fn request_preserves_filters_cursor_and_client_budgets() {
+        let directory = tempfile::tempdir().unwrap();
+        let context = LocalGraphContext {
+            root: directory.path().to_path_buf(),
+            repository: crate::repository_graph::domain::RepositoryRef {
+                namespace: crate::repository_graph::domain::RepositoryNamespace::new("local:test")
+                    .unwrap(),
+                repository_id: crate::repository_graph::domain::RepositoryId::new("root").unwrap(),
+            },
+            config: crate::repository_graph::config::RepositoryGraphConfig::default(),
+        };
+        let input = parse_input(serde_json::json!({
+            "query": "  crate::api  ",
+            "kinds": [" rust.struct "],
+            "paths": ["src/api"],
+            "max_results": 7,
+            "max_bytes": 4096,
+            "max_duration_ms": 50,
+            "max_diagnostics": 3,
+            "cursor": "opaque"
+        }))
+        .unwrap();
+
+        let request = search_request(&context, input).unwrap();
+
+        assert_eq!(request.text, "crate::api");
+        assert_eq!(request.node_kinds, ["rust.struct"]);
+        assert_eq!(request.paths[0].as_str(), "src/api");
+        assert_eq!(request.scope.budget.max_results.get(), 7);
+        assert_eq!(request.scope.budget.max_bytes.get(), 4096);
+        assert_eq!(request.scope.budget.max_duration_ms.get(), 50);
+        assert_eq!(request.scope.budget.max_diagnostics.get(), 3);
+        assert_eq!(request.page.cursor.unwrap().as_str(), "opaque");
+    }
+
+    #[test]
+    fn invalid_paths_and_zero_budgets_are_rejected_before_querying() {
+        let directory = tempfile::tempdir().unwrap();
+        let context = LocalGraphContext {
+            root: directory.path().to_path_buf(),
+            repository: crate::repository_graph::domain::RepositoryRef {
+                namespace: crate::repository_graph::domain::RepositoryNamespace::new("local:test")
+                    .unwrap(),
+                repository_id: crate::repository_graph::domain::RepositoryId::new("root").unwrap(),
+            },
+            config: crate::repository_graph::config::RepositoryGraphConfig::default(),
+        };
+
+        let invalid_path = parse_input(serde_json::json!({
+            "query": "main",
+            "paths": ["../secret"]
+        }))
+        .unwrap();
+        assert!(search_request(&context, invalid_path).is_err());
+
+        let zero_budget = parse_input(serde_json::json!({
+            "query": "main",
+            "max_results": 0
+        }))
+        .unwrap();
+        assert!(search_request(&context, zero_budget).is_err());
+    }
+}

--- a/tests/fixtures/repository_graph_eval/cases.json
+++ b/tests/fixtures/repository_graph_eval/cases.json
@@ -1,0 +1,268 @@
+{
+  "schema_version": 1,
+  "corpus_version": "rg2.5-v1",
+  "cases": [
+    {
+      "id": "exact-path-api",
+      "labels": ["exact_path", "navigation"],
+      "operation": "search",
+      "query": "src/api.rs",
+      "baseline_hint": "src/api.rs",
+      "expected_paths": ["src/api.rs"],
+      "supported": true,
+      "designated_navigation": false
+    },
+    {
+      "id": "exact-path-readme",
+      "labels": ["exact_path", "documentation"],
+      "operation": "search",
+      "query": "README.md",
+      "baseline_hint": "README.md",
+      "expected_paths": ["README.md"],
+      "supported": true,
+      "designated_navigation": false
+    },
+    {
+      "id": "exact-path-config",
+      "labels": ["exact_path", "configuration"],
+      "operation": "search",
+      "query": "config/app.toml",
+      "baseline_hint": "config/app.toml",
+      "expected_paths": ["config/app.toml"],
+      "supported": true,
+      "designated_navigation": false
+    },
+    {
+      "id": "exact-path-malformed",
+      "labels": ["exact_path", "malformed_source"],
+      "operation": "search",
+      "query": "src/malformed.rs",
+      "baseline_hint": "src/malformed.rs",
+      "expected_paths": ["src/malformed.rs"],
+      "supported": true,
+      "designated_navigation": false
+    },
+    {
+      "id": "unique-runtime-context",
+      "labels": ["exact_unique_symbol", "supported_discovery", "navigation"],
+      "operation": "search",
+      "query": "RuntimeTaskContext",
+      "baseline_hint": "RuntimeTaskContext",
+      "expected_paths": ["src/service.rs"],
+      "supported": true,
+      "designated_navigation": true
+    },
+    {
+      "id": "unique-api-client",
+      "labels": ["exact_unique_symbol", "supported_discovery", "navigation"],
+      "operation": "search",
+      "query": "ApiClient",
+      "baseline_hint": "ApiClient",
+      "expected_paths": ["src/api.rs"],
+      "supported": true,
+      "designated_navigation": true
+    },
+    {
+      "id": "unique-background-worker",
+      "labels": ["exact_unique_symbol", "supported_discovery", "navigation"],
+      "operation": "search",
+      "query": "BackgroundWorker",
+      "baseline_hint": "BackgroundWorker",
+      "expected_paths": ["src/worker.rs"],
+      "supported": true,
+      "designated_navigation": true
+    },
+    {
+      "id": "unique-navigation-target",
+      "labels": ["exact_unique_symbol", "supported_discovery", "navigation"],
+      "operation": "search",
+      "query": "navigation_target",
+      "baseline_hint": "navigation_target",
+      "expected_paths": ["src/zeta_navigation.rs"],
+      "supported": true,
+      "designated_navigation": true
+    },
+    {
+      "id": "ambiguous-shared-symbol",
+      "labels": ["ambiguous_symbol", "supported_discovery", "navigation"],
+      "operation": "search",
+      "query": "Shared",
+      "baseline_hint": "pub struct Shared",
+      "expected_paths": ["src/duplicate_a.rs", "src/duplicate_b.rs"],
+      "supported": true,
+      "designated_navigation": true
+    },
+    {
+      "id": "discover-build-context",
+      "labels": ["supported_discovery", "navigation"],
+      "operation": "search",
+      "query": "build_context",
+      "baseline_hint": "build_context",
+      "expected_paths": ["src/service.rs"],
+      "supported": true,
+      "designated_navigation": true
+    },
+    {
+      "id": "discover-worker-run",
+      "labels": ["supported_discovery", "navigation"],
+      "operation": "search",
+      "query": "run_worker",
+      "baseline_hint": "run_worker",
+      "expected_paths": ["src/worker.rs"],
+      "supported": true,
+      "designated_navigation": true
+    },
+    {
+      "id": "discover-guide",
+      "labels": ["supported_discovery", "documentation"],
+      "operation": "search",
+      "query": "guide.md",
+      "baseline_hint": "guide.md",
+      "expected_paths": ["docs/guide.md"],
+      "supported": true,
+      "designated_navigation": true
+    },
+    {
+      "id": "discover-app-config",
+      "labels": ["supported_discovery", "configuration"],
+      "operation": "search",
+      "query": "app.toml",
+      "baseline_hint": "app.toml",
+      "expected_paths": ["config/app.toml"],
+      "supported": true,
+      "designated_navigation": true
+    },
+    {
+      "id": "discover-entrypoint",
+      "labels": ["supported_discovery", "configuration"],
+      "operation": "search",
+      "query": "entrypoint.sh",
+      "baseline_hint": "entrypoint.sh",
+      "expected_paths": ["scripts/entrypoint.sh"],
+      "supported": true,
+      "designated_navigation": true
+    },
+    {
+      "id": "dependency-service-api",
+      "labels": ["supported_discovery", "dependency", "navigation"],
+      "operation": "context",
+      "seed": {"type": "path", "value": "src/service.rs"},
+      "baseline_hint": "pub struct ApiClient",
+      "expected_paths": ["src/api.rs"],
+      "supported": true,
+      "designated_navigation": true
+    },
+    {
+      "id": "dependency-worker-service",
+      "labels": ["supported_discovery", "dependency", "navigation"],
+      "operation": "context",
+      "seed": {"type": "path", "value": "src/worker.rs"},
+      "baseline_hint": "pub fn build_context",
+      "expected_paths": ["src/service.rs"],
+      "supported": true,
+      "designated_navigation": true
+    },
+    {
+      "id": "documentation-architecture",
+      "labels": ["supported_discovery", "documentation"],
+      "operation": "context",
+      "seed": {"type": "path", "value": "docs/architecture.md"},
+      "baseline_hint": "Architecture Overview",
+      "expected_paths": ["docs/architecture.md"],
+      "supported": true,
+      "designated_navigation": true
+    },
+    {
+      "id": "configuration-context",
+      "labels": ["supported_discovery", "configuration"],
+      "operation": "context",
+      "seed": {"type": "path", "value": "config/app.toml"},
+      "baseline_hint": "timeout_ms",
+      "expected_paths": ["config/app.toml"],
+      "supported": true,
+      "designated_navigation": true
+    },
+    {
+      "id": "malformed-rust-visible",
+      "labels": ["supported_discovery", "malformed_source"],
+      "operation": "context",
+      "seed": {"type": "path", "value": "src/malformed.rs"},
+      "baseline_hint": "deliberately malformed",
+      "expected_paths": ["src/malformed.rs"],
+      "supported": true,
+      "designated_navigation": false
+    },
+    {
+      "id": "unsupported-macro-expansion",
+      "labels": ["unsupported_capability"],
+      "operation": "search",
+      "query": "derive_generated_route",
+      "baseline_hint": "derive_generated_route",
+      "expected_paths": ["src/macro_only.rs"],
+      "supported": false,
+      "designated_navigation": false
+    },
+    {
+      "id": "missing-index-actionable",
+      "labels": ["missing_index"],
+      "operation": "missing_index",
+      "baseline_hint": "RuntimeTaskContext",
+      "expected_paths": [],
+      "supported": true,
+      "designated_navigation": false
+    },
+    {
+      "id": "stale-index-visible",
+      "labels": ["stale_index"],
+      "operation": "stale_status",
+      "baseline_hint": "RuntimeTaskContext",
+      "expected_paths": [],
+      "supported": true,
+      "designated_navigation": false
+    },
+    {
+      "id": "search-result-truncation",
+      "labels": ["truncation", "ambiguous_symbol"],
+      "operation": "search_truncation",
+      "query": "Shared",
+      "baseline_hint": "pub struct Shared",
+      "expected_paths": ["src/duplicate_a.rs", "src/duplicate_b.rs"],
+      "supported": true,
+      "designated_navigation": false,
+      "expected_truncation": "results"
+    },
+    {
+      "id": "context-result-truncation",
+      "labels": ["truncation", "dependency"],
+      "operation": "context_truncation",
+      "seed": {"type": "path", "value": "src/service.rs"},
+      "baseline_hint": "pub struct ApiClient",
+      "expected_paths": ["src/api.rs"],
+      "supported": true,
+      "designated_navigation": false,
+      "expected_truncation": "results"
+    },
+    {
+      "id": "repeat-search-determinism",
+      "labels": ["determinism", "supported_discovery"],
+      "operation": "search",
+      "query": "RuntimeTaskContext",
+      "baseline_hint": "RuntimeTaskContext",
+      "expected_paths": ["src/service.rs"],
+      "supported": true,
+      "designated_navigation": false,
+      "require_repeat_determinism": true
+    },
+    {
+      "id": "repeat-context-determinism",
+      "labels": ["determinism", "dependency"],
+      "operation": "context",
+      "seed": {"type": "path", "value": "src/worker.rs"},
+      "baseline_hint": "pub fn build_context",
+      "expected_paths": ["src/service.rs"],
+      "supported": true,
+      "designated_navigation": false,
+      "require_repeat_determinism": true
+    }
+  ]
+}

--- a/tests/repository_graph_eval.rs
+++ b/tests/repository_graph_eval.rs
@@ -1,0 +1,29 @@
+#[path = "support/repository_graph_eval.rs"]
+mod evaluation;
+
+use evaluation::{AutomationRecommendation, run_evaluation};
+
+#[test]
+fn rg2_navigation_corpus_meets_usefulness_gates() {
+    let report = run_evaluation().unwrap();
+
+    assert!(report.case_count >= 20);
+    assert!(report.gates.all_passed);
+    assert!(report.gates.exact_path_recall_at_1.passed);
+    assert!(report.gates.exact_unique_symbol_recall_at_1.passed);
+    assert!(report.gates.supported_discovery_recall_at_10.passed);
+    assert!(report.gates.repeated_query_determinism.passed);
+    assert!(report.gates.no_correctness_regression.passed);
+    assert!(report.gates.navigation_context_reduction.passed);
+    assert!(matches!(
+        report.automation_recommendation,
+        AutomationRecommendation::EligibleForStrongerGuidance
+    ));
+
+    let json = serde_json::to_value(&report).unwrap();
+    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["corpus_version"], "rg2.5-v1");
+    assert!(json["distributions"]["graph_cold_latency_us"].is_array());
+    assert!(json["distributions"]["graph_warm_latency_us"].is_array());
+    assert!(json["distributions"]["graph_response_bytes"].is_array());
+}

--- a/tests/support/repository_graph_eval.rs
+++ b/tests/support/repository_graph_eval.rs
@@ -1,0 +1,818 @@
+use std::{
+    collections::{BTreeSet, HashSet},
+    num::{NonZeroU32, NonZeroU64},
+    path::{Path, PathBuf},
+    time::Instant,
+};
+
+use anyhow::{Context, Result, bail};
+use ferrus::repository_graph::{
+    config::RepositoryGraphConfig,
+    domain::{
+        BuildId, NodeId, PublishedViewName, QueryBudget, RepoPath, RepositoryId,
+        RepositoryNamespace, RepositoryRef, SemanticKey,
+    },
+    index::{IndexCoordinator, IndexRequest, active_extractor_identities},
+    ports::GraphQuery,
+    query::{
+        ContextPolicy, ContextRequest, ContextSeed, EdgeDirection, PageRequest, QueryScope,
+        SearchRequest, SnapshotSelector, StatusRequest, TruncationReason,
+    },
+    query_sqlite::{FreshnessComparison, SqliteGraphQuery, default_budget},
+    source::{FilesystemRepositorySource, SourceDiscoveryContext},
+    sqlite::{
+        OpenQuerySidecarResult, OpenSidecarResult, Sidecar, open_for_build_at, open_for_query_at,
+    },
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+use tempfile::TempDir;
+
+const CORPUS_JSON: &str = include_str!("../fixtures/repository_graph_eval/cases.json");
+const MIN_CASES: usize = 20;
+const DISCOVERY_RECALL_THRESHOLD: f64 = 0.90;
+const NAVIGATION_REDUCTION_THRESHOLD: f64 = 0.20;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EvalCorpus {
+    schema_version: u32,
+    corpus_version: String,
+    cases: Vec<EvalCase>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EvalCase {
+    id: String,
+    labels: Vec<String>,
+    operation: EvalOperation,
+    query: Option<String>,
+    seed: Option<SeedSpec>,
+    baseline_hint: String,
+    expected_paths: Vec<String>,
+    supported: bool,
+    designated_navigation: bool,
+    #[serde(default)]
+    expected_truncation: Option<TruncationReason>,
+    #[serde(default)]
+    require_repeat_determinism: bool,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum EvalOperation {
+    Search,
+    Context,
+    MissingIndex,
+    StaleStatus,
+    SearchTruncation,
+    ContextTruncation,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(
+    tag = "type",
+    content = "value",
+    rename_all = "snake_case",
+    deny_unknown_fields
+)]
+enum SeedSpec {
+    Node(String),
+    Symbol(String),
+    Path(String),
+}
+
+#[derive(Debug, Serialize)]
+pub struct EvalReport {
+    pub schema_version: u32,
+    pub corpus_version: String,
+    pub fixture_digest: String,
+    pub case_count: usize,
+    pub cases: Vec<CaseReport>,
+    pub distributions: EvaluationDistributions,
+    pub gates: QualityGates,
+    pub automation_recommendation: AutomationRecommendation,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CaseReport {
+    pub id: String,
+    pub labels: Vec<String>,
+    pub supported: bool,
+    pub designated_navigation: bool,
+    pub expected_paths: Vec<String>,
+    pub returned_paths: Vec<String>,
+    pub truncation: Option<TruncationReason>,
+    pub repeat_required: bool,
+    pub repeat_semantically_identical: bool,
+    pub graph_cold: NavigationMetrics,
+    pub graph_warm: NavigationMetrics,
+    pub baseline: NavigationMetrics,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct NavigationMetrics {
+    pub success: bool,
+    pub time_to_first_relevant_us: u64,
+    pub tool_calls: u64,
+    pub files_read: u64,
+    pub context_bytes: u64,
+    pub graph_query_bytes: u64,
+    pub total_duration_us: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct EvaluationDistributions {
+    pub graph_cold_latency_us: Vec<u64>,
+    pub graph_warm_latency_us: Vec<u64>,
+    pub graph_response_bytes: Vec<u64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct QualityGates {
+    pub exact_path_recall_at_1: GateResult,
+    pub exact_unique_symbol_recall_at_1: GateResult,
+    pub supported_discovery_recall_at_10: GateResult,
+    pub repeated_query_determinism: GateResult,
+    pub no_correctness_regression: GateResult,
+    pub navigation_context_reduction: ReductionGateResult,
+    pub all_passed: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct GateResult {
+    pub passed: bool,
+    pub observed: f64,
+    pub threshold: f64,
+    pub evaluated_cases: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ReductionGateResult {
+    pub passed: bool,
+    pub median_files_read_reduction: f64,
+    pub median_context_bytes_reduction: f64,
+    pub threshold: f64,
+    pub evaluated_cases: usize,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AutomationRecommendation {
+    EligibleForStrongerGuidance,
+    KeepStrongerGuidanceDisabled,
+}
+
+struct EvalFixture {
+    source_dir: TempDir,
+    _sidecar_dir: TempDir,
+    sidecar: Sidecar,
+    config: RepositoryGraphConfig,
+    repository: RepositoryRef,
+    view: PublishedViewName,
+    files: Vec<RepoPath>,
+    freshness: FreshnessComparison,
+    missing_sidecar: PathBuf,
+    fixture_digest: String,
+}
+
+#[derive(Clone)]
+struct GraphObservation {
+    response: serde_json::Value,
+    paths: Vec<String>,
+    truncation: Option<TruncationReason>,
+    metrics: NavigationMetrics,
+}
+
+pub fn run_evaluation() -> Result<EvalReport> {
+    let corpus: EvalCorpus = serde_json::from_str(CORPUS_JSON)
+        .context("repository graph evaluation corpus is invalid")?;
+    validate_corpus(&corpus)?;
+    let fixture = EvalFixture::new()?;
+    let mut reports = Vec::with_capacity(corpus.cases.len());
+
+    for case in &corpus.cases {
+        let cold = fixture.run_graph(case)?;
+        let warm = fixture.run_graph(case)?;
+        let repeat_semantically_identical = cold.response == warm.response;
+        let baseline = fixture.run_baseline(case)?;
+        reports.push(CaseReport {
+            id: case.id.clone(),
+            labels: case.labels.clone(),
+            supported: case.supported,
+            designated_navigation: case.designated_navigation,
+            expected_paths: case.expected_paths.clone(),
+            returned_paths: cold.paths.clone(),
+            truncation: cold.truncation,
+            repeat_required: case.require_repeat_determinism,
+            repeat_semantically_identical,
+            graph_cold: cold.metrics,
+            graph_warm: warm.metrics,
+            baseline,
+        });
+    }
+
+    let gates = quality_gates(&reports);
+    let automation_recommendation = if gates.all_passed {
+        AutomationRecommendation::EligibleForStrongerGuidance
+    } else {
+        AutomationRecommendation::KeepStrongerGuidanceDisabled
+    };
+    let mut cold_latency = reports
+        .iter()
+        .map(|case| case.graph_cold.total_duration_us)
+        .collect::<Vec<_>>();
+    let mut warm_latency = reports
+        .iter()
+        .map(|case| case.graph_warm.total_duration_us)
+        .collect::<Vec<_>>();
+    let mut response_bytes = reports
+        .iter()
+        .map(|case| case.graph_warm.graph_query_bytes)
+        .collect::<Vec<_>>();
+    cold_latency.sort_unstable();
+    warm_latency.sort_unstable();
+    response_bytes.sort_unstable();
+
+    Ok(EvalReport {
+        schema_version: corpus.schema_version,
+        corpus_version: corpus.corpus_version,
+        fixture_digest: fixture.fixture_digest,
+        case_count: reports.len(),
+        cases: reports,
+        distributions: EvaluationDistributions {
+            graph_cold_latency_us: cold_latency,
+            graph_warm_latency_us: warm_latency,
+            graph_response_bytes: response_bytes,
+        },
+        gates,
+        automation_recommendation,
+    })
+}
+
+fn validate_corpus(corpus: &EvalCorpus) -> Result<()> {
+    if corpus.schema_version != 1 {
+        bail!("unsupported repository graph evaluation corpus version");
+    }
+    if corpus.cases.len() < MIN_CASES {
+        bail!("repository graph evaluation corpus requires at least {MIN_CASES} cases");
+    }
+    let mut ids = HashSet::new();
+    for case in &corpus.cases {
+        if case.id.trim().is_empty() || !ids.insert(case.id.as_str()) {
+            bail!("repository graph evaluation case ids must be non-empty and unique");
+        }
+        if case.labels.is_empty() {
+            bail!("repository graph evaluation cases require labels");
+        }
+        match case.operation {
+            EvalOperation::Search | EvalOperation::SearchTruncation
+                if case.query.as_deref().is_none_or(str::is_empty) =>
+            {
+                bail!("search evaluation cases require a query")
+            }
+            EvalOperation::Context | EvalOperation::ContextTruncation if case.seed.is_none() => {
+                bail!("context evaluation cases require a seed")
+            }
+            _ => {}
+        }
+    }
+    for required in [
+        "exact_path",
+        "exact_unique_symbol",
+        "ambiguous_symbol",
+        "supported_discovery",
+        "dependency",
+        "documentation",
+        "configuration",
+        "malformed_source",
+        "unsupported_capability",
+        "missing_index",
+        "stale_index",
+        "truncation",
+        "determinism",
+    ] {
+        if !corpus
+            .cases
+            .iter()
+            .any(|case| case.labels.iter().any(|label| label == required))
+        {
+            bail!("repository graph evaluation corpus is missing the {required} label");
+        }
+    }
+    Ok(())
+}
+
+impl EvalFixture {
+    fn new() -> Result<Self> {
+        let source_dir = tempfile::tempdir()?;
+        write_fixture(source_dir.path())?;
+        let repository = RepositoryRef {
+            namespace: RepositoryNamespace::new("local:evaluation")?,
+            repository_id: RepositoryId::new("rg2-navigation")?,
+        };
+        let config = RepositoryGraphConfig::default();
+        let source = discover(source_dir.path(), &repository, &config)?;
+        let files = source
+            .manifest()
+            .files
+            .iter()
+            .map(|file| file.path.clone())
+            .collect::<Vec<_>>();
+        let fixture_digest = fixture_digest(source_dir.path(), &files)?;
+        let freshness = FreshnessComparison::from_manifest(source.manifest());
+        let sidecar_dir = tempfile::tempdir()?;
+        let sidecar_path = sidecar_dir.path().join("repo-graph.db");
+        let mut sidecar = match open_for_build_at(&sidecar_path)? {
+            OpenSidecarResult::Ready(sidecar) => sidecar,
+            OpenSidecarResult::RequiresRebuild(_) => bail!("new evaluation sidecar needs rebuild"),
+        };
+        let view = PublishedViewName::new("canonical")?;
+        IndexCoordinator::new(&mut sidecar).index(
+            &source,
+            &config,
+            IndexRequest {
+                build_id: BuildId::new("eval-build")?,
+                view_name: view.clone(),
+                force_full: true,
+            },
+        )?;
+        let missing_sidecar = sidecar_dir.path().join("missing-repo-graph.db");
+        Ok(Self {
+            source_dir,
+            _sidecar_dir: sidecar_dir,
+            sidecar,
+            config,
+            repository,
+            view,
+            files,
+            freshness,
+            missing_sidecar,
+            fixture_digest,
+        })
+    }
+
+    fn run_graph(&self, case: &EvalCase) -> Result<GraphObservation> {
+        let started = Instant::now();
+        let (response, paths, truncation) = match case.operation {
+            EvalOperation::Search | EvalOperation::SearchTruncation => {
+                let budget =
+                    self.budget(matches!(case.operation, EvalOperation::SearchTruncation))?;
+                let request = SearchRequest {
+                    scope: self.scope(budget),
+                    text: case.query.clone().expect("validated search query"),
+                    node_kinds: vec![],
+                    paths: vec![],
+                    page: PageRequest { cursor: None },
+                };
+                let query = self.query(self.freshness.clone());
+                let response = query.search(&request)?;
+                let paths = response
+                    .data
+                    .hits
+                    .iter()
+                    .filter_map(|hit| hit.path.as_ref().map(ToString::to_string))
+                    .collect::<Vec<_>>();
+                let truncation = response.page.truncation.as_ref().map(|value| value.reason);
+                (
+                    serde_json::to_value(response)?,
+                    stable_unique(paths),
+                    truncation,
+                )
+            }
+            EvalOperation::Context | EvalOperation::ContextTruncation => {
+                let budget =
+                    self.budget(matches!(case.operation, EvalOperation::ContextTruncation))?;
+                let request = ContextRequest {
+                    scope: self.scope(budget),
+                    seeds: vec![context_seed(
+                        case.seed.as_ref().expect("validated context seed"),
+                    )?],
+                    policy: ContextPolicy {
+                        direction: EdgeDirection::Both,
+                        edge_kinds: vec![],
+                        include_unresolved: false,
+                        include_external: false,
+                    },
+                    page: PageRequest { cursor: None },
+                };
+                let query = self.query(self.freshness.clone());
+                let response = query.context(&request)?;
+                let paths = response
+                    .data
+                    .items
+                    .iter()
+                    .map(|item| item.path.to_string())
+                    .collect::<Vec<_>>();
+                let truncation = response.page.truncation.as_ref().map(|value| value.reason);
+                (
+                    serde_json::to_value(response)?,
+                    stable_unique(paths),
+                    truncation,
+                )
+            }
+            EvalOperation::MissingIndex => {
+                let state = match open_for_query_at(&self.missing_sidecar)? {
+                    OpenQuerySidecarResult::Absent => "not_built",
+                    _ => "unexpected",
+                };
+                (
+                    serde_json::json!({
+                        "availability": state,
+                        "recommended_action": "index"
+                    }),
+                    vec![],
+                    None,
+                )
+            }
+            EvalOperation::StaleStatus => {
+                let changed = self.stale_comparison()?;
+                let query = self.query(changed);
+                let response = query.status(&StatusRequest {
+                    scope: self.scope(default_budget(&self.config.query_limits)?),
+                })?;
+                (serde_json::to_value(response)?, vec![], None)
+            }
+        };
+        let response_bytes = serde_json::to_vec(&response)?.len() as u64;
+        let success = graph_success(case, &response, &paths, truncation);
+        let elapsed = elapsed_us(started);
+        Ok(GraphObservation {
+            response,
+            paths,
+            truncation,
+            metrics: NavigationMetrics {
+                success,
+                time_to_first_relevant_us: elapsed,
+                tool_calls: 1,
+                files_read: 0,
+                context_bytes: response_bytes,
+                graph_query_bytes: response_bytes,
+                total_duration_us: elapsed,
+            },
+        })
+    }
+
+    fn run_baseline(&self, case: &EvalCase) -> Result<NavigationMetrics> {
+        let started = Instant::now();
+        if case.labels.iter().any(|label| label == "exact_path") {
+            let success = self
+                .files
+                .iter()
+                .any(|path| path.as_str() == case.baseline_hint);
+            let elapsed = elapsed_us(started);
+            return Ok(NavigationMetrics {
+                success,
+                time_to_first_relevant_us: elapsed,
+                tool_calls: 1,
+                files_read: 0,
+                context_bytes: 0,
+                graph_query_bytes: 0,
+                total_duration_us: elapsed,
+            });
+        }
+        let mut files_read = 0_u64;
+        let mut context_bytes = 0_u64;
+        let mut matches = BTreeSet::new();
+        for path in &self.files {
+            let bytes = std::fs::read(self.source_dir.path().join(path.as_str()))?;
+            files_read += 1;
+            context_bytes += bytes.len() as u64;
+            let is_match = String::from_utf8_lossy(&bytes).contains(&case.baseline_hint)
+                || path.as_str().contains(&case.baseline_hint);
+            if is_match {
+                matches.insert(path.as_str().to_string());
+            }
+            if baseline_complete(case, &matches) {
+                break;
+            }
+        }
+        let success = if case.expected_paths.is_empty() {
+            true
+        } else {
+            case.expected_paths
+                .iter()
+                .all(|path| matches.contains(path))
+        };
+        let elapsed = elapsed_us(started);
+        Ok(NavigationMetrics {
+            success,
+            time_to_first_relevant_us: elapsed,
+            tool_calls: files_read,
+            files_read,
+            context_bytes,
+            graph_query_bytes: 0,
+            total_duration_us: elapsed,
+        })
+    }
+
+    fn query(&self, freshness: FreshnessComparison) -> SqliteGraphQuery<'_> {
+        SqliteGraphQuery::new(
+            &self.sidecar,
+            self.config.query_limits.clone(),
+            Some(freshness),
+        )
+    }
+
+    fn scope(&self, budget: QueryBudget) -> QueryScope {
+        QueryScope::current(
+            self.repository.clone(),
+            SnapshotSelector::Published(self.view.clone()),
+            budget,
+        )
+    }
+
+    fn budget(&self, truncated: bool) -> Result<QueryBudget> {
+        let defaults = default_budget(&self.config.query_limits)?;
+        if !truncated {
+            return Ok(defaults);
+        }
+        Ok(QueryBudget::new(
+            NonZeroU32::new(1).expect("one is non-zero"),
+            NonZeroU64::new(self.config.query_limits.max_bytes)
+                .context("evaluation query byte limit is zero")?,
+            NonZeroU32::new(self.config.query_limits.max_depth)
+                .context("evaluation query depth is zero")?,
+            NonZeroU64::new(self.config.query_limits.max_duration_ms)
+                .context("evaluation query duration is zero")?,
+            NonZeroU32::new(self.config.query_limits.max_diagnostics)
+                .context("evaluation query diagnostic limit is zero")?,
+        ))
+    }
+
+    fn stale_comparison(&self) -> Result<FreshnessComparison> {
+        let path = self.source_dir.path().join("zz-stale-marker.rs");
+        std::fs::write(&path, "pub struct StaleMarker;\n")?;
+        let changed = discover(self.source_dir.path(), &self.repository, &self.config)?;
+        let comparison = FreshnessComparison::from_manifest(changed.manifest());
+        std::fs::remove_file(path)?;
+        Ok(comparison)
+    }
+}
+
+fn graph_success(
+    case: &EvalCase,
+    response: &serde_json::Value,
+    paths: &[String],
+    truncation: Option<TruncationReason>,
+) -> bool {
+    match case.operation {
+        EvalOperation::MissingIndex => response["availability"] == "not_built",
+        EvalOperation::StaleStatus => response["freshness"]["freshness"] == "stale",
+        EvalOperation::SearchTruncation | EvalOperation::ContextTruncation => {
+            truncation == case.expected_truncation
+        }
+        _ if !case.supported => paths.is_empty(),
+        _ => case
+            .expected_paths
+            .iter()
+            .all(|expected| paths.iter().any(|path| path == expected)),
+    }
+}
+
+fn baseline_complete(case: &EvalCase, matches: &BTreeSet<String>) -> bool {
+    !case.expected_paths.is_empty()
+        && case
+            .expected_paths
+            .iter()
+            .all(|path| matches.contains(path))
+}
+
+fn quality_gates(cases: &[CaseReport]) -> QualityGates {
+    let exact_path = recall_gate(cases, "exact_path", 1, 1.0);
+    let exact_symbol = recall_gate(cases, "exact_unique_symbol", 1, 1.0);
+    let discovery = recall_gate(cases, "supported_discovery", 10, DISCOVERY_RECALL_THRESHOLD);
+    let deterministic_cases = cases
+        .iter()
+        .filter(|case| case.repeat_required)
+        .collect::<Vec<_>>();
+    let deterministic_passes = deterministic_cases
+        .iter()
+        .filter(|case| case.repeat_semantically_identical)
+        .count();
+    let deterministic = ratio_gate(deterministic_passes, deterministic_cases.len(), 1.0);
+    let regression_cases = cases
+        .iter()
+        .filter(|case| {
+            case.supported
+                && case.baseline.success
+                && !case.expected_paths.is_empty()
+                && !case.labels.iter().any(|label| label == "truncation")
+        })
+        .collect::<Vec<_>>();
+    let regression_passes = regression_cases
+        .iter()
+        .filter(|case| case.graph_cold.success)
+        .count();
+    let no_regression = ratio_gate(regression_passes, regression_cases.len(), 1.0);
+    let reduction = reduction_gate(cases);
+    let all_passed = exact_path.passed
+        && exact_symbol.passed
+        && discovery.passed
+        && deterministic.passed
+        && no_regression.passed
+        && reduction.passed;
+    QualityGates {
+        exact_path_recall_at_1: exact_path,
+        exact_unique_symbol_recall_at_1: exact_symbol,
+        supported_discovery_recall_at_10: discovery,
+        repeated_query_determinism: deterministic,
+        no_correctness_regression: no_regression,
+        navigation_context_reduction: reduction,
+        all_passed,
+    }
+}
+
+fn recall_gate(cases: &[CaseReport], label: &str, limit: usize, threshold: f64) -> GateResult {
+    let selected = cases
+        .iter()
+        .filter(|case| case.labels.iter().any(|candidate| candidate == label))
+        .collect::<Vec<_>>();
+    let passes = selected
+        .iter()
+        .filter(|case| {
+            let returned = case
+                .returned_paths
+                .iter()
+                .take(limit)
+                .collect::<BTreeSet<_>>();
+            !case.expected_paths.is_empty()
+                && case
+                    .expected_paths
+                    .iter()
+                    .all(|expected| returned.iter().any(|path| path.as_str() == expected))
+        })
+        .count();
+    ratio_gate(passes, selected.len(), threshold)
+}
+
+fn ratio_gate(passes: usize, total: usize, threshold: f64) -> GateResult {
+    let observed = if total == 0 {
+        0.0
+    } else {
+        passes as f64 / total as f64
+    };
+    GateResult {
+        passed: total > 0 && observed >= threshold,
+        observed,
+        threshold,
+        evaluated_cases: total,
+    }
+}
+
+fn reduction_gate(cases: &[CaseReport]) -> ReductionGateResult {
+    let selected = cases
+        .iter()
+        .filter(|case| case.designated_navigation && case.baseline.success)
+        .collect::<Vec<_>>();
+    let mut file_reductions = selected
+        .iter()
+        .filter(|case| case.baseline.files_read > 0)
+        .map(|case| 1.0 - case.graph_warm.files_read as f64 / case.baseline.files_read as f64)
+        .collect::<Vec<_>>();
+    let mut byte_reductions = selected
+        .iter()
+        .filter(|case| case.baseline.context_bytes > 0)
+        .map(|case| 1.0 - case.graph_warm.context_bytes as f64 / case.baseline.context_bytes as f64)
+        .collect::<Vec<_>>();
+    let median_files = median(&mut file_reductions);
+    let median_bytes = median(&mut byte_reductions);
+    ReductionGateResult {
+        passed: !selected.is_empty()
+            && (median_files >= NAVIGATION_REDUCTION_THRESHOLD
+                || median_bytes >= NAVIGATION_REDUCTION_THRESHOLD),
+        median_files_read_reduction: median_files,
+        median_context_bytes_reduction: median_bytes,
+        threshold: NAVIGATION_REDUCTION_THRESHOLD,
+        evaluated_cases: selected.len(),
+    }
+}
+
+fn median(values: &mut [f64]) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    values.sort_by(f64::total_cmp);
+    let middle = values.len() / 2;
+    if values.len().is_multiple_of(2) {
+        (values[middle - 1] + values[middle]) / 2.0
+    } else {
+        values[middle]
+    }
+}
+
+fn context_seed(seed: &SeedSpec) -> Result<ContextSeed> {
+    match seed {
+        SeedSpec::Node(value) => Ok(ContextSeed::Node(NodeId::new(value)?)),
+        SeedSpec::Symbol(value) => Ok(ContextSeed::Symbol(SemanticKey::new(value)?)),
+        SeedSpec::Path(value) => Ok(ContextSeed::Path(RepoPath::new(value)?)),
+    }
+}
+
+fn discover(
+    root: &Path,
+    repository: &RepositoryRef,
+    config: &RepositoryGraphConfig,
+) -> Result<FilesystemRepositorySource> {
+    let identities = active_extractor_identities(config)?;
+    let context = SourceDiscoveryContext::from_config(repository.clone(), config, &identities)?;
+    Ok(FilesystemRepositorySource::discover(root, context)?)
+}
+
+fn stable_unique(paths: Vec<String>) -> Vec<String> {
+    let mut seen = HashSet::new();
+    paths
+        .into_iter()
+        .filter(|path| seen.insert(path.clone()))
+        .collect()
+}
+
+fn elapsed_us(started: Instant) -> u64 {
+    u64::try_from(started.elapsed().as_micros()).unwrap_or(u64::MAX)
+}
+
+fn fixture_digest(root: &Path, files: &[RepoPath]) -> Result<String> {
+    let mut hash = Sha256::new();
+    hash.update(CORPUS_JSON.as_bytes());
+    for path in files {
+        hash.update(path.as_str().as_bytes());
+        hash.update([0]);
+        hash.update(std::fs::read(root.join(path.as_str()))?);
+        hash.update([0]);
+    }
+    Ok(format!("sha256:{}", hex_lower(&hash.finalize())))
+}
+
+fn hex_lower(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    output
+}
+
+fn write_fixture(root: &Path) -> Result<()> {
+    for directory in ["config", "docs", "scripts", "src"] {
+        std::fs::create_dir_all(root.join(directory))?;
+    }
+    std::fs::write(
+        root.join("README.md"),
+        "# Repository Graph Evaluation\nDeterministic navigation fixture.\n",
+    )?;
+    std::fs::write(
+        root.join("docs/architecture.md"),
+        "# Architecture Overview\nThe service depends on the API boundary.\n",
+    )?;
+    std::fs::write(
+        root.join("docs/guide.md"),
+        "# Navigation Guide\nUse the worker through the service layer.\n",
+    )?;
+    std::fs::write(
+        root.join("config/app.toml"),
+        "service = \"repository-graph\"\ntimeout_ms = 250\n",
+    )?;
+    std::fs::write(
+        root.join("scripts/entrypoint.sh"),
+        "#!/bin/sh\nexec ferrus \"$@\"\n",
+    )?;
+    std::fs::write(
+        root.join("src/lib.rs"),
+        "pub mod api;\npub mod duplicate_a;\npub mod duplicate_b;\npub mod malformed;\npub mod service;\npub mod worker;\npub mod zeta_navigation;\n",
+    )?;
+    std::fs::write(
+        root.join("src/api.rs"),
+        "pub struct ApiClient;\nimpl ApiClient { pub fn request(&self) -> bool { true } }\n",
+    )?;
+    std::fs::write(
+        root.join("src/service.rs"),
+        "use crate::api::ApiClient;\npub struct RuntimeTaskContext { pub api: ApiClient }\npub fn build_context(api: ApiClient) -> RuntimeTaskContext { RuntimeTaskContext { api } }\n",
+    )?;
+    std::fs::write(
+        root.join("src/worker.rs"),
+        "use crate::service::{build_context, RuntimeTaskContext};\npub struct BackgroundWorker;\npub fn run_worker() -> fn(crate::api::ApiClient) -> RuntimeTaskContext { build_context }\n",
+    )?;
+    std::fs::write(root.join("src/duplicate_a.rs"), "pub struct Shared;\n")?;
+    std::fs::write(root.join("src/duplicate_b.rs"), "pub struct Shared;\n")?;
+    std::fs::write(
+        root.join("src/malformed.rs"),
+        "// deliberately malformed\npub fn broken( {\n",
+    )?;
+    std::fs::write(
+        root.join("src/macro_only.rs"),
+        "// derive_generated_route exists only in unindexed comment text\npub fn macro_host() {}\n",
+    )?;
+    std::fs::write(
+        root.join("src/zeta_navigation.rs"),
+        "pub fn navigation_target() -> &'static str { \"target\" }\n",
+    )?;
+    for index in 0..24 {
+        std::fs::write(
+            root.join(format!("src/filler_{index:02}.rs")),
+            format!("pub struct Filler{index:02};\n"),
+        )?;
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary
Exposes the published local repository graph to Ferrus Supervisor and Executor agents through a small, read-only, snapshot-aware MCP retrieval surface. It adds deterministic search and bounded context assembly, freshness and evidence reporting, safe on-demand snippets, and evaluation tooling that measures whether repository context actually reduces navigation work, latency, and context volume.

## Type
- [ ] Bug fix
- [x] Feature
- [x] Enhancement
- [ ] Performance
- [ ] Documentation
- [ ] Refactor
- [ ] Security
- [ ] Breaking change

## Workflow impact (if applicable)
Does this change affect the Supervisor → Executor → Reviewer flow?

- [x] No impact
- [ ] Minor change (does not alter lifecycle semantics)
- [ ] Changes behavior of an existing step
- [ ] Introduces new state/transition

If yes, briefly explain:

## Checklist
- [x] I added/updated tests where it makes sense
- [x] I updated docs/examples if needed
- [x] This change is backwards-compatible (or clearly marked as breaking)
- [x] I ran formatting/lints locally (if applicable)
