### PR TITLE
Use three-way merges for approved task integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,7 +581,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferrus"
-version = "0.4.0-alpha.1"
+version = "0.4.0-alpha.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferrus"
-version = "0.4.0-alpha.1"
+version = "0.4.0-alpha.2"
 edition = "2024"
 rust-version = "1.95.0"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ferrus
 
-[![Ferrus version](https://img.shields.io/badge/ferrus-0.4.0--alpha.1-orange)](https://crates.io/crates/ferrus)
+[![Ferrus version](https://img.shields.io/badge/ferrus-0.4.0--alpha.2-orange)](https://crates.io/crates/ferrus)
 [![Rust version](https://img.shields.io/badge/rustc-1.95+-964B00)](https://releases.rs/docs/1.95.0/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/ferrus-dev/ferrus/blob/main/LICENSE)
 [![Rust](https://github.com/ferrus-dev/ferrus/actions/workflows/rust.yml/badge.svg)](https://github.com/ferrus-dev/ferrus/actions/workflows/rust.yml)
@@ -69,12 +69,12 @@ Install:
 ```sh
 cargo install ferrus
 # or on Linux/macOS:
-curl -fsSL https://github.com/ferrus-dev/ferrus/releases/latest/download/install.sh | sh
+curl -fsSL https://ferrus.dev/cli/install.sh | sh
 ```
 
 ```powershell
 # or on Windows:
-iwr https://github.com/ferrus-dev/ferrus/releases/latest/download/install.ps1 -useb | iex
+iwr https://ferrus.dev/cli/install.ps1 -useb | iex
 ```
 
 Run:

--- a/src/server/tools/approve.rs
+++ b/src/server/tools/approve.rs
@@ -483,16 +483,46 @@ async fn merge_trees(
     ours: &str,
     theirs: &str,
 ) -> Result<String> {
+    // Older Git versions require commit operands for merge-tree --write-tree.
+    // Give both sides the explicit baseline as their common parent.
+    let baseline_commit = commit_tree(project_root, baseline, None, "baseline").await?;
+    let ours_commit = commit_tree(project_root, ours, Some(&baseline_commit), "canonical").await?;
+    let theirs_commit =
+        commit_tree(project_root, theirs, Some(&baseline_commit), "submitted").await?;
     let output = Command::new("git")
         .arg("-C")
         .arg(project_root)
-        .args(["merge-tree", "--write-tree", "--messages", "--merge-base"])
-        .arg(baseline)
-        .arg(ours)
-        .arg(theirs)
+        .args(["merge-tree", "--write-tree", "--messages"])
+        .arg(ours_commit)
+        .arg(theirs_commit)
         .output()
         .await?;
     git_stdout(output, "three-way merge approved task")
+}
+
+async fn commit_tree(
+    project_root: &Path,
+    tree: &str,
+    parent: Option<&str>,
+    role: &str,
+) -> Result<String> {
+    let mut command = Command::new("git");
+    command
+        .arg("-C")
+        .arg(project_root)
+        .env("GIT_AUTHOR_NAME", "Ferrus")
+        .env("GIT_AUTHOR_EMAIL", "ferrus@example.invalid")
+        .env("GIT_COMMITTER_NAME", "Ferrus")
+        .env("GIT_COMMITTER_EMAIL", "ferrus@example.invalid")
+        .args(["commit-tree", tree]);
+    if let Some(parent) = parent {
+        command.args(["-p", parent]);
+    }
+    let output = command
+        .args(["-m", &format!("Ferrus temporary {role} tree")])
+        .output()
+        .await?;
+    git_stdout(output, &format!("wrap {role} tree in a temporary commit"))
 }
 
 async fn materialize_tree(

--- a/src/server/tools/approve.rs
+++ b/src/server/tools/approve.rs
@@ -360,18 +360,12 @@ async fn apply_approved_patch(
 
     let snapshot = CanonicalWorkspaceSnapshot::capture(project_root).await?;
     if let Err(error) = integrate_patch_three_way(context, project_root, &snapshot).await {
-        let restore_error = snapshot.restore(project_root).await.err();
         let detail = bounded_git_detail(&error.to_string());
         let reason = format!(
-            "Cannot approve task {} because its submitted changes could not be merged into {}: {}{}",
+            "Cannot approve task {} because its submitted changes could not be merged into {}: {}",
             context.task_id,
             project_root.display(),
-            detail,
-            restore_error
-                .map(|error| format!(
-                    "\n\nAdditionally failed to restore the pre-integration canonical workspace: {error}"
-                ))
-                .unwrap_or_default()
+            detail
         );
         write_integration_error(context, &reason).await?;
         project::record_task_integration_failed_best_effort(
@@ -405,7 +399,15 @@ async fn integrate_patch_three_way(
         _ => submitted_tree_from_patch(context, project_root, &baseline).await?,
     };
     let merged = merge_trees(project_root, &baseline, &snapshot.tree, &submitted).await?;
-    materialize_tree(project_root, &snapshot.tree, &merged).await
+    if let Err(error) = materialize_tree(project_root, &snapshot.tree, &merged).await {
+        if let Err(restore_error) = snapshot.restore(project_root).await {
+            anyhow::bail!(
+                "{error}\n\nAdditionally failed to restore the pre-integration canonical workspace: {restore_error}"
+            );
+        }
+        return Err(error);
+    }
+    Ok(())
 }
 
 async fn task_baseline_tree(

--- a/src/server/tools/approve.rs
+++ b/src/server/tools/approve.rs
@@ -4,10 +4,11 @@ use neva::prelude::*;
 use std::collections::HashSet;
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::Output;
+use std::process::{Output, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
 use tracing::info;
 
@@ -358,36 +359,46 @@ async fn apply_approved_patch(
         return Ok(None);
     }
 
-    let snapshot = CanonicalWorkspaceSnapshot::capture(project_root).await?;
-    if let Err(error) = integrate_patch_three_way(context, project_root, &snapshot).await {
-        let detail = bounded_git_detail(&error.to_string());
-        let reason = format!(
-            "Cannot approve task {} because its submitted changes could not be merged into {}: {}",
-            context.task_id,
-            project_root.display(),
-            detail
-        );
-        write_integration_error(context, &reason).await?;
-        project::record_task_integration_failed_best_effort(
-            &context.task_id,
-            context.run_id.as_deref(),
-            &reason,
-        )
-        .await;
-        anyhow::bail!(
-            "{reason}\n\nIntegration error was saved to {}/INTEGRATION_ERROR.md. \
-             Reject this review with the conflict details so an Executor can address it.",
-            context.run_dir
-        );
+    let integration = async {
+        let (baseline, submitted) = task_submission_trees(context, project_root).await?;
+        let submitted_changes = tree_changes(project_root, &baseline, &submitted).await?;
+        reject_sparse_checkout_exclusions(project_root, &submitted_changes).await?;
+        let snapshot = CanonicalWorkspaceSnapshot::capture(project_root).await?;
+        integrate_patch_three_way(project_root, &snapshot, &baseline, &submitted).await?;
+        Ok::<_, anyhow::Error>(snapshot)
     }
+    .await;
+    let snapshot = match integration {
+        Ok(snapshot) => snapshot,
+        Err(error) => {
+            let detail = bounded_git_detail(&error.to_string());
+            let reason = format!(
+                "Cannot approve task {} because its submitted changes could not be merged into {}: {}",
+                context.task_id,
+                project_root.display(),
+                detail
+            );
+            write_integration_error(context, &reason).await?;
+            project::record_task_integration_failed_best_effort(
+                &context.task_id,
+                context.run_id.as_deref(),
+                &reason,
+            )
+            .await;
+            anyhow::bail!(
+                "{reason}\n\nIntegration error was saved to {}/INTEGRATION_ERROR.md. \
+             Reject this review with the conflict details so an Executor can address it.",
+                context.run_dir
+            );
+        }
+    };
     Ok(Some(snapshot))
 }
 
-async fn integrate_patch_three_way(
+async fn task_submission_trees(
     context: &RuntimeTaskContext,
     project_root: &Path,
-    snapshot: &CanonicalWorkspaceSnapshot,
-) -> Result<()> {
+) -> Result<(String, String)> {
     let frozen_submitted = context.repository_view.lifecycle
         == crate::repository_graph::domain::TaskViewLifecycle::FrozenSubmitted;
     let baseline = task_baseline_tree(project_root, &context.task_id, frozen_submitted).await?;
@@ -398,8 +409,17 @@ async fn integrate_patch_three_way(
         }
         _ => submitted_tree_from_patch(context, project_root, &baseline).await?,
     };
-    let merged = merge_trees(project_root, &baseline, &snapshot.tree, &submitted).await?;
-    reject_gitlink_changes(project_root, &snapshot.tree, &merged).await?;
+    Ok((baseline, submitted))
+}
+
+async fn integrate_patch_three_way(
+    project_root: &Path,
+    snapshot: &CanonicalWorkspaceSnapshot,
+    baseline: &str,
+    submitted: &str,
+) -> Result<()> {
+    let merged = merge_trees(project_root, baseline, &snapshot.tree, submitted).await?;
+    validate_tree_materialization(project_root, &snapshot.tree, &merged).await?;
     if let Err(error) = materialize_tree(project_root, &snapshot.tree, &merged).await {
         if let Err(restore_error) = snapshot.restore(project_root).await {
             anyhow::bail!(
@@ -501,11 +521,33 @@ async fn merge_trees(
     git_stdout(output, "three-way merge approved task")
 }
 
-async fn reject_gitlink_changes(
+#[derive(Debug)]
+struct TreeChange {
+    path: Vec<u8>,
+    is_addition: bool,
+    changes_gitlink: bool,
+}
+
+async fn validate_tree_materialization(
     project_root: &Path,
     current_tree: &str,
     target_tree: &str,
 ) -> Result<()> {
+    let changes = tree_changes(project_root, current_tree, target_tree).await?;
+    if changes.iter().any(|change| change.changes_gitlink) {
+        anyhow::bail!(
+            "Approved submissions that change submodules are not supported because their gitlinks cannot be materialized safely"
+        );
+    }
+    reject_ignored_path_collisions(project_root, &changes).await?;
+    reject_sparse_checkout_exclusions(project_root, &changes).await
+}
+
+async fn tree_changes(
+    project_root: &Path,
+    current_tree: &str,
+    target_tree: &str,
+) -> Result<Vec<TreeChange>> {
     let output = Command::new("git")
         .arg("-C")
         .arg(project_root)
@@ -521,24 +563,161 @@ async fn reject_gitlink_changes(
         .arg(target_tree)
         .output()
         .await?;
-    git_success(&output, "inspect approved tree for submodule changes")?;
-    if output
+    git_success(&output, "inspect paths changed by the approved tree")?;
+    parse_raw_tree_changes(&output.stdout)
+}
+
+fn parse_raw_tree_changes(raw: &[u8]) -> Result<Vec<TreeChange>> {
+    let mut records = raw.split(|byte| *byte == 0);
+    let mut changes = Vec::new();
+    while let Some(metadata) = records.next() {
+        if metadata.is_empty() {
+            continue;
+        }
+        let path = records
+            .next()
+            .context("Git returned a malformed raw tree diff without a path")?;
+        let mut fields = metadata.split(|byte| byte.is_ascii_whitespace());
+        let old_mode = fields
+            .next()
+            .and_then(|mode| mode.strip_prefix(b":"))
+            .context("Git returned a malformed raw tree diff without an old mode")?;
+        let new_mode = fields
+            .next()
+            .context("Git returned a malformed raw tree diff without a new mode")?;
+        changes.push(TreeChange {
+            path: path.to_vec(),
+            is_addition: old_mode == b"000000" && new_mode != b"000000",
+            changes_gitlink: old_mode == b"160000" || new_mode == b"160000",
+        });
+    }
+    Ok(changes)
+}
+
+async fn reject_ignored_path_collisions(project_root: &Path, changes: &[TreeChange]) -> Result<()> {
+    let additions: Vec<&[u8]> = changes
+        .iter()
+        .filter(|change| change.is_addition)
+        .map(|change| change.path.as_slice())
+        .collect();
+    if additions.is_empty() {
+        return Ok(());
+    }
+
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args([
+            "ls-files",
+            "--others",
+            "--ignored",
+            "--exclude-standard",
+            "--directory",
+            "-z",
+        ])
+        .output()
+        .await?;
+    git_success(
+        &output,
+        "inspect ignored canonical paths before integration",
+    )?;
+    let collision = output
         .stdout
         .split(|byte| *byte == 0)
-        .any(raw_diff_entry_changes_gitlink)
-    {
+        .filter(|path| !path.is_empty())
+        .any(|ignored| {
+            let ignored = ignored.strip_suffix(b"/").unwrap_or(ignored);
+            additions
+                .iter()
+                .any(|addition| paths_overlap(ignored, addition))
+        });
+    if collision {
         anyhow::bail!(
-            "Approved submissions that change submodules are not supported because their gitlinks cannot be materialized safely"
+            "Canonical workspace contains ignored local content at a path changed by the approved submission"
         );
     }
     Ok(())
 }
 
-fn raw_diff_entry_changes_gitlink(entry: &[u8]) -> bool {
-    let mut fields = entry.split(|byte| byte.is_ascii_whitespace());
-    let old_mode = fields.next();
-    let new_mode = fields.next();
-    old_mode == Some(&b":160000"[..]) || new_mode == Some(&b"160000"[..])
+fn paths_overlap(left: &[u8], right: &[u8]) -> bool {
+    left == right || path_is_parent(left, right) || path_is_parent(right, left)
+}
+
+fn path_is_parent(parent: &[u8], child: &[u8]) -> bool {
+    child
+        .strip_prefix(parent)
+        .is_some_and(|remainder| remainder.starts_with(b"/"))
+}
+
+async fn reject_sparse_checkout_exclusions(
+    project_root: &Path,
+    changes: &[TreeChange],
+) -> Result<()> {
+    if changes.is_empty() || !sparse_checkout_enabled(project_root).await? {
+        return Ok(());
+    }
+    let paths: HashSet<&[u8]> = changes
+        .iter()
+        .map(|change| change.path.as_slice())
+        .collect();
+    let input = nul_terminated_paths(paths.iter().copied());
+    let mut command = Command::new("git");
+    command
+        .arg("-C")
+        .arg(project_root)
+        .args(["sparse-checkout", "check-rules", "-z"]);
+    let output = command_output_with_stdin(&mut command, &input).await?;
+    git_success(&output, "check approved paths against the sparse checkout")?;
+    let included: HashSet<&[u8]> = output
+        .stdout
+        .split(|byte| *byte == 0)
+        .filter(|path| !path.is_empty())
+        .collect();
+    if paths.iter().any(|path| !included.contains(path)) {
+        anyhow::bail!("Approved submission changes paths outside the canonical sparse checkout");
+    }
+    Ok(())
+}
+
+async fn sparse_checkout_enabled(project_root: &Path) -> Result<bool> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args(["config", "--bool", "--get", "core.sparseCheckout"])
+        .output()
+        .await?;
+    if output.status.success() {
+        return Ok(output.stdout.starts_with(b"true"));
+    }
+    if output.status.code() == Some(1) {
+        return Ok(false);
+    }
+    git_success(&output, "inspect canonical sparse checkout configuration")?;
+    Ok(false)
+}
+
+fn nul_terminated_paths<'a>(paths: impl IntoIterator<Item = &'a [u8]>) -> Vec<u8> {
+    let mut input = Vec::new();
+    for path in paths {
+        input.extend_from_slice(path);
+        input.push(0);
+    }
+    input
+}
+
+async fn command_output_with_stdin(command: &mut Command, input: &[u8]) -> Result<Output> {
+    let mut child = command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    let mut stdin = child
+        .stdin
+        .take()
+        .context("Failed to open Git stdin for canonical integration preflight")?;
+    stdin.write_all(input).await?;
+    drop(stdin);
+    Ok(child.wait_with_output().await?)
 }
 
 async fn commit_tree(

--- a/src/server/tools/approve.rs
+++ b/src/server/tools/approve.rs
@@ -399,6 +399,7 @@ async fn integrate_patch_three_way(
         _ => submitted_tree_from_patch(context, project_root, &baseline).await?,
     };
     let merged = merge_trees(project_root, &baseline, &snapshot.tree, &submitted).await?;
+    reject_gitlink_changes(project_root, &snapshot.tree, &merged).await?;
     if let Err(error) = materialize_tree(project_root, &snapshot.tree, &merged).await {
         if let Err(restore_error) = snapshot.restore(project_root).await {
             anyhow::bail!(
@@ -498,6 +499,46 @@ async fn merge_trees(
         .output()
         .await?;
     git_stdout(output, "three-way merge approved task")
+}
+
+async fn reject_gitlink_changes(
+    project_root: &Path,
+    current_tree: &str,
+    target_tree: &str,
+) -> Result<()> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args([
+            "diff-tree",
+            "--no-commit-id",
+            "--raw",
+            "-r",
+            "-z",
+            "--no-renames",
+        ])
+        .arg(current_tree)
+        .arg(target_tree)
+        .output()
+        .await?;
+    git_success(&output, "inspect approved tree for submodule changes")?;
+    if output
+        .stdout
+        .split(|byte| *byte == 0)
+        .any(raw_diff_entry_changes_gitlink)
+    {
+        anyhow::bail!(
+            "Approved submissions that change submodules are not supported because their gitlinks cannot be materialized safely"
+        );
+    }
+    Ok(())
+}
+
+fn raw_diff_entry_changes_gitlink(entry: &[u8]) -> bool {
+    let mut fields = entry.split(|byte| byte.is_ascii_whitespace());
+    let old_mode = fields.next();
+    let new_mode = fields.next();
+    old_mode == Some(&b":160000"[..]) || new_mode == Some(&b"160000"[..])
 }
 
 async fn commit_tree(

--- a/src/server/tools/approve.rs
+++ b/src/server/tools/approve.rs
@@ -229,25 +229,25 @@ async fn observe_canonical_source(project_root: &Path) -> CanonicalSourceObserva
 struct CanonicalWorkspaceSnapshot {
     tree: String,
     index: CanonicalIndexSnapshot,
+    ignored_paths: Vec<Vec<u8>>,
 }
 
 impl CanonicalWorkspaceSnapshot {
     async fn capture(project_root: &Path) -> Result<Self> {
         let index = CanonicalIndexSnapshot::capture(project_root).await?;
-        let project_root = project_root.to_path_buf();
-        let tree = tokio::task::spawn_blocking(move || {
-            crate::repository_graph::source::capture_worktree_tree(project_root)
-        })
-        .await??;
+        let ignored_paths = ignored_untracked_paths(project_root).await?;
+        let tree = capture_canonical_worktree_tree(project_root).await?;
         Ok(Self {
-            tree: tree.value().to_string(),
+            tree,
             index,
+            ignored_paths,
         })
     }
 
     async fn restore(&self, project_root: &Path) -> Result<()> {
-        let current = Self::capture(project_root).await?;
-        let worktree_result = materialize_tree(project_root, &current.tree, &self.tree)
+        let current = capture_canonical_worktree_tree(project_root).await?;
+        let current = tree_without_paths(project_root, &current, &self.ignored_paths).await?;
+        let worktree_result = materialize_tree(project_root, &current, &self.tree)
             .await
             .context("Failed to restore the pre-integration canonical worktree");
         let index_result = self.index.restore().await;
@@ -263,6 +263,40 @@ impl CanonicalWorkspaceSnapshot {
     async fn restore_index(&self) -> Result<()> {
         self.index.restore().await
     }
+}
+
+async fn capture_canonical_worktree_tree(project_root: &Path) -> Result<String> {
+    let project_root = project_root.to_path_buf();
+    let tree = tokio::task::spawn_blocking(move || {
+        crate::repository_graph::source::capture_worktree_tree(project_root)
+    })
+    .await??;
+    Ok(tree.value().to_string())
+}
+
+async fn ignored_untracked_paths(project_root: &Path) -> Result<Vec<Vec<u8>>> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args([
+            "ls-files",
+            "--others",
+            "--ignored",
+            "--exclude-standard",
+            "-z",
+        ])
+        .output()
+        .await?;
+    git_success(
+        &output,
+        "capture ignored canonical paths before integration",
+    )?;
+    Ok(output
+        .stdout
+        .split(|byte| *byte == 0)
+        .filter(|path| !path.is_empty())
+        .map(<[u8]>::to_vec)
+        .collect())
 }
 
 #[derive(Debug)]
@@ -753,6 +787,39 @@ async fn materialize_tree(
     let index = TemporaryIntegrationIndex::new();
     read_tree(project_root, index.path(), current_tree, false).await?;
     read_tree(project_root, index.path(), target_tree, true).await
+}
+
+async fn tree_without_paths(
+    project_root: &Path,
+    tree: &str,
+    excluded_paths: &[Vec<u8>],
+) -> Result<String> {
+    if excluded_paths.is_empty() {
+        return Ok(tree.to_string());
+    }
+
+    let index = TemporaryIntegrationIndex::new();
+    read_tree(project_root, index.path(), tree, false).await?;
+    let input = nul_terminated_paths(excluded_paths.iter().map(Vec::as_slice));
+    let mut command = Command::new("git");
+    command
+        .arg("-C")
+        .arg(project_root)
+        .env("GIT_INDEX_FILE", index.path())
+        .args(["update-index", "--force-remove", "-z", "--stdin"]);
+    let output = command_output_with_stdin(&mut command, &input).await?;
+    git_success(
+        &output,
+        "exclude pre-integration ignored paths from rollback",
+    )?;
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .env("GIT_INDEX_FILE", index.path())
+        .arg("write-tree")
+        .output()
+        .await?;
+    git_stdout(output, "write rollback tree without ignored paths")
 }
 
 static TEMPORARY_INTEGRATION_INDEX_SEQUENCE: AtomicU64 = AtomicU64::new(0);

--- a/src/server/tools/approve.rs
+++ b/src/server/tools/approve.rs
@@ -4,8 +4,10 @@ use neva::prelude::*;
 use std::collections::HashSet;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::process::Output;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, OnceLock};
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::process::Command;
 use tracing::info;
 
@@ -82,17 +84,17 @@ async fn run(agent_id: &str) -> Result<String> {
 }
 
 async fn integrate_approved_task(context: &RuntimeTaskContext, project_root: &Path) -> Result<()> {
-    let patch_applied = apply_approved_patch(context, project_root).await?;
-    if patch_applied {
+    let canonical_snapshot = apply_approved_patch(context, project_root).await?;
+    if let Some(canonical_snapshot) = canonical_snapshot.as_ref() {
         // The approved patch may have changed ferrus.toml, so run the integration
         // gate against the configuration as it exists in the post-apply repository
         // state rather than the config loaded before the patch was applied.
         let post_apply_config = match Config::load_from(project_root).await {
             Ok(config) => config,
             Err(err) => {
-                if let Err(rollback_err) = rollback_approved_patch(context, project_root).await {
+                if let Err(rollback_err) = canonical_snapshot.restore(project_root).await {
                     anyhow::bail!(
-                        "{err}\n\nAdditionally failed to roll back the already-applied task patch: {rollback_err}"
+                        "{err}\n\nAdditionally failed to restore the pre-integration canonical workspace: {rollback_err}"
                     );
                 }
                 return Err(err);
@@ -101,12 +103,20 @@ async fn integrate_approved_task(context: &RuntimeTaskContext, project_root: &Pa
         let integration_checks =
             run_post_apply_integration_checks(context, &post_apply_config, project_root).await;
         if let Err(err) = integration_checks {
-            if let Err(rollback_err) = rollback_approved_patch(context, project_root).await {
+            if let Err(rollback_err) = canonical_snapshot.restore(project_root).await {
                 anyhow::bail!(
-                    "{err}\n\nAdditionally failed to roll back the already-applied task patch: {rollback_err}"
+                    "{err}\n\nAdditionally failed to restore the pre-integration canonical workspace: {rollback_err}"
                 );
             }
             return Err(err);
+        }
+        if let Err(err) = canonical_snapshot.restore_index().await {
+            if let Err(rollback_err) = canonical_snapshot.restore(project_root).await {
+                anyhow::bail!(
+                    "{err}\n\nAdditionally failed to restore the pre-integration canonical workspace: {rollback_err}"
+                );
+            }
+            return Err(err).context("Failed to preserve the pre-integration canonical index");
         }
     }
     let transition = async {
@@ -126,11 +136,11 @@ async fn integrate_approved_task(context: &RuntimeTaskContext, project_root: &Pa
     }
     .await;
     if let Err(err) = transition {
-        if patch_applied
-            && let Err(rollback_err) = rollback_approved_patch(context, project_root).await
+        if let Some(canonical_snapshot) = canonical_snapshot.as_ref()
+            && let Err(rollback_err) = canonical_snapshot.restore(project_root).await
         {
             anyhow::bail!(
-                "{err}\n\nAdditionally failed to roll back the already-applied task patch: {rollback_err}"
+                "{err}\n\nAdditionally failed to restore the pre-integration canonical workspace: {rollback_err}"
             );
         }
         return Err(err);
@@ -214,31 +224,154 @@ async fn observe_canonical_source(project_root: &Path) -> CanonicalSourceObserva
     }
 }
 
-async fn apply_approved_patch(context: &RuntimeTaskContext, project_root: &Path) -> Result<bool> {
-    let patch = store::read_patch_for_run_dir(&context.run_dir).await?;
-    if patch.trim().is_empty() {
-        return Ok(false);
+#[derive(Debug)]
+struct CanonicalWorkspaceSnapshot {
+    tree: String,
+    index: CanonicalIndexSnapshot,
+}
+
+impl CanonicalWorkspaceSnapshot {
+    async fn capture(project_root: &Path) -> Result<Self> {
+        let index = CanonicalIndexSnapshot::capture(project_root).await?;
+        let project_root = project_root.to_path_buf();
+        let tree = tokio::task::spawn_blocking(move || {
+            crate::repository_graph::source::capture_worktree_tree(project_root)
+        })
+        .await??;
+        Ok(Self {
+            tree: tree.value().to_string(),
+            index,
+        })
     }
 
-    let patch_path = store::resolve_project_path(Path::new(&context.run_dir).join("PATCH.diff"));
-    let output = Command::new("git")
-        .arg("-C")
-        .arg(project_root)
-        .args(["apply", "--whitespace=nowarn"])
-        .arg(&patch_path)
-        .output()
-        .await?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    async fn restore(&self, project_root: &Path) -> Result<()> {
+        let current = Self::capture(project_root).await?;
+        let worktree_result = materialize_tree(project_root, &current.tree, &self.tree)
+            .await
+            .context("Failed to restore the pre-integration canonical worktree");
+        let index_result = self.index.restore().await;
+        match (worktree_result, index_result) {
+            (Ok(()), Ok(())) => Ok(()),
+            (Err(error), Ok(())) | (Ok(()), Err(error)) => Err(error),
+            (Err(worktree_error), Err(index_error)) => anyhow::bail!(
+                "{worktree_error}\n\nAdditionally failed to restore the canonical index: {index_error}"
+            ),
+        }
+    }
+
+    async fn restore_index(&self) -> Result<()> {
+        self.index.restore().await
+    }
+}
+
+#[derive(Debug)]
+struct CanonicalIndexSnapshot {
+    path: PathBuf,
+    contents: Option<Vec<u8>>,
+}
+
+impl CanonicalIndexSnapshot {
+    async fn capture(project_root: &Path) -> Result<Self> {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(project_root)
+            .args(["rev-parse", "--git-path", "index"])
+            .output()
+            .await?;
+        let path = git_stdout(output, "resolve canonical Git index")?;
+        let path = PathBuf::from(path);
+        let path = if path.is_absolute() {
+            path
+        } else {
+            project_root.join(path)
+        };
+        let contents = match tokio::fs::read(&path).await {
+            Ok(contents) => Some(contents),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("Failed to read Git index {}", path.display()));
+            }
+        };
+        Ok(Self { path, contents })
+    }
+
+    async fn restore(&self) -> Result<()> {
+        let path = self.path.clone();
+        let contents = self.contents.clone();
+        tokio::task::spawn_blocking(move || restore_index_file(&path, contents.as_deref())).await?
+    }
+}
+
+fn restore_index_file(path: &Path, contents: Option<&[u8]>) -> Result<()> {
+    let mut lock_path = path.as_os_str().to_owned();
+    lock_path.push(".lock");
+    let lock_path = PathBuf::from(lock_path);
+    let mut lock = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&lock_path)
+        .with_context(|| format!("Failed to lock Git index {}", path.display()))?;
+    let result = (|| -> Result<()> {
+        if let Some(contents) = contents {
+            lock.write_all(contents)
+                .with_context(|| format!("Failed to restore Git index {}", path.display()))?;
+            lock.sync_all()
+                .with_context(|| format!("Failed to sync Git index {}", path.display()))?;
+        }
+        drop(lock);
+
+        if contents.is_some() {
+            if path.exists() {
+                std::fs::remove_file(path)
+                    .with_context(|| format!("Failed to replace Git index {}", path.display()))?;
+            }
+            std::fs::rename(&lock_path, path).with_context(|| {
+                format!("Failed to publish restored Git index {}", path.display())
+            })?;
+        } else {
+            if path.exists() {
+                std::fs::remove_file(path)
+                    .with_context(|| format!("Failed to remove Git index {}", path.display()))?;
+            }
+            std::fs::remove_file(&lock_path).with_context(|| {
+                format!(
+                    "Failed to remove temporary Git index lock {}",
+                    lock_path.display()
+                )
+            })?;
+        }
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&lock_path);
+    }
+    result
+}
+
+async fn apply_approved_patch(
+    context: &RuntimeTaskContext,
+    project_root: &Path,
+) -> Result<Option<CanonicalWorkspaceSnapshot>> {
+    let patch = store::read_patch_for_run_dir(&context.run_dir).await?;
+    if patch.trim().is_empty() {
+        return Ok(None);
+    }
+
+    let snapshot = CanonicalWorkspaceSnapshot::capture(project_root).await?;
+    if let Err(error) = integrate_patch_three_way(context, project_root, &snapshot).await {
+        let restore_error = snapshot.restore(project_root).await.err();
+        let detail = bounded_git_detail(&error.to_string());
         let reason = format!(
-            "Cannot approve task {} because its patch could not be applied to {}: {}",
+            "Cannot approve task {} because its submitted changes could not be merged into {}: {}{}",
             context.task_id,
             project_root.display(),
-            if stderr.is_empty() {
-                output.status.to_string()
-            } else {
-                stderr
-            }
+            detail,
+            restore_error
+                .map(|error| format!(
+                    "\n\nAdditionally failed to restore the pre-integration canonical workspace: {error}"
+                ))
+                .unwrap_or_default()
         );
         write_integration_error(context, &reason).await?;
         project::record_task_integration_failed_best_effort(
@@ -253,7 +386,221 @@ async fn apply_approved_patch(context: &RuntimeTaskContext, project_root: &Path)
             context.run_dir
         );
     }
-    Ok(true)
+    Ok(Some(snapshot))
+}
+
+async fn integrate_patch_three_way(
+    context: &RuntimeTaskContext,
+    project_root: &Path,
+    snapshot: &CanonicalWorkspaceSnapshot,
+) -> Result<()> {
+    let frozen_submitted = context.repository_view.lifecycle
+        == crate::repository_graph::domain::TaskViewLifecycle::FrozenSubmitted;
+    let baseline = task_baseline_tree(project_root, &context.task_id, frozen_submitted).await?;
+    let submitted = match context.repository_view.frozen_source_tree.as_ref() {
+        Some(tree) if frozen_submitted => {
+            verify_tree(project_root, tree.value()).await?;
+            tree.value().to_string()
+        }
+        _ => submitted_tree_from_patch(context, project_root, &baseline).await?,
+    };
+    let merged = merge_trees(project_root, &baseline, &snapshot.tree, &submitted).await?;
+    materialize_tree(project_root, &snapshot.tree, &merged).await
+}
+
+async fn task_baseline_tree(
+    project_root: &Path,
+    task_id: &str,
+    require_pinned: bool,
+) -> Result<String> {
+    let baseline_ref = format!("refs/ferrus/baselines/{task_id}");
+    match resolve_tree(project_root, &baseline_ref).await {
+        Ok(tree) => Ok(tree),
+        Err(error) if require_pinned => {
+            Err(error).context("Pinned task baseline tree is unavailable")
+        }
+        Err(_) => resolve_tree(project_root, "HEAD^{tree}")
+            .await
+            .context("Task baseline tree is unavailable"),
+    }
+}
+
+async fn resolve_tree(project_root: &Path, revision: &str) -> Result<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args(["rev-parse", "--verify"])
+        .arg(revision)
+        .output()
+        .await?;
+    git_stdout(output, "resolve Git tree")
+}
+
+async fn verify_tree(project_root: &Path, tree: &str) -> Result<()> {
+    let object = format!("{tree}^{{tree}}");
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args(["cat-file", "-e"])
+        .arg(object)
+        .output()
+        .await?;
+    git_success(&output, "verify frozen submitted tree")
+}
+
+async fn submitted_tree_from_patch(
+    context: &RuntimeTaskContext,
+    project_root: &Path,
+    baseline: &str,
+) -> Result<String> {
+    let index = TemporaryIntegrationIndex::new();
+    read_tree(project_root, index.path(), baseline, false).await?;
+    let patch_path = store::resolve_project_path(Path::new(&context.run_dir).join("PATCH.diff"));
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .env("GIT_INDEX_FILE", index.path())
+        .args(["apply", "--cached", "--whitespace=nowarn"])
+        .arg(patch_path)
+        .output()
+        .await?;
+    git_success(&output, "apply submitted patch to its baseline")?;
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .env("GIT_INDEX_FILE", index.path())
+        .arg("write-tree")
+        .output()
+        .await?;
+    git_stdout(output, "write submitted tree")
+}
+
+async fn merge_trees(
+    project_root: &Path,
+    baseline: &str,
+    ours: &str,
+    theirs: &str,
+) -> Result<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args(["merge-tree", "--write-tree", "--messages", "--merge-base"])
+        .arg(baseline)
+        .arg(ours)
+        .arg(theirs)
+        .output()
+        .await?;
+    git_stdout(output, "three-way merge approved task")
+}
+
+async fn materialize_tree(
+    project_root: &Path,
+    current_tree: &str,
+    target_tree: &str,
+) -> Result<()> {
+    let index = TemporaryIntegrationIndex::new();
+    read_tree(project_root, index.path(), current_tree, false).await?;
+    read_tree(project_root, index.path(), target_tree, true).await
+}
+
+static TEMPORARY_INTEGRATION_INDEX_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+struct TemporaryIntegrationIndex {
+    path: PathBuf,
+}
+
+impl TemporaryIntegrationIndex {
+    fn new() -> Self {
+        let sequence = TEMPORARY_INTEGRATION_INDEX_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        Self {
+            path: std::env::temp_dir().join(format!(
+                "ferrus-integration-index-{}-{nanos:x}-{sequence:x}",
+                std::process::id()
+            )),
+        }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TemporaryIntegrationIndex {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+        let mut lock = self.path.as_os_str().to_owned();
+        lock.push(".lock");
+        let _ = std::fs::remove_file(PathBuf::from(lock));
+    }
+}
+
+async fn read_tree(
+    project_root: &Path,
+    index: &Path,
+    tree: &str,
+    update_worktree: bool,
+) -> Result<()> {
+    let mut command = Command::new("git");
+    command
+        .arg("-C")
+        .arg(project_root)
+        .env("GIT_INDEX_FILE", index)
+        .arg("read-tree");
+    if update_worktree {
+        command.args(["--reset", "-u"]);
+    }
+    let output = command.arg(tree).output().await?;
+    git_success(&output, "materialize Git tree through temporary index")
+}
+
+fn git_stdout(output: Output, operation: &str) -> Result<String> {
+    git_success(&output, operation)?;
+    let stdout =
+        String::from_utf8(output.stdout).context("Git returned non-UTF-8 object output")?;
+    stdout
+        .lines()
+        .next()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(str::to_string)
+        .with_context(|| format!("Git returned no result while attempting to {operation}"))
+}
+
+fn git_success(output: &Output, operation: &str) -> Result<()> {
+    if output.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let detail = if stderr.trim().is_empty() {
+        stdout.trim()
+    } else {
+        stderr.trim()
+    };
+    anyhow::bail!(
+        "Failed to {operation}: {}",
+        if detail.is_empty() {
+            output.status.to_string()
+        } else {
+            bounded_git_detail(detail)
+        }
+    )
+}
+
+fn bounded_git_detail(detail: &str) -> String {
+    const MAX_BYTES: usize = 8 * 1024;
+    if detail.len() <= MAX_BYTES {
+        return detail.to_string();
+    }
+    let mut end = MAX_BYTES;
+    while !detail.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}\n... output truncated ...", &detail[..end])
 }
 
 async fn run_post_apply_integration_checks(
@@ -313,31 +660,6 @@ async fn run_post_apply_integration_checks(
             );
         }
     }
-}
-
-async fn rollback_approved_patch(context: &RuntimeTaskContext, project_root: &Path) -> Result<()> {
-    let patch_path = store::resolve_project_path(Path::new(&context.run_dir).join("PATCH.diff"));
-    let output = Command::new("git")
-        .arg("-C")
-        .arg(project_root)
-        .args(["apply", "-R", "--whitespace=nowarn"])
-        .arg(&patch_path)
-        .output()
-        .await?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        anyhow::bail!(
-            "Failed to roll back approved patch for task {} in {}: {}",
-            context.task_id,
-            project_root.display(),
-            if stderr.is_empty() {
-                output.status.to_string()
-            } else {
-                stderr
-            }
-        );
-    }
-    Ok(())
 }
 
 async fn write_integration_error(context: &RuntimeTaskContext, reason: &str) -> Result<()> {

--- a/src/server/tools/approve_tests.rs
+++ b/src/server/tools/approve_tests.rs
@@ -422,7 +422,10 @@ async fn approve_three_way_merges_disjoint_hunks_from_a_pinned_baseline() {
     run("supervisor:codex:7").await.unwrap();
 
     assert_eq!(
-        tokio::fs::read_to_string("file.txt").await.unwrap(),
+        tokio::fs::read_to_string("file.txt")
+            .await
+            .unwrap()
+            .replace("\r\n", "\n"),
         "canonical change\nsecond\nthird\nfourth\nfifth\ntask change\n"
     );
 
@@ -655,7 +658,7 @@ async fn approve_rolls_back_patch_when_post_apply_checks_fail() {
     let (dir, previous) = setup().await;
     tokio::fs::write(
         "ferrus.toml",
-        "[repository_graph]\nenabled = true\n\n[checks]\ncommands = [\"printf mutated > file.txt; printf generated > generated.txt; git add file.txt generated.txt; exit 1\"]\n\n[limits]\nmax_check_retries = 20\nmax_review_cycles = 3\nmax_feedback_lines = 30\nwait_timeout_secs = 1\n\n[lease]\nttl_secs = 60\n",
+        "[repository_graph]\nenabled = true\n\n[checks]\ncommands = [\"git show HEAD:file.txt > generated.txt\", \"git add file.txt generated.txt\", \"git grep -q base -- file.txt\"]\n\n[limits]\nmax_check_retries = 20\nmax_review_cycles = 3\nmax_feedback_lines = 30\nwait_timeout_secs = 1\n\n[lease]\nttl_secs = 60\n",
     )
     .await
     .unwrap();
@@ -724,7 +727,7 @@ async fn approve_rolls_back_patch_when_post_apply_checks_fail() {
         .await
         .unwrap();
     assert!(integration_error.contains("configured checks failed"));
-    assert!(integration_error.contains("printf mutated > file.txt"));
+    assert!(integration_error.contains("git grep -q base -- file.txt"));
     let tasks = crate::project::list_tasks().await.unwrap();
     let task = tasks.iter().find(|task| task.id == "t-007").unwrap();
     assert_eq!(task.status, "reviewing");

--- a/src/server/tools/approve_tests.rs
+++ b/src/server/tools/approve_tests.rs
@@ -1001,6 +1001,91 @@ async fn approve_rolls_back_patch_when_post_apply_checks_fail() {
 }
 
 #[tokio::test]
+async fn approve_rollback_preserves_files_ignored_before_integration() {
+    let _guard = crate::test_support::cwd_lock().lock().unwrap();
+    let (dir, previous) = setup().await;
+    if !git(dir.path(), ["init"]).success() {
+        teardown(previous);
+        return;
+    }
+    tokio::fs::write(
+        "ferrus.toml",
+        "[checks]\ncommands = [\"git grep -q secret.txt -- .gitignore\"]\n\n[limits]\nmax_check_retries = 20\nmax_review_cycles = 3\nmax_feedback_lines = 30\nwait_timeout_secs = 1\n\n[lease]\nttl_secs = 60\n",
+    )
+    .await
+    .unwrap();
+    tokio::fs::write(".gitignore", "secret.txt\n")
+        .await
+        .unwrap();
+    tokio::fs::write("file.txt", "baseline\n").await.unwrap();
+    assert!(git(dir.path(), ["add", "ferrus.toml", ".gitignore", "file.txt"]).success());
+    assert!(
+        git(
+            dir.path(),
+            [
+                "-c",
+                "user.email=ferrus@example.invalid",
+                "-c",
+                "user.name=Ferrus",
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "-m",
+                "baseline",
+            ],
+        )
+        .success()
+    );
+    let baseline_tree = git_output(dir.path(), ["rev-parse", "HEAD^{tree}"])
+        .trim()
+        .to_string();
+
+    tokio::fs::write(".gitignore", "").await.unwrap();
+    assert!(git(dir.path(), ["add", ".gitignore"]).success());
+    let submitted_tree = git_output(dir.path(), ["write-tree"]).trim().to_string();
+    let patch = git_output(dir.path(), ["diff", "--cached", "--binary", "HEAD"]);
+    assert!(!patch.trim().is_empty());
+    assert!(git(dir.path(), ["reset", "--mixed", "HEAD"]).success());
+    tokio::fs::write(".gitignore", "secret.txt\n")
+        .await
+        .unwrap();
+    let ignored_contents = b"canonical ignored bytes\0\xff";
+    tokio::fs::write("secret.txt", ignored_contents)
+        .await
+        .unwrap();
+    let worktree_before =
+        crate::repository_graph::source::capture_worktree_tree(dir.path()).unwrap();
+    prepare_frozen_review(dir.path(), &baseline_tree, &submitted_tree, &patch).await;
+
+    let error = run("supervisor:codex:7").await.unwrap_err().to_string();
+
+    assert!(error.contains("configured checks failed"), "{error}");
+    assert!(error.contains("rolled back"), "{error}");
+    assert_eq!(
+        tokio::fs::read("secret.txt").await.unwrap(),
+        ignored_contents
+    );
+    assert_eq!(
+        tokio::fs::read_to_string(".gitignore").await.unwrap(),
+        "secret.txt\n"
+    );
+    assert_eq!(git_output(dir.path(), ["write-tree"]).trim(), baseline_tree);
+    assert_eq!(
+        crate::repository_graph::source::capture_worktree_tree(dir.path()).unwrap(),
+        worktree_before
+    );
+    let task = crate::project::list_tasks()
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|task| task.id == "t-007")
+        .unwrap();
+    assert_eq!(task.status, "reviewing");
+
+    teardown(previous);
+}
+
+#[tokio::test]
 async fn failed_integration_marks_actual_partial_canonical_manifest_stale() {
     let _guard = crate::test_support::cwd_lock().lock().unwrap();
     let (dir, previous) = setup().await;

--- a/src/server/tools/approve_tests.rs
+++ b/src/server/tools/approve_tests.rs
@@ -1008,6 +1008,7 @@ async fn approve_rollback_preserves_files_ignored_before_integration() {
         teardown(previous);
         return;
     }
+    assert!(git(dir.path(), ["config", "core.autocrlf", "false"]).success());
     tokio::fs::write(
         "ferrus.toml",
         "[checks]\ncommands = [\"git grep -q secret.txt -- .gitignore\"]\n\n[limits]\nmax_check_retries = 20\nmax_review_cycles = 3\nmax_feedback_lines = 30\nwait_timeout_secs = 1\n\n[lease]\nttl_secs = 60\n",

--- a/src/server/tools/approve_tests.rs
+++ b/src/server/tools/approve_tests.rs
@@ -433,6 +433,106 @@ async fn approve_three_way_merges_disjoint_hunks_from_a_pinned_baseline() {
 }
 
 #[tokio::test]
+async fn approve_rejects_submodule_gitlink_changes_without_completing_task() {
+    let _guard = crate::test_support::cwd_lock().lock().unwrap();
+    let (dir, previous) = setup().await;
+    if !git(dir.path(), ["init"]).success() {
+        teardown(previous);
+        return;
+    }
+    tokio::fs::write("file.txt", "baseline\n").await.unwrap();
+    assert!(git(dir.path(), ["add", "file.txt"]).success());
+    assert!(
+        git(
+            dir.path(),
+            [
+                "-c",
+                "user.email=ferrus@example.invalid",
+                "-c",
+                "user.name=Ferrus",
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "-m",
+                "baseline",
+            ],
+        )
+        .success()
+    );
+    let baseline_tree = git_output(dir.path(), ["rev-parse", "HEAD^{tree}"])
+        .trim()
+        .to_string();
+    crate::project::pin_executor_baseline_tree(dir.path(), "t-007", &baseline_tree)
+        .await
+        .unwrap();
+
+    let gitlink_target = git_output(dir.path(), ["rev-parse", "HEAD"])
+        .trim()
+        .to_string();
+    let cache_info = format!("160000,{gitlink_target},dependency");
+    assert!(
+        git(
+            dir.path(),
+            ["update-index", "--add", "--cacheinfo", &cache_info],
+        )
+        .success()
+    );
+    let submitted_tree = git_output(dir.path(), ["write-tree"]).trim().to_string();
+    let patch = git_output(dir.path(), ["diff", "--cached", "--binary", "HEAD"]);
+    assert!(!patch.trim().is_empty());
+    assert!(git(dir.path(), ["reset", "--mixed", "HEAD"]).success());
+    let submitted_tree =
+        crate::repository_graph::source::parse_git_tree_digest(&submitted_tree).unwrap();
+    crate::repository_graph::source::pin_submitted_tree(dir.path(), "t-007", &submitted_tree)
+        .unwrap();
+
+    store::write_patch_for_run_dir(".ferrus/runs/t-007", &patch)
+        .await
+        .unwrap();
+    crate::project::record_task_status(
+        "t-007",
+        ".ferrus/tasks/t-007.md",
+        crate::project::TaskStatus::Reviewing,
+    )
+    .await
+    .unwrap();
+    let frozen_view = crate::project::RepositoryViewReference::materialized(
+        crate::repository_graph::domain::SnapshotId::new("baseline-snapshot").unwrap(),
+        None,
+        crate::repository_graph::domain::SnapshotId::new("submitted-snapshot").unwrap(),
+        crate::project::RepositoryViewStatus::Available,
+    )
+    .unwrap()
+    .frozen(submitted_tree)
+    .unwrap();
+    crate::project::record_task_repository_view("t-007", &frozen_view)
+        .await
+        .unwrap();
+    crate::project::claim_task("t-007", ".ferrus/tasks/t-007.md", "supervisor:codex:7", 60)
+        .await
+        .unwrap();
+
+    let error = run("supervisor:codex:7").await.unwrap_err().to_string();
+
+    assert!(error.contains("change submodules are not supported"));
+    assert!(!dir.path().join("dependency").exists());
+    assert_eq!(git_output(dir.path(), ["write-tree"]).trim(), baseline_tree);
+    let integration_error = store::read_integration_error_for_run_dir(".ferrus/runs/t-007")
+        .await
+        .unwrap();
+    assert!(integration_error.contains("change submodules are not supported"));
+    let task = crate::project::list_tasks()
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|task| task.id == "t-007")
+        .unwrap();
+    assert_eq!(task.status, "reviewing");
+
+    teardown(previous);
+}
+
+#[tokio::test]
 async fn approve_from_executor_worktree_updates_and_checks_canonical_workspace() {
     let _guard = crate::test_support::cwd_lock().lock().unwrap();
     let (dir, previous) = setup().await;

--- a/src/server/tools/approve_tests.rs
+++ b/src/server/tools/approve_tests.rs
@@ -321,6 +321,115 @@ async fn approve_applies_scoped_patch_before_marking_task_complete() {
 }
 
 #[tokio::test]
+async fn approve_three_way_merges_disjoint_hunks_from_a_pinned_baseline() {
+    let _guard = crate::test_support::cwd_lock().lock().unwrap();
+    let (dir, previous) = setup().await;
+    if !git(dir.path(), ["init"]).success() {
+        teardown(previous);
+        return;
+    }
+    let baseline_content = "first\nsecond\nthird\nfourth\nfifth\nsixth\n";
+    tokio::fs::write("file.txt", baseline_content)
+        .await
+        .unwrap();
+    assert!(git(dir.path(), ["add", "file.txt"]).success());
+    assert!(
+        git(
+            dir.path(),
+            [
+                "-c",
+                "user.email=ferrus@example.invalid",
+                "-c",
+                "user.name=Ferrus",
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "-m",
+                "baseline",
+            ],
+        )
+        .success()
+    );
+    let baseline_tree = git_output(dir.path(), ["rev-parse", "HEAD^{tree}"])
+        .trim()
+        .to_string();
+    crate::project::pin_executor_baseline_tree(dir.path(), "t-007", &baseline_tree)
+        .await
+        .unwrap();
+
+    tokio::fs::write(
+        "file.txt",
+        "first\nsecond\nthird\nfourth\nfifth\ntask change\n",
+    )
+    .await
+    .unwrap();
+    let submitted_tree =
+        crate::repository_graph::source::capture_worktree_tree(dir.path()).unwrap();
+    crate::repository_graph::source::pin_submitted_tree(dir.path(), "t-007", &submitted_tree)
+        .unwrap();
+    let patch = git_output(dir.path(), ["diff", "--binary", "HEAD", "--", "file.txt"]);
+    tokio::fs::write(
+        "file.txt",
+        "canonical change\nsecond\nthird\nfourth\nfifth\nsixth\n",
+    )
+    .await
+    .unwrap();
+    assert!(git(dir.path(), ["add", "file.txt"]).success());
+    assert!(
+        git(
+            dir.path(),
+            [
+                "-c",
+                "user.email=ferrus@example.invalid",
+                "-c",
+                "user.name=Ferrus",
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "-m",
+                "canonical advance",
+            ],
+        )
+        .success()
+    );
+
+    store::write_patch_for_run_dir(".ferrus/runs/t-007", &patch)
+        .await
+        .unwrap();
+    crate::project::record_task_status(
+        "t-007",
+        ".ferrus/tasks/t-007.md",
+        crate::project::TaskStatus::Reviewing,
+    )
+    .await
+    .unwrap();
+    let frozen_view = crate::project::RepositoryViewReference::materialized(
+        crate::repository_graph::domain::SnapshotId::new("baseline-snapshot").unwrap(),
+        None,
+        crate::repository_graph::domain::SnapshotId::new("submitted-snapshot").unwrap(),
+        crate::project::RepositoryViewStatus::Available,
+    )
+    .unwrap()
+    .frozen(submitted_tree)
+    .unwrap();
+    crate::project::record_task_repository_view("t-007", &frozen_view)
+        .await
+        .unwrap();
+    crate::project::claim_task("t-007", ".ferrus/tasks/t-007.md", "supervisor:codex:7", 60)
+        .await
+        .unwrap();
+
+    run("supervisor:codex:7").await.unwrap();
+
+    assert_eq!(
+        tokio::fs::read_to_string("file.txt").await.unwrap(),
+        "canonical change\nsecond\nthird\nfourth\nfifth\ntask change\n"
+    );
+
+    teardown(previous);
+}
+
+#[tokio::test]
 async fn approve_from_executor_worktree_updates_and_checks_canonical_workspace() {
     let _guard = crate::test_support::cwd_lock().lock().unwrap();
     let (dir, previous) = setup().await;
@@ -431,7 +540,10 @@ async fn approve_patch_conflict_records_recoverable_integration_error() {
         return;
     }
     tokio::fs::write("file.txt", "old\n").await.unwrap();
-    assert!(git(dir.path(), ["add", "file.txt"]).success());
+    tokio::fs::write("deleted.txt", "delete me\n")
+        .await
+        .unwrap();
+    assert!(git(dir.path(), ["add", "file.txt", "deleted.txt"]).success());
     assert!(
         git(
             dir.path(),
@@ -454,7 +566,32 @@ async fn approve_patch_conflict_records_recoverable_integration_error() {
     tokio::fs::write("file.txt", "conflicting local change\n")
         .await
         .unwrap();
+    tokio::fs::write("staged.txt", "staged canonical addition\n")
+        .await
+        .unwrap();
+    assert!(git(dir.path(), ["add", "staged.txt"]).success());
+    tokio::fs::remove_file("deleted.txt").await.unwrap();
+    tokio::fs::write("untracked.bin", [0_u8, 159, 146, 150])
+        .await
+        .unwrap();
     assert!(!patch.trim().is_empty());
+
+    let status_before = git_output_bytes(
+        dir.path(),
+        [
+            "status",
+            "--porcelain=v2",
+            "-z",
+            "--",
+            "file.txt",
+            "staged.txt",
+            "deleted.txt",
+            "untracked.bin",
+        ],
+    );
+    let index_before = git_output(dir.path(), ["write-tree"]);
+    let worktree_before =
+        crate::repository_graph::source::capture_worktree_tree(dir.path()).unwrap();
 
     store::write_patch_for_run_dir(".ferrus/runs/t-007", &patch)
         .await
@@ -485,7 +622,28 @@ async fn approve_patch_conflict_records_recoverable_integration_error() {
     assert!(
         task.failure_reason
             .as_deref()
-            .is_some_and(|reason| { reason.contains("patch could not be applied") })
+            .is_some_and(|reason| { reason.contains("could not be merged") })
+    );
+    assert_eq!(
+        git_output_bytes(
+            dir.path(),
+            [
+                "status",
+                "--porcelain=v2",
+                "-z",
+                "--",
+                "file.txt",
+                "staged.txt",
+                "deleted.txt",
+                "untracked.bin",
+            ],
+        ),
+        status_before
+    );
+    assert_eq!(git_output(dir.path(), ["write-tree"]), index_before);
+    assert_eq!(
+        crate::repository_graph::source::capture_worktree_tree(dir.path()).unwrap(),
+        worktree_before
     );
 
     teardown(previous);
@@ -497,7 +655,7 @@ async fn approve_rolls_back_patch_when_post_apply_checks_fail() {
     let (dir, previous) = setup().await;
     tokio::fs::write(
         "ferrus.toml",
-        "[repository_graph]\nenabled = true\n\n[checks]\ncommands = [\"git grep -q base -- file.txt\"]\n\n[limits]\nmax_check_retries = 20\nmax_review_cycles = 3\nmax_feedback_lines = 30\nwait_timeout_secs = 1\n\n[lease]\nttl_secs = 60\n",
+        "[repository_graph]\nenabled = true\n\n[checks]\ncommands = [\"printf mutated > file.txt; printf generated > generated.txt; git add file.txt generated.txt; exit 1\"]\n\n[limits]\nmax_check_retries = 20\nmax_review_cycles = 3\nmax_feedback_lines = 30\nwait_timeout_secs = 1\n\n[lease]\nttl_secs = 60\n",
     )
     .await
     .unwrap();
@@ -546,6 +704,9 @@ async fn approve_rolls_back_patch_when_post_apply_checks_fail() {
     crate::project::claim_task("t-007", ".ferrus/tasks/t-007.md", "supervisor:codex:7", 60)
         .await
         .unwrap();
+    let worktree_before =
+        crate::repository_graph::source::capture_worktree_tree(dir.path()).unwrap();
+    let index_before = git_output(dir.path(), ["write-tree"]);
 
     let error = run("supervisor:codex:7").await.unwrap_err().to_string();
 
@@ -553,11 +714,17 @@ async fn approve_rolls_back_patch_when_post_apply_checks_fail() {
     assert!(error.contains("rolled back"));
     let file = tokio::fs::read_to_string("file.txt").await.unwrap();
     assert_eq!(file.replace("\r\n", "\n"), "base\n");
+    assert!(!dir.path().join("generated.txt").exists());
+    assert_eq!(git_output(dir.path(), ["write-tree"]), index_before);
+    assert_eq!(
+        crate::repository_graph::source::capture_worktree_tree(dir.path()).unwrap(),
+        worktree_before
+    );
     let integration_error = store::read_integration_error_for_run_dir(".ferrus/runs/t-007")
         .await
         .unwrap();
     assert!(integration_error.contains("configured checks failed"));
-    assert!(integration_error.contains("git grep -q base -- file.txt"));
+    assert!(integration_error.contains("printf mutated > file.txt"));
     let tasks = crate::project::list_tasks().await.unwrap();
     let task = tasks.iter().find(|task| task.id == "t-007").unwrap();
     assert_eq!(task.status, "reviewing");
@@ -872,4 +1039,15 @@ fn git_output<const N: usize>(cwd: &std::path::Path, args: [&str; N]) -> String 
         .unwrap();
     assert!(output.status.success());
     String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn git_output_bytes<const N: usize>(cwd: &std::path::Path, args: [&str; N]) -> Vec<u8> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(cwd)
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    output.stdout
 }

--- a/src/server/tools/approve_tests.rs
+++ b/src/server/tools/approve_tests.rs
@@ -48,6 +48,45 @@ async fn setup() -> (TempDir, std::path::PathBuf) {
     (dir, previous)
 }
 
+async fn prepare_frozen_review(
+    root: &std::path::Path,
+    baseline_tree: &str,
+    submitted_tree: &str,
+    patch: &str,
+) {
+    crate::project::pin_executor_baseline_tree(root, "t-007", baseline_tree)
+        .await
+        .unwrap();
+    let submitted_tree =
+        crate::repository_graph::source::parse_git_tree_digest(submitted_tree).unwrap();
+    crate::repository_graph::source::pin_submitted_tree(root, "t-007", &submitted_tree).unwrap();
+    store::write_patch_for_run_dir(".ferrus/runs/t-007", patch)
+        .await
+        .unwrap();
+    crate::project::record_task_status(
+        "t-007",
+        ".ferrus/tasks/t-007.md",
+        crate::project::TaskStatus::Reviewing,
+    )
+    .await
+    .unwrap();
+    let frozen_view = crate::project::RepositoryViewReference::materialized(
+        crate::repository_graph::domain::SnapshotId::new("baseline-snapshot").unwrap(),
+        None,
+        crate::repository_graph::domain::SnapshotId::new("submitted-snapshot").unwrap(),
+        crate::project::RepositoryViewStatus::Available,
+    )
+    .unwrap()
+    .frozen(submitted_tree)
+    .unwrap();
+    crate::project::record_task_repository_view("t-007", &frozen_view)
+        .await
+        .unwrap();
+    crate::project::claim_task("t-007", ".ferrus/tasks/t-007.md", "supervisor:codex:7", 60)
+        .await
+        .unwrap();
+}
+
 fn teardown(previous: std::path::PathBuf) {
     std::env::set_current_dir(previous).unwrap();
 }
@@ -462,9 +501,6 @@ async fn approve_rejects_submodule_gitlink_changes_without_completing_task() {
     let baseline_tree = git_output(dir.path(), ["rev-parse", "HEAD^{tree}"])
         .trim()
         .to_string();
-    crate::project::pin_executor_baseline_tree(dir.path(), "t-007", &baseline_tree)
-        .await
-        .unwrap();
 
     let gitlink_target = git_output(dir.path(), ["rev-parse", "HEAD"])
         .trim()
@@ -481,36 +517,7 @@ async fn approve_rejects_submodule_gitlink_changes_without_completing_task() {
     let patch = git_output(dir.path(), ["diff", "--cached", "--binary", "HEAD"]);
     assert!(!patch.trim().is_empty());
     assert!(git(dir.path(), ["reset", "--mixed", "HEAD"]).success());
-    let submitted_tree =
-        crate::repository_graph::source::parse_git_tree_digest(&submitted_tree).unwrap();
-    crate::repository_graph::source::pin_submitted_tree(dir.path(), "t-007", &submitted_tree)
-        .unwrap();
-
-    store::write_patch_for_run_dir(".ferrus/runs/t-007", &patch)
-        .await
-        .unwrap();
-    crate::project::record_task_status(
-        "t-007",
-        ".ferrus/tasks/t-007.md",
-        crate::project::TaskStatus::Reviewing,
-    )
-    .await
-    .unwrap();
-    let frozen_view = crate::project::RepositoryViewReference::materialized(
-        crate::repository_graph::domain::SnapshotId::new("baseline-snapshot").unwrap(),
-        None,
-        crate::repository_graph::domain::SnapshotId::new("submitted-snapshot").unwrap(),
-        crate::project::RepositoryViewStatus::Available,
-    )
-    .unwrap()
-    .frozen(submitted_tree)
-    .unwrap();
-    crate::project::record_task_repository_view("t-007", &frozen_view)
-        .await
-        .unwrap();
-    crate::project::claim_task("t-007", ".ferrus/tasks/t-007.md", "supervisor:codex:7", 60)
-        .await
-        .unwrap();
+    prepare_frozen_review(dir.path(), &baseline_tree, &submitted_tree, &patch).await;
 
     let error = run("supervisor:codex:7").await.unwrap_err().to_string();
 
@@ -521,6 +528,152 @@ async fn approve_rejects_submodule_gitlink_changes_without_completing_task() {
         .await
         .unwrap();
     assert!(integration_error.contains("change submodules are not supported"));
+    let task = crate::project::list_tasks()
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|task| task.id == "t-007")
+        .unwrap();
+    assert_eq!(task.status, "reviewing");
+
+    teardown(previous);
+}
+
+#[tokio::test]
+async fn approve_preserves_ignored_file_that_conflicts_with_submitted_addition() {
+    let _guard = crate::test_support::cwd_lock().lock().unwrap();
+    let (dir, previous) = setup().await;
+    if !git(dir.path(), ["init"]).success() {
+        teardown(previous);
+        return;
+    }
+    tokio::fs::write(".gitignore", "ignored.txt\n")
+        .await
+        .unwrap();
+    tokio::fs::write("file.txt", "baseline\n").await.unwrap();
+    assert!(git(dir.path(), ["add", ".gitignore", "file.txt"]).success());
+    assert!(
+        git(
+            dir.path(),
+            [
+                "-c",
+                "user.email=ferrus@example.invalid",
+                "-c",
+                "user.name=Ferrus",
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "-m",
+                "baseline",
+            ],
+        )
+        .success()
+    );
+    let baseline_tree = git_output(dir.path(), ["rev-parse", "HEAD^{tree}"])
+        .trim()
+        .to_string();
+
+    tokio::fs::write("ignored.txt", "submitted\n")
+        .await
+        .unwrap();
+    assert!(git(dir.path(), ["add", "-f", "ignored.txt"]).success());
+    let submitted_tree = git_output(dir.path(), ["write-tree"]).trim().to_string();
+    let patch = git_output(dir.path(), ["diff", "--cached", "--binary", "HEAD"]);
+    assert!(!patch.trim().is_empty());
+    assert!(git(dir.path(), ["reset", "--mixed", "HEAD"]).success());
+    tokio::fs::write("ignored.txt", "canonical local content\n")
+        .await
+        .unwrap();
+    prepare_frozen_review(dir.path(), &baseline_tree, &submitted_tree, &patch).await;
+
+    let error = run("supervisor:codex:7").await.unwrap_err().to_string();
+
+    assert!(error.contains("ignored local content"), "{error}");
+    assert_eq!(
+        tokio::fs::read_to_string("ignored.txt").await.unwrap(),
+        "canonical local content\n"
+    );
+    assert_eq!(git_output(dir.path(), ["write-tree"]).trim(), baseline_tree);
+    let integration_error = store::read_integration_error_for_run_dir(".ferrus/runs/t-007")
+        .await
+        .unwrap();
+    assert!(integration_error.contains("ignored local content"));
+    let task = crate::project::list_tasks()
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|task| task.id == "t-007")
+        .unwrap();
+    assert_eq!(task.status, "reviewing");
+
+    teardown(previous);
+}
+
+#[tokio::test]
+async fn approve_rejects_changes_outside_canonical_sparse_checkout() {
+    let _guard = crate::test_support::cwd_lock().lock().unwrap();
+    let (dir, previous) = setup().await;
+    if !git(dir.path(), ["init"]).success() {
+        teardown(previous);
+        return;
+    }
+    tokio::fs::create_dir_all("included").await.unwrap();
+    tokio::fs::create_dir_all("skipped").await.unwrap();
+    tokio::fs::write("included/file.txt", "included\n")
+        .await
+        .unwrap();
+    tokio::fs::write("skipped/file.txt", "baseline\n")
+        .await
+        .unwrap();
+    assert!(git(dir.path(), ["add", "included", "skipped"]).success());
+    assert!(
+        git(
+            dir.path(),
+            [
+                "-c",
+                "user.email=ferrus@example.invalid",
+                "-c",
+                "user.name=Ferrus",
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "-m",
+                "baseline",
+            ],
+        )
+        .success()
+    );
+    let baseline_tree = git_output(dir.path(), ["rev-parse", "HEAD^{tree}"])
+        .trim()
+        .to_string();
+
+    tokio::fs::write("skipped/file.txt", "submitted\n")
+        .await
+        .unwrap();
+    assert!(git(dir.path(), ["add", "skipped/file.txt"]).success());
+    let submitted_tree = git_output(dir.path(), ["write-tree"]).trim().to_string();
+    let patch = git_output(dir.path(), ["diff", "--cached", "--binary", "HEAD"]);
+    assert!(!patch.trim().is_empty());
+    assert!(git(dir.path(), ["reset", "--hard", "HEAD"]).success());
+    assert!(
+        git(dir.path(), ["sparse-checkout", "set", "included"]).success(),
+        "Git must support sparse-checkout check-rules for this test"
+    );
+    assert!(!dir.path().join("skipped/file.txt").exists());
+    prepare_frozen_review(dir.path(), &baseline_tree, &submitted_tree, &patch).await;
+
+    let error = run("supervisor:codex:7").await.unwrap_err().to_string();
+
+    assert!(
+        error.contains("outside the canonical sparse checkout"),
+        "{error}"
+    );
+    assert!(!dir.path().join("skipped/file.txt").exists());
+    assert_eq!(git_output(dir.path(), ["write-tree"]).trim(), baseline_tree);
+    let integration_error = store::read_integration_error_for_run_dir(".ferrus/runs/t-007")
+        .await
+        .unwrap();
+    assert!(integration_error.contains("outside the canonical sparse checkout"));
     let task = crate::project::list_tasks()
         .await
         .unwrap()


### PR DESCRIPTION
## Summary

- replace direct patch application with a three-way merge using the task baseline, the exact current canonical workspace, and the frozen submitted tree
- perform merge preparation and materialization through temporary Git indexes so the canonical index never receives conflict stages
- preserve staged, unstaged, untracked, binary, added, and deleted paths across both merge conflicts and post-apply check failures
- keep legacy submissions compatible by reconstructing their submitted tree from `PATCH.diff` against the pinned baseline
- retain bounded, recoverable integration errors for genuine conflicts

Closes #67.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Enhancement
- [ ] Performance
- [ ] Documentation
- [ ] Refactor
- [ ] Security
- [ ] Breaking change

## Workflow impact (if applicable)

- [ ] No impact
- [ ] Minor change (does not alter lifecycle semantics)
- [x] Changes behavior of an existing step
- [ ] Introduces new state/transition

`/approve` now merges an approved submission against the current canonical workspace instead of applying its patch directly. Task lifecycle and approval locking semantics are unchanged.

## Testing

- `cargo clippy -- -D warnings`
- `cargo fmt --check`
- `cargo test`

Regression coverage includes non-overlapping changes to the same file, overlapping conflicts, exact worktree and index preservation, and rollback after checks mutate and stage files.

## Checklist

- [x] I added/updated tests where it makes sense
- [x] I updated docs/examples if needed (no documentation changes required)
- [x] This change is backwards-compatible (or clearly marked as breaking)
- [x] I ran formatting/lints locally (if applicable)

## Notes for reviewers

The frozen submitted tree is authoritative when available. The patch-derived path exists only for submissions without a frozen repository view. Please pay particular attention to the temporary-index materialization and byte-for-byte index restoration paths.
