### PR TITLE
Render CLI tables with framed TUI output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,7 +581,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferrus"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -969,9 +969,9 @@ dependencies = [
 
 [[package]]
 name = "neva"
-version = "0.5.2"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a193dbe30828e326fa3c871137d1209da395c0303ffe3bf06bce67e8faa1cc9"
+checksum = "01dc6efd7d547724860ba419a19d5e6ade81204f7f997cf4a721cb91c4e20417"
 dependencies = [
  "base64 0.23.1",
  "bytes",
@@ -994,14 +994,14 @@ dependencies = [
 
 [[package]]
 name = "neva_macros"
-version = "0.5.2"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da175fc026f05e0d48ead4d53cbbf0544a896cdac051855316dcd30ea69e5ab"
+checksum = "1f8104e43d9f71bd3e1af203cbaec42d7d8cf9da40b8fb0ff01bfaeb8cf112fb"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1349,7 +1349,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1391,7 +1391,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1402,7 +1402,7 @@ checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1557,9 +1557,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1882,9 +1882,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.24.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -1912,9 +1912,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "volga-di"
-version = "0.9.6"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecfee2c5c6172647ee547c85306bb1b6447368f31e40df8a5ab0b1a834c32ea0"
+checksum = "8350199ab0f6b04576b74611e85af4adc80ac991a975e89dc093778a3bc76292"
 dependencies = [
  "http",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferrus"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 edition = "2024"
 rust-version = "1.95.0"
 license = "Apache-2.0"
@@ -24,11 +24,11 @@ name = "ferrus"
 path = "src/main.rs"
 
 [dependencies]
-neva = { version = "0.5.2", features = ["server", "di", "legacy-spec"] }
+neva = { version = "0.5.6", features = ["server", "di", "legacy-spec"] }
 tokio = { version = "1.52.3", features = ["fs", "macros", "process", "rt-multi-thread", "sync", "time"] }
 clap = { version = "4.6.1", features = ["derive"] }
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.150"
+serde = { version = "1.0.229", features = ["derive"] }
+serde_json = "1.0.151"
 toml = "1.1.2"
 toml_edit = "0.25.11"
 anyhow = "1.0.103"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ferrus
 
-[![Ferrus version](https://img.shields.io/badge/ferrus-0.4.0--alpha.2-orange)](https://crates.io/crates/ferrus)
+[![Ferrus version](https://img.shields.io/badge/ferrus-0.4.0--alpha.3-orange)](https://crates.io/crates/ferrus)
 [![Rust version](https://img.shields.io/badge/rustc-1.95+-964B00)](https://releases.rs/docs/1.95.0/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/ferrus-dev/ferrus/blob/main/LICENSE)
 [![Rust](https://github.com/ferrus-dev/ferrus/actions/workflows/rust.yml/badge.svg)](https://github.com/ferrus-dev/ferrus/actions/workflows/rust.yml)

--- a/src/hq/display.rs
+++ b/src/hq/display.rs
@@ -26,6 +26,17 @@ impl Display {
         }
     }
 
+    pub fn table(&self, lines: impl IntoIterator<Item = String>) {
+        let lines = lines.into_iter().collect::<Vec<_>>();
+        match lines.len() {
+            0 => {}
+            1 => self.info(lines.into_iter().next().unwrap_or_default()),
+            _ => {
+                let _ = self.0.send(UiMessage::Table(lines));
+            }
+        }
+    }
+
     pub fn tip(&self, msg: impl Into<String>) {
         let _ = self.0.send(UiMessage::Tip(msg.into()));
     }
@@ -157,6 +168,38 @@ mod tests {
         let msg = rx.try_recv().expect("message should be sent");
         match msg {
             UiMessage::Info(text) => assert_eq!(text, "first\nsecond"),
+            _ => panic!("expected info message"),
+        }
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn table_sends_structured_rows() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let display = Display(tx);
+
+        display.table(vec!["ID  Status".to_string(), "1   pending".to_string()]);
+
+        let msg = rx.try_recv().expect("message should be sent");
+        match msg {
+            UiMessage::Table(lines) => {
+                assert_eq!(lines, vec!["ID  Status", "1   pending"]);
+            }
+            _ => panic!("expected table message"),
+        }
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn single_table_message_stays_plain() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let display = Display(tx);
+
+        display.table(vec!["No tasks recorded in ferrus.db.".to_string()]);
+
+        let msg = rx.try_recv().expect("message should be sent");
+        match msg {
+            UiMessage::Info(text) => assert_eq!(text, "No tasks recorded in ferrus.db."),
             _ => panic!("expected info message"),
         }
         assert!(rx.try_recv().is_err());

--- a/src/hq/mod.rs
+++ b/src/hq/mod.rs
@@ -315,18 +315,16 @@ async fn dispatch_with_human_question_target(
         }
         ShellCommand::Tasks => {
             let tasks = crate::project::list_tasks().await?;
-            ctx.display
-                .info_block(crate::runtime_table::task_lines(&tasks));
+            ctx.display.table(crate::runtime_table::task_lines(&tasks));
         }
         ShellCommand::Run { limit } => ctx.run_batch_plan(limit).await?,
         ShellCommand::Runs { limit } => {
             let runs = crate::project::list_runs(limit).await?;
-            ctx.display
-                .info_block(crate::runtime_table::run_lines(&runs));
+            ctx.display.table(crate::runtime_table::run_lines(&runs));
         }
         ShellCommand::Events { limit, run_id } => {
             let events = crate::project::list_events(limit, run_id.clone()).await?;
-            ctx.display.info_block(crate::runtime_table::event_lines(
+            ctx.display.table(crate::runtime_table::event_lines(
                 &events,
                 run_id.as_deref(),
             ));

--- a/src/hq/tui.rs
+++ b/src/hq/tui.rs
@@ -65,6 +65,7 @@ const COMMANDS: &[(&str, &str)] = &[
 
 pub enum UiMessage {
     Info(String),
+    Table(Vec<String>),
     Success(String),
     Tip(String),
     Muted(String),
@@ -179,6 +180,10 @@ struct TranscriptLine {
 #[derive(Clone, Copy)]
 enum TranscriptKind {
     Info,
+    TableTop,
+    TableHeader,
+    TableRow,
+    TableBottom,
     Success,
     Tip,
     Muted,
@@ -601,6 +606,12 @@ fn handle_message(
         UiMessage::Info(text) => {
             let lines = split_transcript(&text, TranscriptKind::Info);
             app.messages.extend(lines.iter().cloned());
+            if !app.suspended {
+                redraw_dashboard(stdout, app, ui)?;
+            }
+        }
+        UiMessage::Table(rows) => {
+            app.messages.extend(table_transcript(&rows));
             if !app.suspended {
                 redraw_dashboard(stdout, app, ui)?;
             }

--- a/src/hq/tui/live_area.rs
+++ b/src/hq/tui/live_area.rs
@@ -342,7 +342,7 @@ pub(super) fn table_transcript(rows: &[String]) -> Vec<TranscriptLine> {
         continuation: false,
     });
     lines.extend(rows.iter().enumerate().map(|(idx, row)| TranscriptLine {
-        text: row.clone(),
+        text: sanitize_table_row(row),
         kind: if idx == 0 {
             TranscriptKind::TableHeader
         } else {
@@ -356,6 +356,12 @@ pub(super) fn table_transcript(rows: &[String]) -> Vec<TranscriptLine> {
         continuation: true,
     });
     lines
+}
+
+fn sanitize_table_row(row: &str) -> String {
+    row.chars()
+        .map(|ch| if ch.is_control() { ' ' } else { ch })
+        .collect()
 }
 
 #[allow(dead_code)]

--- a/src/hq/tui/live_area.rs
+++ b/src/hq/tui/live_area.rs
@@ -330,6 +330,34 @@ pub(super) fn split_transcript(text: &str, kind: TranscriptKind) -> Vec<Transcri
     lines
 }
 
+pub(super) fn table_transcript(rows: &[String]) -> Vec<TranscriptLine> {
+    if rows.is_empty() {
+        return Vec::new();
+    }
+
+    let mut lines = Vec::with_capacity(rows.len() + 2);
+    lines.push(TranscriptLine {
+        text: String::new(),
+        kind: TranscriptKind::TableTop,
+        continuation: false,
+    });
+    lines.extend(rows.iter().enumerate().map(|(idx, row)| TranscriptLine {
+        text: row.clone(),
+        kind: if idx == 0 {
+            TranscriptKind::TableHeader
+        } else {
+            TranscriptKind::TableRow
+        },
+        continuation: true,
+    }));
+    lines.push(TranscriptLine {
+        text: String::new(),
+        kind: TranscriptKind::TableBottom,
+        continuation: true,
+    });
+    lines
+}
+
 #[allow(dead_code)]
 pub(super) fn terminal_width() -> u16 {
     size().map(|(w, _)| w).unwrap_or(80)

--- a/src/hq/tui/render.rs
+++ b/src/hq/tui/render.rs
@@ -4,7 +4,7 @@ use super::*;
 pub(super) struct StyledSegment {
     pub(super) text: String,
     pub(super) color: Color,
-    bold: bool,
+    pub(super) bold: bool,
     pub(super) link: Option<String>,
 }
 
@@ -547,11 +547,38 @@ pub(super) fn recent_transcript_blocks(
         }
 
         let take = block.len().min(remaining - gap_before_newer_block);
-        selected.push(block.into_iter().take(take).collect::<Vec<_>>());
+        selected.push(take_transcript_block(block, take));
         remaining -= gap_before_newer_block + take;
     }
     selected.reverse();
     selected
+}
+
+pub(super) fn take_transcript_block(
+    mut block: Vec<TranscriptLine>,
+    take: usize,
+) -> Vec<TranscriptLine> {
+    if block.len() <= take {
+        return block;
+    }
+
+    let is_table = matches!(
+        block.first().map(|line| line.kind),
+        Some(TranscriptKind::TableTop)
+    ) && matches!(
+        block.last().map(|line| line.kind),
+        Some(TranscriptKind::TableBottom)
+    );
+    if is_table && take >= 2 {
+        let bottom = block
+            .pop()
+            .expect("table block should have a bottom border");
+        let mut visible = block.into_iter().take(take - 1).collect::<Vec<_>>();
+        visible.push(bottom);
+        return visible;
+    }
+
+    block.into_iter().take(take).collect()
 }
 
 pub(super) fn runtime_task_activity_lines(

--- a/src/hq/tui/render/support.rs
+++ b/src/hq/tui/render/support.rs
@@ -243,10 +243,70 @@ pub(in crate::hq::tui) fn transcript_activity_line(
     line: &TranscriptLine,
     width: usize,
 ) -> StyledLine {
+    if matches!(
+        line.kind,
+        TranscriptKind::TableTop
+            | TranscriptKind::TableHeader
+            | TranscriptKind::TableRow
+            | TranscriptKind::TableBottom
+    ) {
+        return table_activity_line(line, width);
+    }
+
     let text = format!("  {}", activity_text(line));
     let color = transcript_color(line.kind);
     log_path_line(&text, color, width)
         .unwrap_or_else(|| StyledLine::plain(truncate_to_width(&text, width), color))
+}
+
+pub(in crate::hq::tui) fn table_activity_line(line: &TranscriptLine, width: usize) -> StyledLine {
+    const TABLE_INSET: usize = 2;
+    const CELL_PADDING: usize = 1;
+
+    let block_width = width.saturating_sub(TABLE_INSET * 2);
+    if block_width < 2 {
+        return StyledLine::plain(truncate_to_width(&line.text, width), Color::Grey);
+    }
+
+    let inset = " ".repeat(TABLE_INSET.min(width));
+    match line.kind {
+        TranscriptKind::TableTop => StyledLine::plain(
+            format!("{inset}╭{}╮", "─".repeat(block_width.saturating_sub(2))),
+            Color::DarkGrey,
+        ),
+        TranscriptKind::TableBottom => StyledLine::plain(
+            format!("{inset}╰{}╯", "─".repeat(block_width.saturating_sub(2))),
+            Color::DarkGrey,
+        ),
+        TranscriptKind::TableHeader | TranscriptKind::TableRow => {
+            let content_width = block_width.saturating_sub(CELL_PADDING * 2 + 2);
+            let content = pad_or_truncate(&line.text, content_width);
+            let is_header = matches!(line.kind, TranscriptKind::TableHeader);
+            StyledLine {
+                segments: vec![
+                    StyledSegment {
+                        text: format!("{inset}│{}", " ".repeat(CELL_PADDING)),
+                        color: Color::DarkGrey,
+                        bold: false,
+                        link: None,
+                    },
+                    StyledSegment {
+                        text: content,
+                        color: if is_header { orange() } else { Color::Grey },
+                        bold: is_header,
+                        link: None,
+                    },
+                    StyledSegment {
+                        text: format!("{}│", " ".repeat(CELL_PADDING)),
+                        color: Color::DarkGrey,
+                        bold: false,
+                        link: None,
+                    },
+                ],
+            }
+        }
+        _ => StyledLine::plain(truncate_to_width(&line.text, width), Color::Grey),
+    }
 }
 
 pub(in crate::hq::tui) fn log_path_line(
@@ -327,6 +387,9 @@ pub(in crate::hq::tui) fn percent_encode_uri_path(value: &str) -> String {
 pub(in crate::hq::tui) fn transcript_color(kind: TranscriptKind) -> Color {
     match kind {
         TranscriptKind::Info => Color::Grey,
+        TranscriptKind::TableTop | TranscriptKind::TableBottom => Color::DarkGrey,
+        TranscriptKind::TableHeader => orange(),
+        TranscriptKind::TableRow => Color::Grey,
         TranscriptKind::Success => Color::Green,
         TranscriptKind::Tip => Color::Yellow,
         TranscriptKind::Muted => Color::DarkGrey,

--- a/src/hq/tui_tests.rs
+++ b/src/hq/tui_tests.rs
@@ -353,6 +353,66 @@ fn command_output_renders_in_unframed_activity_area() {
 }
 
 #[test]
+fn table_output_renders_with_frame_and_orange_header() {
+    let mut app = App::new();
+    app.messages.extend(table_transcript(&[
+        "ID            Status".into(),
+        "t-001         pending".into(),
+    ]));
+
+    let rows = dashboard_lines(&app, 80, 40);
+    let rendered = rows
+        .iter()
+        .map(|row| {
+            row.line
+                .segments
+                .iter()
+                .map(|segment| segment.text.as_str())
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>();
+    let header_row = rendered
+        .iter()
+        .position(|line| line.starts_with("  │ ID"))
+        .expect("table header should be rendered");
+    let top = header_row - 1;
+
+    assert!(rendered[top].starts_with("  ╭"));
+    assert!(rendered[top + 2].starts_with("  │ t-001"));
+    assert!(rendered[top + 3].starts_with("  ╰"));
+    assert!(
+        rendered[top..=top + 3]
+            .iter()
+            .all(|line| display_width(line) == 78)
+    );
+
+    let header = &rows[top + 1].line;
+    let header_content = header
+        .segments
+        .iter()
+        .find(|segment| segment.text.contains("ID"))
+        .expect("table header content should be styled separately");
+    assert_eq!(header_content.color, orange());
+    assert!(header_content.bold);
+}
+
+#[test]
+fn truncated_table_keeps_both_borders_and_header() {
+    let table = table_transcript(&[
+        "ID  Status".into(),
+        "1   pending".into(),
+        "2   complete".into(),
+    ]);
+
+    let blocks = recent_transcript_blocks(&table, 3);
+
+    assert_eq!(blocks.len(), 1);
+    assert!(matches!(blocks[0][0].kind, TranscriptKind::TableTop));
+    assert!(matches!(blocks[0][1].kind, TranscriptKind::TableHeader));
+    assert!(matches!(blocks[0][2].kind, TranscriptKind::TableBottom));
+}
+
+#[test]
 fn success_activity_gets_leading_dot() {
     let line = TranscriptLine {
         text: "Task t-001 completed.".into(),

--- a/src/hq/tui_tests.rs
+++ b/src/hq/tui_tests.rs
@@ -413,6 +413,20 @@ fn truncated_table_keeps_both_borders_and_header() {
 }
 
 #[test]
+fn table_transcript_replaces_control_characters_without_adding_rows() {
+    let table = table_transcript(&["ID\nStatus".into(), "t-001\r\npending\t\u{1b}[31m".into()]);
+
+    assert_eq!(table.len(), 4);
+    assert_eq!(table[1].text, "ID Status");
+    assert_eq!(table[2].text, "t-001  pending  [31m");
+    assert!(
+        table[1..=2]
+            .iter()
+            .all(|line| !line.text.chars().any(char::is_control))
+    );
+}
+
+#[test]
 fn success_activity_gets_leading_dot() {
     let line = TranscriptLine {
         text: "Task t-001 completed.".into(),

--- a/src/runtime_table.rs
+++ b/src/runtime_table.rs
@@ -126,11 +126,16 @@ pub fn event_lines(events: &[EventRecord], run_filter: Option<&str>) -> Vec<Stri
 }
 
 fn compact(value: &str, max_chars: usize) -> String {
-    let mut chars = value.chars();
-    let mut shortened: String = chars.by_ref().take(max_chars).collect();
-    if chars.next().is_some() {
-        shortened.push_str("...");
+    if value.chars().count() <= max_chars {
+        return value.to_string();
     }
+
+    if max_chars <= 3 {
+        return ".".repeat(max_chars);
+    }
+
+    let mut shortened = value.chars().take(max_chars - 3).collect::<String>();
+    shortened.push_str("...");
     shortened
 }
 
@@ -167,8 +172,30 @@ mod tests {
 
         assert!(lines[0].contains("Spec"));
         assert!(lines[0].contains("Milestone"));
-        assert!(lines[1].contains("docs/specs/sp"));
+        assert!(lines[1].contains("docs/specs/..."));
         assert!(lines[1].contains("m1.0"));
+    }
+
+    #[test]
+    fn task_lines_keep_columns_aligned_after_compacted_spec() {
+        let tasks = vec![TaskRecord {
+            id: "t-001".to_string(),
+            path: ".ferrus/tasks/t-001.md".to_string(),
+            spec_path: Some("docs/specs/a-very-long-spec-name.md".to_string()),
+            milestone_id: Some("m1.0".to_string()),
+            status: "complete".to_string(),
+            paused_status: None,
+            claimed_by: None,
+            lease_until: None,
+            last_heartbeat: None,
+            check_retries: 0,
+            review_cycles: 0,
+            failure_reason: None,
+        }];
+
+        let lines = task_lines(&tasks);
+
+        assert_eq!(lines[0].find("Milestone"), lines[1].find("m1.0"));
     }
 
     #[test]
@@ -213,6 +240,34 @@ mod tests {
         assert!(lines[1].contains("r-123"));
         assert!(lines[1].contains("executor"));
         assert!(lines[1].contains("42"));
+    }
+
+    #[test]
+    fn run_lines_keep_columns_aligned_after_compacted_agent() {
+        let runs = vec![RunRecord {
+            id: "r-123".to_string(),
+            task_id: "t-001".to_string(),
+            role: "executor".to_string(),
+            agent: "executor:a-very-long-agent-name".to_string(),
+            status: "completed".to_string(),
+            started_at: "2026-05-17T10:00:00Z".to_string(),
+            updated_at: "2026-05-17T10:01:00Z".to_string(),
+            pid: None,
+            workspace_path: "/tmp/ferrus".to_string(),
+        }];
+
+        let lines = run_lines(&runs);
+
+        assert_eq!(lines[0].find("Status"), lines[1].find("completed"));
+    }
+
+    #[test]
+    fn compact_keeps_ellipsis_within_the_requested_width() {
+        assert_eq!(compact("abcdefgh", 6), "abc...");
+        assert_eq!(compact("abcdefgh", 3), "...");
+        assert_eq!(compact("abcdefgh", 2), "..");
+        assert_eq!(compact("abcdefgh", 0), "");
+        assert_eq!(compact("abc", 3), "abc");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add structured HQ table messages for `/tasks`, `/runs`, and `/events`.
- Render table output with terminal-width frames and bold orange headers consistent with the existing dashboard panels.
- Preserve plain empty-state messages and keep both table borders visible when terminal height truncates the rows.
- Keep columns aligned by including `...` within each field's configured width.
- Bump Ferrus to `0.4.0-alpha.3`, update the README badge, and refresh `neva`, `serde`, `serde_json`, and related lockfile dependencies.

## Type

- [x] Bug fix
- [ ] Feature
- [x] Enhancement
- [ ] Performance
- [ ] Documentation
- [ ] Refactor
- [ ] Security
- [ ] Breaking change

## Workflow impact (if applicable)

Does this change affect the Supervisor -> Executor -> Reviewer flow?

- [x] No impact
- [ ] Minor change (does not alter lifecycle semantics)
- [ ] Changes behavior of an existing step
- [ ] Introduces new state/transition

If yes, briefly explain:

Not applicable. This changes HQ presentation only; task, run, and lifecycle semantics are unchanged.

## Checklist

- [x] I added/updated tests where it makes sense
- [x] I updated docs/examples if needed
- [x] This change is backwards-compatible (or clearly marked as breaking)
- [x] I ran formatting/lints locally (if applicable)

## Notes for reviewers

- Table framing is limited to the HQ `/tasks`, `/runs`, and `/events` output; ordinary transcript and empty-state messages remain unframed.
- Regression coverage checks header styling, terminal-width framing, height truncation, and column alignment after value compaction.
- Verified with `cargo clippy -- -D warnings`, `cargo fmt --check`, and `cargo test`.
