### PR TITLE
Reduce runtime overhead and binary size

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,6 +39,12 @@ jobs:
       - name: Run tests
         run: cargo test --locked
 
+      - name: Check build without update notifications
+        run: cargo clippy --locked --no-default-features -- -D warnings
+
+      - name: Test build without update notifications
+        run: cargo test --locked --no-default-features
+
   smoke:
     strategy:
       fail-fast: false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,7 +543,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferrus"
-version = "0.4.0-alpha.3"
+version = "0.4.1-alpha.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
- "crypto-common 0.2.2",
+ "crypto-common",
  "inout",
 ]
 
@@ -127,15 +127,6 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
@@ -185,7 +176,7 @@ checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures 0.3.0",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -247,8 +238,8 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "block-buffer 0.12.1",
- "crypto-common 0.2.2",
+ "block-buffer",
+ "crypto-common",
  "inout",
 ]
 
@@ -324,15 +315,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -418,16 +400,6 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "crypto-common"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
@@ -484,23 +456,13 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer 0.10.4",
- "crypto-common 0.1.7",
-]
-
-[[package]]
-name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.1",
+ "block-buffer",
  "const-oid",
- "crypto-common 0.2.2",
+ "crypto-common",
 ]
 
 [[package]]
@@ -599,7 +561,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "shlex 2.0.1",
  "tempfile",
  "thiserror",
@@ -670,16 +632,6 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -985,7 +937,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "sha2 0.11.0",
+ "sha2",
  "tokio",
  "tokio-util",
  "uuid",
@@ -1103,7 +1055,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2d0073b297041425c7c3df6eb4792d598a15323fe63346852b092eca02904c"
 dependencies = [
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "universal-hash",
 ]
 
@@ -1430,24 +1382,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1830,7 +1771,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
 dependencies = [
- "crypto-common 0.2.2",
+ "crypto-common",
  "ctutils",
 ]
 
@@ -1903,12 +1844,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "volga-di"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ path = "src/main.rs"
 
 [dependencies]
 neva = { version = "0.5.6", features = ["server", "di", "legacy-spec"] }
-tokio = { version = "1.52.3", features = ["fs", "macros", "process", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1.52.3", features = ["fs", "io-util", "macros", "process", "rt-multi-thread", "sync", "time"] }
 clap = { version = "4.6.1", features = ["derive"] }
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferrus"
-version = "0.4.0-alpha.3"
+version = "0.4.1-alpha.1"
 edition = "2024"
 rust-version = "1.95.0"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,10 @@ exclude = [
 name = "ferrus"
 path = "src/main.rs"
 
+[features]
+default = ["update-check"]
+update-check = ["dep:semver", "dep:ureq"]
+
 [dependencies]
 neva = { version = "0.5.6", features = ["server", "di", "legacy-spec"] }
 tokio = { version = "1.52.3", features = ["fs", "io-util", "macros", "process", "rt-multi-thread", "sync", "time"] }
@@ -41,11 +45,11 @@ shlex = "2.0.1"
 crossterm = { version = "0.29.0", features = ["event-stream"] }
 dirs = "6.0.0"
 futures-util = { version = "0.3.32", default-features = false, features = ["std"] }
-semver = "1.0.28"
-ureq = { version = "3.3.0", default-features = false, features = ["rustls"] }
+semver = { version = "1.0.28", optional = true }
+ureq = { version = "3.3.0", default-features = false, features = ["rustls"], optional = true }
 rusqlite = { version = "0.40.1", features = ["bundled", "hooks"] }
 ring = "0.17.14"
-sha2 = "0.10.9"
+sha2 = "0.11.0"
 tree-sitter = "=0.26.11"
 tree-sitter-rust = "=0.24.2"
 
@@ -64,12 +68,14 @@ tempfile = "3.27.0"
 name = "repository_graph"
 harness = false
 
-[profile.dist]
-inherits = "release"
-opt-level = "z"
+[profile.release]
 lto = "thin"
 codegen-units = 1
 strip = "symbols"
+
+[profile.dist]
+inherits = "release"
+opt-level = "z"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-unknown-linux-gnu"

--- a/README.md
+++ b/README.md
@@ -77,6 +77,20 @@ curl -fsSL https://ferrus.dev/cli/install.sh | sh
 iwr https://ferrus.dev/cli/install.ps1 -useb | iex
 ```
 
+For a smaller Cargo installation, use the same size profile as release assets:
+
+```sh
+cargo install ferrus --locked --profile dist
+```
+
+HQ update notifications are enabled by default. To omit the update-check HTTP/TLS client:
+
+```sh
+cargo install ferrus --locked --profile dist --no-default-features
+```
+
+See [build profiles and size measurements](docs/binary-size.md) for the tradeoffs.
+
 Run:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ferrus
 
-[![Ferrus version](https://img.shields.io/badge/ferrus-0.4.0--alpha.3-orange)](https://crates.io/crates/ferrus)
+[![Ferrus version](https://img.shields.io/badge/ferrus-0.4.1--alpha.1-orange)](https://crates.io/crates/ferrus)
 [![Rust version](https://img.shields.io/badge/rustc-1.95+-964B00)](https://releases.rs/docs/1.95.0/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/ferrus-dev/ferrus/blob/main/LICENSE)
 [![Rust](https://github.com/ferrus-dev/ferrus/actions/workflows/rust.yml/badge.svg)](https://github.com/ferrus-dev/ferrus/actions/workflows/rust.yml)

--- a/docs/binary-size.md
+++ b/docs/binary-size.md
@@ -1,0 +1,73 @@
+# Binary size measurements
+
+These are local development measurements for issue #71, not cross-platform size or performance guarantees.
+Measurements use macOS arm64 and Rust 1.98.0. File sizes include the linked executable, without compression.
+
+## Measurements recorded 2026-09-05
+
+| Build | Bytes | MiB |
+|---|---:|---:|
+| Original release | 22,972,720 | 21.91 |
+| Release with ThinLTO, one codegen unit, stripping, and unified sha2 | 14,411,904 | 13.74 |
+| Original dist (`z`) | 10,918,704 | 10.41 |
+| Dist (`z`) with unified sha2, default features | 10,920,208 | 10.41 |
+| Dist settings with `s`, unified sha2, default features | 12,992,608 | 12.39 |
+| Dist (`z`) with unified sha2, no default features | 9,576,720 | 9.13 |
+
+The final release build is 37.3% smaller than the original release build. Disabling update notifications reduces
+the final `dist` executable by another 12.3%. Standard builds continue to include update notifications.
+The `s` variant is 19.0% larger than `z`, so `dist` retains `z` for compact release assets and installations.
+
+| Graph operation, 302-file fixture | `z` | `s` |
+|---|---:|---:|
+| Cold indexing | 116.57 ms | 102.28 ms |
+| No-op indexing | 31.098 ms | 28.501 ms |
+| One-file change | 92.077 ms | 79.320 ms |
+| Exact symbol search | 351.58 us | 284.53 us |
+
+These quick runs show the tradeoff: `s` was faster on this fixture but added almost 2 MiB. Both profiles passed
+the benchmark's graph reuse and search invariants. Keep `release` at optimization level 3 for ordinary Cargo
+installations and reserve `dist` for users and release assets that prioritize file size.
+
+## Cargo installation profile
+
+The `release` profile uses ThinLTO, one codegen unit, and symbol stripping, including ordinary `cargo install`.
+It retains Cargo's default `opt-level = 3`. The `dist` profile inherits these settings and optimizes for size.
+Panic unwinding remains enabled. ThinLTO and one codegen unit trade additional build/link work for smaller
+executables; stripped release files omit symbol names used in native debugging.
+
+## Reproduce
+
+```sh
+cargo build --locked --release
+cargo build --locked --profile dist
+cargo build --locked --profile dist --no-default-features
+cargo build --locked --profile dist --config 'profile.dist.opt-level="s"'
+
+cargo bench --locked --profile dist --bench repository_graph -- --quick
+cargo bench --locked --profile dist --config 'profile.dist.opt-level="s"' --bench repository_graph -- --quick
+```
+
+Copy each executable before the next build overwrites it. Compare `s` and `z` with the same dependency lockfile,
+features, LTO, stripping, and codegen-unit settings. The graph benchmark creates the same 302-file fixture for
+each profile; fixture setup and initial source discovery are outside measured indexing iterations. Quick runs
+are smoke measurements with too few samples to establish small performance differences.
+
+## Optional update notifications
+
+The default `update-check` feature enables the existing HQ update notification. Disabling default features
+omits its task, cache access, `ureq` client, and TLS dependency tree. CLI commands, orchestration, and graph/memory
+operations remain available. This option does not disable networking performed by agent executables.
+
+```sh
+cargo install ferrus --locked --profile dist --no-default-features
+```
+
+CI runs clippy and tests with both default features and `--no-default-features` on Linux, macOS, and Windows.
+
+## SHA-256 dependency consolidation
+
+Ferrus now uses `sha2` 0.11, matching `neva`. This removes the old `sha2`, `digest`, `block-buffer`,
+`crypto-common`, `cpufeatures`, `generic-array`, and `version_check` packages from the lockfile. No unrelated
+package versions were updated. On identical `dist --no-default-features` builds, the executable changed from
+9,576,336 to 9,576,720 bytes (+384 bytes), so this cleanup provides no meaningful linked-size saving.

--- a/docs/cli-and-runtime.md
+++ b/docs/cli-and-runtime.md
@@ -192,7 +192,9 @@ model = ""
 ```
 
 Executor MCP checks run in the task workspace and write full logs under `.ferrus/logs/`, returning bounded
-failure summaries. HQ `/check` runs in HQ's working directory without task-state or retry changes.
+failure summaries. Output is spooled to disk; each failed command's feedback retains at most
+`max_feedback_lines` trailing lines and 64 KiB, including for a single long line. HQ `/check` runs in
+HQ's working directory without task-state or retry changes.
 A dispatch limit of zero disables that guard; a fresh rejection resets its counter. `max_parallel_tasks`
 controls Executor concurrency, while `/run --limit N` caps the planned batch. Non-Git projects use the
 canonical directory and permit only one Executor.

--- a/docs/repository-graph-architecture.md
+++ b/docs/repository-graph-architecture.md
@@ -239,6 +239,16 @@ Availability, build execution, publication, and freshness are orthogonal and mus
 - `failed`: an attempt stopped with diagnostics;
 - `superseded`: a complete attempt lost publication compare-and-set to a newer view.
 
+Incremental indexing can reuse a completed snapshot without loading cached fragments or rerunning resolution.
+This requires matching snapshot identity, persisted index metrics and fact counts, and identical source warnings
+in both the original fact-producing build and the latest diagnostic set. Analyzer diagnostics or changed source
+warnings use the normal indexing path. `--full` always bypasses both snapshot and fragment reuse.
+
+Reuse still revalidates source before completion and before publication, rechecks eligibility transactionally,
+and uses the normal publication compare-and-set. It records a new build attempt and its diagnostics while
+preserving the existing snapshot and publication generation on a no-op. Fragment timestamps are unchanged because
+no fragments were read; retained snapshot file references continue to protect those fragments from collection.
+
 ### Freshness
 
 - `fresh`: the current effective source manifest, graph model, semantic config, and extractor set match the pinned

--- a/docs/repository-graph-benchmarks.md
+++ b/docs/repository-graph-benchmarks.md
@@ -32,6 +32,28 @@ point estimates; compilation and per-iteration setup are excluded.
 | Medium fixture one-file change | 84.0 ms | 1 | 301 | new snapshot |
 | Medium fixture indexed symbol search | 238 us | -- | -- | 1 hit |
 
+## Completed-snapshot reuse recorded 2026-09-04
+
+Environment: macOS arm64, Rust 1.98.0, Criterion 0.8.2. Both runs used
+`cargo bench --offline --locked --bench repository_graph -- --quick` and the same 302-file fixture.
+The before run includes the preceding fragment-cache and allocation improvements from issue #71.
+
+| Operation | Before snapshot reuse | After snapshot reuse |
+|---|---:|---:|
+| Cold indexing | 92.487 ms | 91.644 ms |
+| No-op indexing | 38.127 ms | 24.134 ms |
+| One-file change | 71.513 ms | 73.616 ms |
+| Exact symbol search | 262.55 us | 263.64 us |
+
+No-op elapsed time decreased by about 37% in this smoke run. The quick sample was too small for Criterion's
+significance threshold (p = 0.06); treat the values as preliminary timings, not a statistically established
+speedup. The fast path retains both source revalidations, so it still reads the source during verification.
+It skips fragment loading, graph merging, and resolution, and sends no file or fact payload to completion.
+
+Reuse requires unchanged source warnings and no analyzer diagnostics in the original and current diagnostic
+sets. Otherwise normal indexing runs. Regression tests cover absent fragment caches, forced full builds,
+diagnostic refresh, source changes, concurrent publication, and snapshot collection during revalidation.
+
 ## Ferrus dogfood recorded 2026-07-14
 
 These dogfood timings used the debug CLI build and are retained as functional evidence, not as values to compare

--- a/src/checks/runner.rs
+++ b/src/checks/runner.rs
@@ -70,6 +70,7 @@ async fn run_command(
     }
     let mut command = platform::shell_command(cmd);
     command.kill_on_drop(true);
+    command.stdin(Stdio::null());
     if let Some(cwd) = cwd {
         command.current_dir(cwd);
     }
@@ -131,6 +132,65 @@ mod tests {
     //! Check ordering, aggregate failure reporting, and empty-command behavior.
 
     use super::*;
+
+    #[cfg(unix)]
+    const STDIN_HELPER_ENV: &str = "FERRUS_CHECK_RUNNER_STDIN_HELPER";
+
+    #[cfg(unix)]
+    #[test]
+    fn check_commands_cannot_consume_runner_stdin() {
+        use std::io::Write as _;
+
+        for mode in ["logged", "unlogged"] {
+            let mut child = std::process::Command::new(std::env::current_exe().unwrap())
+                .args([
+                    "--exact",
+                    "checks::runner::tests::stdin_is_closed_in_check_helper",
+                    "--nocapture",
+                ])
+                .env(STDIN_HELPER_ENV, mode)
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .unwrap();
+
+            let mut stdin = child.stdin.take().unwrap();
+            stdin.write_all(b"{\"jsonrpc\":\"2.0\"}\n").unwrap();
+            drop(stdin);
+
+            let output = child.wait_with_output().unwrap();
+            assert!(
+                output.status.success(),
+                "{mode} check inherited runner stdin:\n{}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn stdin_is_closed_in_check_helper() {
+        let Ok(mode) = std::env::var(STDIN_HELPER_ENV) else {
+            return;
+        };
+        let commands = vec!["if IFS= read -r line; then exit 42; fi".into()];
+        let result = if mode == "logged" {
+            let dir = tempfile::tempdir().unwrap();
+            run_checks_logged(
+                &commands,
+                Some(dir.path()),
+                &dir.path().join("checks.log"),
+                30,
+            )
+            .await
+            .unwrap()
+        } else {
+            run_checks(&commands).await.unwrap()
+        };
+
+        assert!(result.passed);
+    }
 
     #[cfg(unix)]
     #[tokio::test]

--- a/src/checks/runner.rs
+++ b/src/checks/runner.rs
@@ -1,15 +1,18 @@
-//! Run configured checks in order and capture each command's exit status and output.
+//! Run configured checks in order, spooling review output to disk.
 
 use anyhow::{Context, Result};
-use std::path::Path;
+use std::{path::Path, process::Stdio};
 
 use crate::platform;
+
+mod output;
+pub(crate) use output::CapturedOutput;
+use output::Spool;
 
 pub struct CommandResult {
     pub command: String,
     pub passed: bool,
-    pub stdout: String,
-    pub stderr: String,
+    pub output: CapturedOutput,
 }
 
 pub struct CheckResult {
@@ -17,59 +20,109 @@ pub struct CheckResult {
     pub commands: Vec<CommandResult>,
 }
 
-/// Run every configured check command in order, collecting stdout/stderr for each.
+/// HQ needs exit statuses only; discard output directly rather than buffering it.
 pub async fn run_checks(commands: &[String]) -> Result<CheckResult> {
-    run_checks_with_cwd(commands, None).await
+    run_checks_with_cwd(commands, None, None, 0).await
 }
 
-pub async fn run_checks_in(commands: &[String], cwd: &Path) -> Result<CheckResult> {
-    run_checks_with_cwd(commands, Some(cwd)).await
+pub async fn run_checks_logged(
+    commands: &[String],
+    cwd: Option<&Path>,
+    log_path: &Path,
+    max_feedback_lines: usize,
+) -> Result<CheckResult> {
+    run_checks_with_cwd(commands, cwd, Some(log_path), max_feedback_lines).await
 }
 
-async fn run_checks_with_cwd(commands: &[String], cwd: Option<&Path>) -> Result<CheckResult> {
+async fn run_checks_with_cwd(
+    commands: &[String],
+    cwd: Option<&Path>,
+    log_path: Option<&Path>,
+    max_feedback_lines: usize,
+) -> Result<CheckResult> {
     let mut results = Vec::with_capacity(commands.len());
     let mut passed = true;
-
     for cmd in commands {
-        let result = run_command(cmd, cwd)
+        let result = run_command(cmd, cwd, log_path, max_feedback_lines)
             .await
-            .with_context(|| format!("Failed to spawn command: {cmd}"))?;
-        if !result.passed {
-            passed = false;
-        }
+            .with_context(|| format!("Failed to run command: {cmd}"))?;
+        passed &= result.passed;
         results.push(result);
     }
-
     Ok(CheckResult {
         passed,
         commands: results,
     })
 }
 
-async fn run_command(cmd: &str, cwd: Option<&Path>) -> Result<CommandResult> {
+async fn run_command(
+    cmd: &str,
+    cwd: Option<&Path>,
+    log_path: Option<&Path>,
+    max_feedback_lines: usize,
+) -> Result<CommandResult> {
     if cmd.trim().is_empty() {
         return Ok(CommandResult {
             command: cmd.to_string(),
             passed: true,
-            stdout: String::new(),
-            stderr: String::new(),
+            output: CapturedOutput::default(),
         });
     }
-
     let mut command = platform::shell_command(cmd);
+    command.kill_on_drop(true);
     if let Some(cwd) = cwd {
         command.current_dir(cwd);
     }
-    let output = command
-        .output()
-        .await
-        .with_context(|| format!("Failed to run check command `{cmd}`"))?;
-
+    let Some(log_path) = log_path else {
+        let status = command
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .await?;
+        return Ok(CommandResult {
+            command: cmd.to_string(),
+            passed: status.success(),
+            output: CapturedOutput::default(),
+        });
+    };
+    let stdout_spool = Spool::new(log_path, "stdout")?;
+    let stderr_spool = Spool::new(log_path, "stderr")?;
+    let mut stdout_file = tokio::fs::File::from_std(stdout_spool.file().try_clone()?);
+    let mut stderr_file = tokio::fs::File::from_std(stderr_spool.file().try_clone()?);
+    let mut child = command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    let mut stdout = child.stdout.take().expect("stdout is piped");
+    let mut stderr = child.stderr.take().expect("stderr is piped");
+    let (status, _, _) = tokio::try_join!(
+        child.wait(),
+        tokio::io::copy(&mut stdout, &mut stdout_file),
+        tokio::io::copy(&mut stderr, &mut stderr_file),
+    )?;
+    // Tokio file writes may still be in flight after the last poll_write.
+    use tokio::io::AsyncWriteExt;
+    stdout_file.flush().await?;
+    stderr_file.flush().await?;
+    drop((stdout_file, stderr_file));
+    let passed = status.success();
+    let log_path = log_path.to_path_buf();
+    let command = cmd.to_string();
+    let output = tokio::task::spawn_blocking(move || {
+        output::finish_log(
+            &log_path,
+            &command,
+            passed,
+            stdout_spool,
+            stderr_spool,
+            max_feedback_lines,
+        )
+    })
+    .await??;
     Ok(CommandResult {
         command: cmd.to_string(),
-        passed: output.status.success(),
-        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        passed,
+        output,
     })
 }
 
@@ -78,6 +131,62 @@ mod tests {
     //! Check ordering, aggregate failure reporting, and empty-command behavior.
 
     use super::*;
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn logged_checks_drain_both_streams_and_keep_full_output_on_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("checks.log");
+        let commands = vec![
+            "printf 'first\\n'".into(),
+            "i=0; while [ $i -lt 10000 ]; do printf 'stdout-%s\\n' \"$i\"; printf 'stderr-%s\\n' \"$i\" >&2; i=$((i + 1)); done; printf 'last failure\\n' >&2; exit 1".into(),
+        ];
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(15),
+            run_checks_logged(&commands, Some(dir.path()), &log_path, 3),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        assert!(!result.passed);
+        assert!(result.commands[0].passed);
+        let output = &result.commands[1].output;
+        assert_eq!(output.total_lines, 20_001);
+        assert_eq!(output.tail, "stderr-9998\nstderr-9999\nlast failure");
+        assert!(output.truncated);
+        let log = std::fs::read_to_string(&log_path).unwrap();
+        for expected in [
+            "first\n",
+            "stdout-0\n",
+            "stdout-9999\n",
+            "stderr-0\n",
+            "stderr-9999\n",
+            "last failure\n",
+        ] {
+            assert!(log.contains(expected), "missing {expected:?}");
+        }
+        assert!(log.contains("=== [PASS]"));
+        assert!(log.contains("=== [FAIL]"));
+        assert_eq!(
+            std::fs::read_dir(dir.path()).unwrap().count(),
+            1,
+            "spools must be removed"
+        );
+    }
+
+    #[tokio::test]
+    async fn logged_checks_clean_spools_after_spawn_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let result = run_checks_logged(
+            &["echo failure".into()],
+            Some(&dir.path().join("missing-directory")),
+            &dir.path().join("checks.log"),
+            30,
+        )
+        .await;
+        assert!(result.is_err());
+        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 0);
+    }
 
     #[cfg(unix)]
     const PASSING_COMMAND: &str = "true";
@@ -135,8 +244,7 @@ mod tests {
         assert_eq!(result.commands.len(), 1);
         assert_eq!(result.commands[0].command, "");
         assert!(result.commands[0].passed);
-        assert!(result.commands[0].stdout.is_empty());
-        assert!(result.commands[0].stderr.is_empty());
+        assert!(result.commands[0].output.tail.is_empty());
     }
 
     #[tokio::test]
@@ -152,9 +260,17 @@ mod tests {
     async fn run_checks_uses_shell_parsing_for_quoted_arguments() {
         let commands = vec!["printf '%s' 'hello world'".to_string()];
 
-        let result = run_checks(&commands).await.unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let result = run_checks_logged(
+            &commands,
+            Some(dir.path()),
+            &dir.path().join("checks.log"),
+            30,
+        )
+        .await
+        .unwrap();
 
         assert!(result.passed);
-        assert_eq!(result.commands[0].stdout, "hello world");
+        assert_eq!(result.commands[0].output.tail, "hello world");
     }
 }

--- a/src/checks/runner/output.rs
+++ b/src/checks/runner/output.rs
@@ -1,0 +1,240 @@
+//! Temporary stream spools and byte/line bounded feedback. Full logs stay on disk.
+
+use std::{
+    collections::VecDeque,
+    fs::{File, OpenOptions},
+    io::{self, BufWriter, Read, Seek, SeekFrom, Write},
+    path::{Path, PathBuf},
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use anyhow::Result;
+
+const MAX_FEEDBACK_BYTES: usize = 64 * 1024;
+static SPOOL_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Default)]
+pub struct CapturedOutput {
+    pub tail: String,
+    pub total_lines: usize,
+    pub truncated: bool,
+}
+
+pub(super) struct Spool {
+    file: Option<File>,
+    path: PathBuf,
+}
+
+impl Spool {
+    pub(super) fn new(log_path: &Path, stream: &str) -> io::Result<Self> {
+        loop {
+            let sequence = SPOOL_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+            let path =
+                log_path.with_extension(format!("{}-{sequence}.{stream}.tmp", std::process::id()));
+            match OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create_new(true)
+                .open(&path)
+            {
+                Ok(file) => {
+                    return Ok(Self {
+                        file: Some(file),
+                        path,
+                    });
+                }
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+                Err(error) => return Err(error),
+            }
+        }
+    }
+
+    pub(super) fn file(&self) -> &File {
+        self.file.as_ref().expect("spool is open")
+    }
+}
+
+impl Drop for Spool {
+    fn drop(&mut self) {
+        self.file.take();
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+pub(super) fn finish_log(
+    log_path: &Path,
+    command: &str,
+    passed: bool,
+    stdout: Spool,
+    stderr: Spool,
+    max_lines: usize,
+) -> Result<CapturedOutput> {
+    let mut log = BufWriter::new(
+        OpenOptions::new()
+            .append(true)
+            .create(true)
+            .open(log_path)?,
+    );
+    writeln!(
+        log,
+        "=== [{}] {command}\n",
+        if passed { "PASS" } else { "FAIL" }
+    )?;
+    let mut tail = OutputTail::new(max_lines);
+    for (label, spool) in [("stdout", stdout), ("stderr", stderr)] {
+        let mut file = spool.file();
+        file.seek(SeekFrom::Start(0))?;
+        if file.metadata()?.len() == 0 {
+            continue;
+        }
+        writeln!(log, "--- {label} ---")?;
+        let mut buffer = [0u8; 8192];
+        let mut last = None;
+        loop {
+            let read = file.read(&mut buffer)?;
+            if read == 0 {
+                break;
+            }
+            log.write_all(&buffer[..read])?;
+            tail.push(&buffer[..read]);
+            last = buffer.get(read - 1).copied();
+        }
+        if last != Some(b'\n') {
+            writeln!(log)?;
+        }
+    }
+    writeln!(log)?;
+    log.flush()?;
+    Ok(tail.finish())
+}
+
+/// Retains only the requested final lines, with an independent cap for a single
+/// unterminated line. Feed stdout then stderr to preserve existing report order.
+struct OutputTail {
+    bytes: VecDeque<u8>,
+    max_lines: usize,
+    newlines: usize,
+    total_newlines: usize,
+    last: Option<u8>,
+    dropped: bool,
+}
+
+impl OutputTail {
+    fn new(max_lines: usize) -> Self {
+        Self {
+            bytes: VecDeque::new(),
+            max_lines,
+            newlines: 0,
+            total_newlines: 0,
+            last: None,
+            dropped: false,
+        }
+    }
+
+    fn push(&mut self, bytes: &[u8]) {
+        for &byte in bytes {
+            self.last = Some(byte);
+            self.total_newlines = self
+                .total_newlines
+                .saturating_add(usize::from(byte == b'\n'));
+            self.bytes.push_back(byte);
+            self.newlines += usize::from(byte == b'\n');
+            let lines = self.newlines + usize::from(byte != b'\n');
+            if lines > self.max_lines {
+                while let Some(removed) = self.bytes.pop_front() {
+                    self.dropped = true;
+                    if removed == b'\n' {
+                        self.newlines -= 1;
+                        break;
+                    }
+                }
+            }
+            while self.bytes.len() > MAX_FEEDBACK_BYTES {
+                let removed = self.bytes.pop_front().expect("tail exceeds cap");
+                self.newlines -= usize::from(removed == b'\n');
+                self.dropped = true;
+            }
+        }
+    }
+
+    fn finish(mut self) -> CapturedOutput {
+        let total_lines = self
+            .total_newlines
+            .saturating_add(usize::from(self.last.is_some_and(|byte| byte != b'\n')));
+        // A byte cap can split the first UTF-8 codepoint. Keep the intact suffix;
+        // invalid source bytes elsewhere retain the previous lossy-display policy.
+        if self.dropped {
+            while self.bytes.front().is_some_and(|byte| byte & 0xc0 == 0x80) {
+                self.bytes.pop_front();
+            }
+        }
+        let bytes: Vec<_> = self.bytes.into_iter().collect();
+        let decoded = String::from_utf8_lossy(&bytes);
+        // Replacement characters can expand invalid source bytes. Bound the
+        // displayed UTF-8 string as well as the raw stream tail.
+        let mut start = decoded.len().saturating_sub(MAX_FEEDBACK_BYTES);
+        while !decoded.is_char_boundary(start) {
+            start += 1;
+        }
+        self.dropped |= start > 0;
+        let mut tail = String::with_capacity(decoded.len() - start);
+        for (index, line) in decoded[start..].lines().enumerate() {
+            if index > 0 {
+                tail.push('\n');
+            }
+            tail.push_str(line);
+        }
+        CapturedOutput {
+            tail,
+            total_lines,
+            truncated: self.dropped,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tail_matches_line_selection_across_chunk_and_stream_boundaries() {
+        for input in ["", "one\ntwo\nthree\n", "one\r\ntwo\nlast", "\n\n", "a\nb"] {
+            for limit in 0..5 {
+                let mut tail = OutputTail::new(limit);
+                for byte in input.as_bytes() {
+                    tail.push(&[*byte]);
+                }
+                let output = tail.finish();
+                let lines: Vec<_> = input.lines().collect();
+                assert_eq!(
+                    output.tail,
+                    lines[lines.len().saturating_sub(limit)..].join("\n")
+                );
+                assert_eq!(output.total_lines, lines.len());
+            }
+        }
+    }
+
+    #[test]
+    fn caps_unterminated_lines_and_preserves_split_unicode() {
+        let mut tail = OutputTail::new(2);
+        for _ in 0..100 {
+            tail.push(&[b'x'; 8192]);
+        }
+        for byte in "\u{1f980}\nlast".as_bytes() {
+            tail.push(&[*byte]);
+        }
+        assert!(tail.bytes.len() <= MAX_FEEDBACK_BYTES);
+        let output = tail.finish();
+        assert!(output.truncated);
+        assert!(output.tail.ends_with("\u{1f980}\nlast"));
+        assert_eq!(output.total_lines, 2);
+
+        let mut invalid = OutputTail::new(2);
+        invalid.push(&vec![0xff; MAX_FEEDBACK_BYTES]);
+        let output = invalid.finish();
+        assert!(output.tail.len() <= MAX_FEEDBACK_BYTES);
+        assert!(output.truncated);
+        assert!(output.tail.chars().all(|character| character == '\u{fffd}'));
+    }
+}

--- a/src/hq/mod.rs
+++ b/src/hq/mod.rs
@@ -23,6 +23,7 @@ use crate::platform;
 use crate::project::{ProjectSelection, TaskRecord};
 use crate::specs::{self, MilestoneReadiness, SelectedMilestone};
 use crate::state::{agents, store};
+#[cfg(feature = "update-check")]
 use crate::update_check;
 use commands::{ModelTarget, ShellCommand, parse_command};
 use display::Display;
@@ -69,12 +70,15 @@ pub async fn run(debug: bool) -> Result<()> {
         ctx.set_hq_config(&hq);
     }
 
-    let update_display = display.clone();
-    tokio::spawn(async move {
-        if let Some(message) = update_check::notification_message().await {
-            update_display.tip(message);
-        }
-    });
+    #[cfg(feature = "update-check")]
+    {
+        let update_display = display.clone();
+        tokio::spawn(async move {
+            if let Some(message) = update_check::notification_message().await {
+                update_display.tip(message);
+            }
+        });
+    }
 
     let mut tui_task = tokio::spawn(tui::run_tui(
         msg_rx,

--- a/src/hq/tui.rs
+++ b/src/hq/tui.rs
@@ -34,6 +34,7 @@ use super::state_watcher::{WatchedMilestone, WatchedState};
 use crate::specs::MilestoneReadiness;
 
 const MAX_HISTORY: usize = 100;
+const MAX_TRANSCRIPT_LINES: usize = 2_000;
 const MAX_COMPLETIONS: usize = 8;
 const COMMANDS: &[(&str, &str)] = &[
     ("/plan", "spawn supervisor, plan a task"),
@@ -296,7 +297,7 @@ pub async fn run_tui(
                             continuation: false,
                         };
                         app.last_error = Some(line.text.clone());
-                        app.messages.push(line);
+                        app.append_transcript(vec![line]);
                         redraw_dashboard(&mut stdout, &app, &mut ui)?;
                     }
                     None => app.should_quit = true,
@@ -607,20 +608,20 @@ fn handle_message(
     match msg {
         UiMessage::Info(text) => {
             let lines = split_transcript(&text, TranscriptKind::Info);
-            app.messages.extend(lines.iter().cloned());
+            app.append_transcript(lines);
             if !app.suspended {
                 redraw_dashboard(stdout, app, ui)?;
             }
         }
         UiMessage::Table(rows) => {
-            app.messages.extend(table_transcript(&rows));
+            app.append_transcript(table_transcript(&rows));
             if !app.suspended {
                 redraw_dashboard(stdout, app, ui)?;
             }
         }
         UiMessage::Success(text) => {
             let lines = split_transcript(&text, TranscriptKind::Success);
-            app.messages.extend(lines.iter().cloned());
+            app.append_transcript(lines);
             if !app.suspended {
                 redraw_dashboard(stdout, app, ui)?;
             }
@@ -631,14 +632,14 @@ fn handle_message(
                 kind: TranscriptKind::Tip,
                 continuation: false,
             };
-            app.messages.push(line.clone());
+            app.append_transcript(vec![line]);
             if !app.suspended {
                 redraw_dashboard(stdout, app, ui)?;
             }
         }
         UiMessage::Muted(text) => {
             let lines = split_transcript(&text, TranscriptKind::Muted);
-            app.messages.extend(lines.iter().cloned());
+            app.append_transcript(lines);
             if !app.suspended {
                 redraw_dashboard(stdout, app, ui)?;
             }

--- a/src/hq/tui/app.rs
+++ b/src/hq/tui/app.rs
@@ -3,6 +3,12 @@
 use super::*;
 
 impl App {
+    pub(super) fn append_transcript(&mut self, mut lines: Vec<TranscriptLine>) {
+        trim_transcript_history(&mut lines);
+        self.messages.extend(lines);
+        trim_transcript_history(&mut self.messages);
+    }
+
     pub(super) fn new() -> Self {
         Self {
             status: StatusSnapshot::default(),
@@ -368,5 +374,39 @@ impl App {
         self.history_idx = None;
         self.history_saved.clear();
         self.clear_completion();
+    }
+}
+
+/// Keep recent complete blocks. An oversized newest block retains its opening
+/// lines and, for a table, its bottom border, just like the visible viewport.
+fn trim_transcript_history(lines: &mut Vec<TranscriptLine>) {
+    if lines.len() <= MAX_TRANSCRIPT_LINES {
+        return;
+    }
+    let cutoff = lines.len() - MAX_TRANSCRIPT_LINES;
+    if let Some(start) = (cutoff..lines.len()).find(|&index| !lines[index].continuation) {
+        lines.drain(..start);
+    } else {
+        let start = lines
+            .iter()
+            .rposition(|line| !line.continuation)
+            .unwrap_or(0);
+        lines.drain(..start);
+        let bottom = if matches!(
+            lines.first().map(|line| line.kind),
+            Some(TranscriptKind::TableTop)
+        ) && matches!(
+            lines.last().map(|line| line.kind),
+            Some(TranscriptKind::TableBottom)
+        ) {
+            lines.pop()
+        } else {
+            None
+        };
+        lines.truncate(MAX_TRANSCRIPT_LINES - usize::from(bottom.is_some()));
+        lines.extend(bottom);
+    }
+    if lines.capacity() > MAX_TRANSCRIPT_LINES * 2 {
+        lines.shrink_to(MAX_TRANSCRIPT_LINES);
     }
 }

--- a/src/hq/tui/render.rs
+++ b/src/hq/tui/render.rs
@@ -504,7 +504,7 @@ pub(super) fn activity_area_lines(app: &App, width: usize, max_lines: usize) -> 
                 }
             }
             for line in block {
-                lines.push(DashboardLine::new(transcript_activity_line(&line, width)));
+                lines.push(DashboardLine::new(transcript_activity_line(line, width)));
                 if lines.len() >= max_lines {
                     break;
                 }
@@ -519,49 +519,37 @@ pub(super) fn activity_area_lines(app: &App, width: usize, max_lines: usize) -> 
 pub(super) fn recent_transcript_blocks(
     messages: &[TranscriptLine],
     max_lines: usize,
-) -> Vec<Vec<TranscriptLine>> {
+) -> Vec<Vec<&TranscriptLine>> {
     if max_lines == 0 || messages.is_empty() {
         return Vec::new();
     }
 
-    let mut blocks = Vec::new();
-    let mut current = Vec::new();
-    for line in messages {
-        if !line.continuation && !current.is_empty() {
-            blocks.push(std::mem::take(&mut current));
-        }
-        current.push(line.clone());
-    }
-    if !current.is_empty() {
-        blocks.push(current);
-    }
-
     let mut selected = Vec::new();
     let mut remaining = max_lines;
-    for block in blocks.into_iter().rev() {
-        if remaining == 0 {
-            break;
-        }
-
+    let mut end = messages.len();
+    while end > 0 {
         let gap_before_newer_block = usize::from(!selected.is_empty());
         if remaining <= gap_before_newer_block {
             break;
         }
 
+        let start = messages[..end]
+            .iter()
+            .rposition(|line| !line.continuation)
+            .unwrap_or(0);
+        let block = &messages[start..end];
         let take = block.len().min(remaining - gap_before_newer_block);
         selected.push(take_transcript_block(block, take));
         remaining -= gap_before_newer_block + take;
+        end = start;
     }
     selected.reverse();
     selected
 }
 
-pub(super) fn take_transcript_block(
-    mut block: Vec<TranscriptLine>,
-    take: usize,
-) -> Vec<TranscriptLine> {
+pub(super) fn take_transcript_block(block: &[TranscriptLine], take: usize) -> Vec<&TranscriptLine> {
     if block.len() <= take {
-        return block;
+        return block.iter().collect();
     }
 
     let is_table = matches!(
@@ -573,14 +561,14 @@ pub(super) fn take_transcript_block(
     );
     if is_table && take >= 2 {
         let bottom = block
-            .pop()
+            .last()
             .expect("table block should have a bottom border");
-        let mut visible = block.into_iter().take(take - 1).collect::<Vec<_>>();
+        let mut visible = block.iter().take(take - 1).collect::<Vec<_>>();
         visible.push(bottom);
         return visible;
     }
 
-    block.into_iter().take(take).collect()
+    block.iter().take(take).collect()
 }
 
 pub(super) fn runtime_task_activity_lines(

--- a/src/hq/tui_tests.rs
+++ b/src/hq/tui_tests.rs
@@ -3,6 +3,87 @@
 use super::*;
 
 #[test]
+fn recent_transcript_borrows_only_visible_lines_from_large_history() {
+    let messages: Vec<_> = (0..100_000)
+        .map(|index| TranscriptLine {
+            text: format!("message {index}"),
+            kind: TranscriptKind::Info,
+            continuation: false,
+        })
+        .collect();
+    let blocks = recent_transcript_blocks(&messages, 20);
+    assert_eq!(blocks.len(), 10);
+    for (block, original) in blocks.iter().zip(&messages[99_990..]) {
+        assert_eq!(block.len(), 1);
+        assert!(std::ptr::eq(block[0], original));
+    }
+    assert!(recent_transcript_blocks(&messages, 0).is_empty());
+}
+
+#[test]
+fn transcript_retention_evicts_whole_blocks() {
+    let mut app = App::new();
+    for index in 0..MAX_TRANSCRIPT_LINES {
+        app.append_transcript(split_transcript(
+            &format!("message {index}\ndetail\nlast detail"),
+            TranscriptKind::Info,
+        ));
+    }
+    assert!(app.messages.len() <= MAX_TRANSCRIPT_LINES);
+    assert_eq!(app.messages.len() % 3, 0);
+    assert!(!app.messages[0].continuation);
+    assert_eq!(app.messages.last().unwrap().text, "last detail");
+    assert_eq!(
+        app.messages[app.messages.len() - 3].text,
+        format!("message {}", MAX_TRANSCRIPT_LINES - 1)
+    );
+}
+
+#[test]
+fn transcript_retention_preserves_oversized_table_borders_and_viewport_width() {
+    let mut app = App::new();
+    app.append_transcript(split_transcript("old message", TranscriptKind::Info));
+    let mut table: Vec<_> = (0..MAX_TRANSCRIPT_LINES * 3)
+        .map(|index| TranscriptLine {
+            text: format!("| row {index} |"),
+            kind: TranscriptKind::TableRow,
+            continuation: true,
+        })
+        .collect();
+    table[0].text = "+-----------+".into();
+    table[0].kind = TranscriptKind::TableTop;
+    table[0].continuation = false;
+    let last = table.last_mut().unwrap();
+    last.text = "+-----------+".into();
+    last.kind = TranscriptKind::TableBottom;
+    app.append_transcript(table);
+    assert_eq!(app.messages.len(), MAX_TRANSCRIPT_LINES);
+    assert!(matches!(app.messages[0].kind, TranscriptKind::TableTop));
+    assert!(matches!(
+        app.messages.last().unwrap().kind,
+        TranscriptKind::TableBottom
+    ));
+    assert!(app.messages.capacity() <= MAX_TRANSCRIPT_LINES * 2);
+    let blocks = recent_transcript_blocks(&app.messages, 3);
+    assert_eq!(blocks[0].len(), 3);
+    assert!(matches!(blocks[0][2].kind, TranscriptKind::TableBottom));
+    let rendered = activity_area_lines(&app, 9, 3);
+    assert_eq!(rendered.len(), 3);
+    for line in rendered {
+        let text: String = line
+            .line
+            .segments
+            .iter()
+            .map(|segment| segment.text.as_str())
+            .collect();
+        assert!(display_width(&text) <= 9);
+    }
+    app.append_transcript(split_transcript("new message", TranscriptKind::Info));
+    assert_eq!(app.messages.len(), 1);
+    assert_eq!(app.messages[0].text, "new message");
+}
+
+#[test]
 fn first_tab_on_multiple_matches_selects_first_candidate() {
     let mut app = App::new();
     app.input = "/".into();

--- a/src/json_size.rs
+++ b/src/json_size.rs
@@ -1,0 +1,57 @@
+//! Exact JSON wire sizes without retaining an encoded copy of the value.
+
+use std::io::{self, Write};
+
+use serde::Serialize;
+
+pub(crate) fn serialized_len(value: &(impl Serialize + ?Sized)) -> serde_json::Result<u64> {
+    let mut counter = ByteCounter(0);
+    serde_json::to_writer(&mut counter, value)?;
+    Ok(counter.0)
+}
+
+struct ByteCounter(u64);
+
+impl Write for ByteCounter {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        self.0 = self
+            .0
+            .checked_add(bytes.len() as u64)
+            .ok_or_else(|| io::Error::other("JSON byte count overflow"))?;
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn counts_wire_bytes_including_escaping_and_multibyte_text() {
+        for value in [
+            serde_json::json!(null),
+            serde_json::json!({"text": "\u{00e9}\u{1f980}\n\t\"\\\u{0000}", "n": -123.5}),
+            serde_json::json!([[], {}, true, 123456789, "x".repeat(100_000)]),
+        ] {
+            assert_eq!(
+                serialized_len(&value).unwrap(),
+                serde_json::to_vec(&value).unwrap().len() as u64
+            );
+        }
+    }
+
+    #[test]
+    fn propagates_serialization_failure() {
+        struct Invalid;
+        impl Serialize for Invalid {
+            fn serialize<S: serde::Serializer>(&self, _: S) -> Result<S::Ok, S::Error> {
+                Err(serde::ser::Error::custom("invalid"))
+            }
+        }
+        assert!(serialized_len(&Invalid).is_err());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 //! Reusable Ferrus components.
 
 pub mod distributed;
+mod json_size;
 pub mod project_memory;
 pub mod repository_graph;

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod server;
 mod specs;
 mod state;
 mod templates;
+#[cfg(feature = "update-check")]
 mod update_check;
 
 use clap::Parser;

--- a/src/project/database.rs
+++ b/src/project/database.rs
@@ -168,6 +168,23 @@ pub(super) fn open_runtime_database(path: &Path) -> Result<Connection> {
     Ok(connection)
 }
 
+/// Frequent dashboard reads must not contend for the migration writer lock.
+/// Open per operation so replacing a database or switching projects cannot reuse
+/// a stale connection. Only old schemas or pending legacy imports need a writer.
+pub(super) fn open_runtime_database_for_read(path: &Path) -> Result<Connection> {
+    let connection = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .with_context(|| format!("Failed to open {}", path.display()))?;
+    connection.busy_timeout(Duration::from_secs(5))?;
+    validate_runtime_migration_history(&connection)?;
+    if runtime_schema_version(&connection)? != RUNTIME_SCHEMA_VERSION
+        || legacy_runtime_metadata_import(&connection)?.is_some()
+    {
+        drop(connection);
+        return open_runtime_database(path);
+    }
+    Ok(connection)
+}
+
 pub(crate) async fn prepare_runtime_database_for_read_only_operations() -> Result<()> {
     let database_path = current_database_path().await?;
     tokio::task::spawn_blocking(move || {
@@ -649,22 +666,9 @@ pub(super) fn ensure_project_runtime_state_row(connection: &Connection) -> Resul
 }
 
 pub(super) fn migrate_legacy_runtime_metadata(connection: &Connection) -> Result<()> {
-    if !table_exists(connection, "runtime_metadata")? {
+    let Some(import) = legacy_runtime_metadata_import(connection)? else {
         return Ok(());
-    }
-
-    let current_selection = read_project_selection_from_database(connection)?;
-    let current_last_spec_path = read_last_spec_path_from_database(connection)?;
-    let selected_spec = current_selection
-        .selected_spec
-        .or(read_legacy_runtime_metadata(connection, "selected_spec")?);
-    let last_spec_path =
-        current_last_spec_path.or(read_legacy_runtime_metadata(connection, "last_spec_path")?);
-
-    if selected_spec.is_none() && last_spec_path.is_none() {
-        return Ok(());
-    }
-
+    };
     ensure_project_runtime_state_row(connection)?;
     connection.execute(
         r#"
@@ -674,9 +678,41 @@ pub(super) fn migrate_legacy_runtime_metadata(connection: &Connection) -> Result
             updated_at = ?3
         WHERE row_id = 1
         "#,
-        params![selected_spec, last_spec_path, timestamp()],
+        params![import.selected_spec, import.last_spec_path, timestamp()],
     )?;
     Ok(())
+}
+
+struct LegacyRuntimeMetadataImport {
+    selected_spec: Option<String>,
+    last_spec_path: Option<String>,
+}
+
+fn legacy_runtime_metadata_import(
+    connection: &Connection,
+) -> Result<Option<LegacyRuntimeMetadataImport>> {
+    if !table_exists(connection, "runtime_metadata")? {
+        return Ok(None);
+    }
+
+    let current_selection = read_project_selection_from_database(connection)?;
+    let current_last_spec_path = read_last_spec_path_from_database(connection)?;
+    let selected_spec = current_selection
+        .selected_spec
+        .clone()
+        .or(read_legacy_runtime_metadata(connection, "selected_spec")?);
+    let last_spec_path = current_last_spec_path
+        .clone()
+        .or(read_legacy_runtime_metadata(connection, "last_spec_path")?);
+
+    if selected_spec == current_selection.selected_spec && last_spec_path == current_last_spec_path
+    {
+        return Ok(None);
+    }
+    Ok(Some(LegacyRuntimeMetadataImport {
+        selected_spec,
+        last_spec_path,
+    }))
 }
 
 pub(super) fn read_legacy_runtime_metadata(

--- a/src/project/registry.rs
+++ b/src/project/registry.rs
@@ -735,7 +735,7 @@ pub(super) async fn list_registered_projects_from(
 pub async fn list_tasks() -> Result<Vec<TaskRecord>> {
     let database_path = current_database_path().await?;
     tokio::task::spawn_blocking(move || -> Result<Vec<TaskRecord>> {
-        let connection = open_runtime_database(&database_path)?;
+        let connection = open_runtime_database_for_read(&database_path)?;
         let mut statement = connection.prepare(
             r#"
             SELECT id, path, spec_path, milestone_id, status, paused_status, claimed_by,
@@ -932,7 +932,7 @@ pub async fn archive_completed_spec(spec_path: &str, outcome: &str) -> Result<Sp
 pub async fn list_human_questions() -> Result<Vec<HumanQuestion>> {
     let database_path = current_database_path().await?;
     let tasks = tokio::task::spawn_blocking(move || -> Result<Vec<TaskRecord>> {
-        let connection = open_runtime_database(&database_path)?;
+        let connection = open_runtime_database_for_read(&database_path)?;
         let mut statement = connection.prepare(
             r#"
             SELECT id, path, spec_path, milestone_id, status, paused_status, claimed_by,
@@ -1060,7 +1060,7 @@ pub async fn find_non_terminal_task_by_origin(
 pub async fn list_runs(limit: usize) -> Result<Vec<RunRecord>> {
     let database_path = current_database_path().await?;
     tokio::task::spawn_blocking(move || -> Result<Vec<RunRecord>> {
-        let connection = open_runtime_database(&database_path)?;
+        let connection = open_runtime_database_for_read(&database_path)?;
         let mut statement = connection.prepare(
             r#"
             SELECT id, task_id, role, agent, status, started_at, updated_at, pid, workspace_path

--- a/src/project/task.rs
+++ b/src/project/task.rs
@@ -44,7 +44,7 @@ pub async fn read_project_selection() -> Result<ProjectSelection> {
     let database_path = current_database_path().await?;
 
     tokio::task::spawn_blocking(move || -> Result<ProjectSelection> {
-        let connection = open_runtime_database(&database_path)?;
+        let connection = open_runtime_database_for_read(&database_path)?;
         read_project_selection_from_database(&connection)
     })
     .await?

--- a/src/project_memory/federation_service/support.rs
+++ b/src/project_memory/federation_service/support.rs
@@ -271,9 +271,7 @@ pub(super) fn diagnostic_code(value: &str) -> MemoryDiagnosticCode {
 }
 
 pub(super) fn serialized_len(value: &impl Serialize) -> Result<u64, MemoryQueryError> {
-    serde_json::to_vec(value)
-        .map(|bytes| bytes.len() as u64)
-        .map_err(|_| backend_error("federation.serialization"))
+    crate::json_size::serialized_len(value).map_err(|_| backend_error("federation.serialization"))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -292,6 +290,7 @@ pub(super) fn fit_federated_search_response(
     ensure_federated_search_fitting_deadline(started, duration)?;
     set_federated_search_page(
         response,
+        response.results.len(),
         initial_reason,
         offset,
         total,
@@ -308,7 +307,7 @@ pub(super) fn fit_federated_search_response(
     }
 
     ensure_federated_search_fitting_deadline(started, duration)?;
-    let original_results = response.results.clone();
+    let mut original_results = std::mem::take(&mut response.results);
     ensure_federated_search_fitting_deadline(started, duration)?;
     let mut lower = 1usize;
     let mut upper = original_results.len() - 1;
@@ -316,16 +315,21 @@ pub(super) fn fit_federated_search_response(
     while lower <= upper {
         ensure_federated_search_fitting_deadline(started, duration)?;
         let midpoint = lower + (upper - lower) / 2;
-        response.results = original_results[..midpoint].to_vec();
         set_federated_search_page(
             response,
+            midpoint,
             Some(MemoryTruncationReason::Bytes),
             offset,
             total,
             fingerprint,
             revision_key,
         )?;
-        if stabilize_federated_search_size(response, started, duration)? <= max_bytes {
+        let extra_bytes = crate::json_size::serialized_len(&original_results[..midpoint])
+            .map_err(|_| backend_error("federation.serialization"))?
+            - 2;
+        if stabilize_federated_search_size_with_extra(response, extra_bytes, started, duration)?
+            <= max_bytes
+        {
             best = Some(midpoint);
             lower = midpoint + 1;
         } else {
@@ -337,9 +341,11 @@ pub(super) fn fit_federated_search_response(
             MemoryTruncationReason::Bytes,
         ));
     };
-    response.results = original_results[..best].to_vec();
+    original_results.truncate(best);
+    response.results = original_results;
     set_federated_search_page(
         response,
+        response.results.len(),
         Some(MemoryTruncationReason::Bytes),
         offset,
         total,
@@ -355,23 +361,24 @@ pub(super) fn fit_federated_search_response(
 
 fn set_federated_search_page(
     response: &mut FederatedSearchResponse,
+    returned_count: usize,
     reason: Option<MemoryTruncationReason>,
     offset: usize,
     total: usize,
     fingerprint: &str,
     revision_key: &str,
 ) -> Result<(), MemoryQueryError> {
-    let has_more = offset + response.results.len() < total;
+    let has_more = offset + returned_count < total;
     response.page = federated_page(
         reason,
-        response.results.len(),
+        returned_count,
         0,
         0,
         has_more,
         "search",
         fingerprint,
         revision_key,
-        offset + response.results.len(),
+        offset + returned_count,
     )?;
     Ok(())
 }
@@ -381,9 +388,20 @@ fn stabilize_federated_search_size(
     started: Instant,
     duration: std::time::Duration,
 ) -> Result<u64, MemoryQueryError> {
+    stabilize_federated_search_size_with_extra(response, 0, started, duration)
+}
+
+// When probing a prefix the response holds an empty array. Add the difference
+// between that array's two JSON bytes and the borrowed prefix's encoded size.
+fn stabilize_federated_search_size_with_extra(
+    response: &mut FederatedSearchResponse,
+    extra_bytes: u64,
+    started: Instant,
+    duration: std::time::Duration,
+) -> Result<u64, MemoryQueryError> {
     for _ in 0..32 {
         ensure_federated_search_fitting_deadline(started, duration)?;
-        let encoded_bytes = serialized_len(response)?;
+        let encoded_bytes = serialized_len(response)?.saturating_add(extra_bytes);
         ensure_federated_search_fitting_deadline(started, duration)?;
         let Some(truncation) = response.page.truncation.as_mut() else {
             return Ok(encoded_bytes);
@@ -507,9 +525,9 @@ pub(super) fn fit_federated_context_response(
     )
 }
 
-fn fit_context_collection<T: Clone>(
+fn fit_context_collection<T: Serialize>(
     response: &mut FederatedContextResponse,
-    original: Vec<T>,
+    mut original: Vec<T>,
     mut assign: impl FnMut(&mut FederatedContextResponse, Vec<T>),
     max_bytes: u64,
     started: Instant,
@@ -525,8 +543,10 @@ fn fit_context_collection<T: Clone>(
             ));
         }
         let midpoint = lower + (upper - lower) / 2;
-        assign(response, original[..midpoint].to_vec());
-        let encoded_bytes = stabilize_federated_context_size(response)?;
+        let extra_bytes = crate::json_size::serialized_len(&original[..midpoint])
+            .map_err(|_| backend_error("federation.serialization"))?
+            - 2;
+        let encoded_bytes = stabilize_federated_context_size_with_extra(response, extra_bytes)?;
         if started.elapsed() >= duration {
             return Err(MemoryQueryError::BudgetExceeded(
                 MemoryTruncationReason::Duration,
@@ -543,7 +563,8 @@ fn fit_context_collection<T: Clone>(
         assign(response, Vec::new());
         return Ok(false);
     };
-    assign(response, original[..best].to_vec());
+    original.truncate(best);
+    assign(response, original);
     let encoded_bytes = stabilize_federated_context_size(response)?;
     if started.elapsed() >= duration {
         return Err(MemoryQueryError::BudgetExceeded(
@@ -565,7 +586,7 @@ fn fit_federated_context_items(
     started: Instant,
     duration: std::time::Duration,
 ) -> Result<(), MemoryQueryError> {
-    let original = std::mem::take(&mut response.items);
+    let mut original = std::mem::take(&mut response.items);
     if original.is_empty() {
         return Err(MemoryQueryError::BudgetExceeded(
             MemoryTruncationReason::Bytes,
@@ -581,9 +602,9 @@ fn fit_federated_context_items(
             ));
         }
         let midpoint = lower + (upper - lower) / 2;
-        response.items = original[..midpoint].to_vec();
-        set_federated_context_page(
+        set_federated_context_page_with_count(
             response,
+            midpoint,
             Some(MemoryTruncationReason::Bytes),
             explored_depth,
             offset,
@@ -591,7 +612,10 @@ fn fit_federated_context_items(
             fingerprint,
             revision_key,
         )?;
-        let encoded_bytes = stabilize_federated_context_size(response)?;
+        let extra_bytes = crate::json_size::serialized_len(&original[..midpoint])
+            .map_err(|_| backend_error("federation.serialization"))?
+            - 2;
+        let encoded_bytes = stabilize_federated_context_size_with_extra(response, extra_bytes)?;
         if started.elapsed() >= duration {
             return Err(MemoryQueryError::BudgetExceeded(
                 MemoryTruncationReason::Duration,
@@ -609,7 +633,8 @@ fn fit_federated_context_items(
             MemoryTruncationReason::Bytes,
         ));
     };
-    response.items = original[..best].to_vec();
+    original.truncate(best);
+    response.items = original;
     set_federated_context_page(
         response,
         Some(MemoryTruncationReason::Bytes),
@@ -641,17 +666,40 @@ fn set_federated_context_page(
     fingerprint: &str,
     revision_key: &str,
 ) -> Result<(), MemoryQueryError> {
-    let has_more = offset + response.items.len() < total;
+    set_federated_context_page_with_count(
+        response,
+        response.items.len(),
+        reason,
+        explored_depth,
+        offset,
+        total,
+        fingerprint,
+        revision_key,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn set_federated_context_page_with_count(
+    response: &mut FederatedContextResponse,
+    returned_count: usize,
+    reason: Option<MemoryTruncationReason>,
+    explored_depth: u32,
+    offset: usize,
+    total: usize,
+    fingerprint: &str,
+    revision_key: &str,
+) -> Result<(), MemoryQueryError> {
+    let has_more = offset + returned_count < total;
     response.page = federated_page(
         reason,
-        response.items.len(),
+        returned_count,
         0,
         explored_depth,
         has_more,
         "context",
         fingerprint,
         revision_key,
-        offset + response.items.len(),
+        offset + returned_count,
     )?;
     Ok(())
 }
@@ -659,8 +707,15 @@ fn set_federated_context_page(
 fn stabilize_federated_context_size(
     response: &mut FederatedContextResponse,
 ) -> Result<u64, MemoryQueryError> {
+    stabilize_federated_context_size_with_extra(response, 0)
+}
+
+fn stabilize_federated_context_size_with_extra(
+    response: &mut FederatedContextResponse,
+    extra_bytes: u64,
+) -> Result<u64, MemoryQueryError> {
     for _ in 0..32 {
-        let encoded_bytes = serialized_len(response)?;
+        let encoded_bytes = serialized_len(response)?.saturating_add(extra_bytes);
         let Some(truncation) = response.page.truncation.as_mut() else {
             return Ok(encoded_bytes);
         };

--- a/src/project_memory/query_sqlite.rs
+++ b/src/project_memory/query_sqlite.rs
@@ -196,15 +196,19 @@ impl Ord for MemoryHitOrderKey {
 }
 
 fn rank_memory_search_hits(
-    entities: Vec<MemoryEntity>,
+    entities: impl IntoIterator<Item = Result<MemoryEntity, MemoryQueryError>>,
     request: &MemorySearchRequest,
+    keep: usize,
     mut deadline_reached: impl FnMut() -> bool,
-) -> (Vec<MemorySearchHit>, bool) {
+) -> Result<(Vec<MemorySearchHit>, usize, bool), MemoryQueryError> {
+    let query = request.text.as_str().trim().to_lowercase();
     let mut hits = BTreeMap::new();
+    let mut total = 0usize;
     for entity in entities {
         if deadline_reached() {
-            return (hits.into_values().collect(), true);
+            return Ok((hits.into_values().collect(), total, true));
         }
+        let entity = entity?;
         if (!request.entity_kinds.is_empty() && !request.entity_kinds.contains(&entity.data.kind()))
             || (!request.source_categories.is_empty()
                 && !request
@@ -213,15 +217,19 @@ fn rank_memory_search_hits(
         {
             continue;
         }
-        let Some(hit) = memory_search_hit(entity, request.text.as_str()) else {
+        let Some(hit) = memory_search_hit(entity, &query) else {
             continue;
         };
         if deadline_reached() {
-            return (hits.into_values().collect(), true);
+            return Ok((hits.into_values().collect(), total, true));
         }
+        total = total.saturating_add(1);
         hits.insert(MemoryHitOrderKey::new(&hit), hit);
+        if hits.len() > keep {
+            hits.pop_last();
+        }
     }
-    (hits.into_values().collect(), false)
+    Ok((hits.into_values().collect(), total, false))
 }
 
 /// Local query implementation. It never creates, migrates, or mutates a sidecar.
@@ -290,6 +298,66 @@ impl<'a> SqliteMemoryQuery<'a> {
         let resolved = self.resolve_scope(scope);
         drop(deadline);
         finish_at_deadline(resolved, started, budget.duration())
+    }
+
+    fn search_hits(
+        &self,
+        scope: &ResolvedScope,
+        request: &MemorySearchRequest,
+        keep: usize,
+        started: Instant,
+    ) -> Result<(Vec<MemorySearchHit>, usize, bool), MemoryQueryError> {
+        let mut sql = String::from("SELECT entity_json FROM memory_entities WHERE revision_id = ?");
+        let mut values = vec![scope.revision.id.as_str().to_string()];
+        for (column, filters) in [
+            (
+                "kind",
+                request
+                    .entity_kinds
+                    .iter()
+                    .map(|kind| kind.as_str().to_string())
+                    .collect::<Vec<_>>(),
+            ),
+            (
+                "source_category",
+                request
+                    .source_categories
+                    .iter()
+                    .map(|category| super::sqlite::source_category(category).to_string())
+                    .collect(),
+            ),
+        ] {
+            if !filters.is_empty() {
+                sql.push_str(&format!(
+                    " AND {column} IN ({})",
+                    vec!["?"; filters.len()].join(",")
+                ));
+                values.extend(filters);
+            }
+        }
+        sql.push_str(" ORDER BY id");
+        let mut statement = self
+            .sidecar
+            .connection()
+            .prepare(&sql)
+            .map_err(sqlite_error)?;
+        let mut rows = statement
+            .query(rusqlite::params_from_iter(values))
+            .map_err(sqlite_error)?;
+        let entities = std::iter::from_fn(|| match rows.next() {
+            Ok(Some(row)) => Some((|| {
+                let encoded = row.get_ref(0).map_err(sqlite_error)?;
+                let encoded = encoded
+                    .as_str()
+                    .map_err(|_| backend_error("storage.corrupt"))?;
+                serde_json::from_str(encoded).map_err(serialization_error)
+            })()),
+            Ok(None) => None,
+            Err(error) => Some(Err(sqlite_error(error))),
+        });
+        rank_memory_search_hits(entities, request, keep, || {
+            started.elapsed() >= scope.budget.duration()
+        })
     }
 
     fn entities(
@@ -714,23 +782,22 @@ impl MemoryQuery for SqliteMemoryQuery<'_> {
         )?;
         let deadline =
             QueryDeadline::install(self.sidecar.connection(), started, scope.budget.duration())?;
-        let (entities, mut query_timed_out) = match self.entities(&scope.revision.id) {
-            Ok(entities) => (entities, false),
+        let offset = usize::try_from(offset).map_err(|_| MemoryQueryError::StaleCursor)?;
+        let keep = offset
+            .saturating_add(scope.budget.max_results as usize)
+            .saturating_add(1);
+        let (hits, total, query_timed_out) = match self.search_hits(&scope, &request, keep, started)
+        {
+            Ok(result) => result,
             Err(MemoryQueryError::BudgetExceeded(MemoryTruncationReason::Duration)) => {
-                (vec![], true)
+                (vec![], 0, true)
             }
             Err(error) => return Err(error),
         };
         drop(deadline);
-        let (hits, ranking_timed_out) = rank_memory_search_hits(entities, &request, || {
-            started.elapsed() >= scope.budget.duration()
-        });
-        query_timed_out |= ranking_timed_out;
-        let offset = usize::try_from(offset).map_err(|_| MemoryQueryError::StaleCursor)?;
-        if offset > hits.len() {
+        if offset > total {
             return Err(MemoryQueryError::StaleCursor);
         }
-        let total = hits.len();
         let mut hits = hits.into_iter().skip(offset).peekable();
         let mut returned = Vec::new();
         let mut returned_bytes = 0_u64;

--- a/src/project_memory/query_sqlite/support.rs
+++ b/src/project_memory/query_sqlite/support.rs
@@ -110,40 +110,37 @@ pub(super) fn resolution_visible(
     }
 }
 
-pub(super) fn memory_search_hit(entity: MemoryEntity, raw_query: &str) -> Option<MemorySearchHit> {
-    let query = raw_query.trim().to_lowercase();
+/// The caller normalizes the query once for the entire scan.
+pub(super) fn memory_search_hit(entity: MemoryEntity, query: &str) -> Option<MemorySearchHit> {
     let id = entity.id.as_str().to_lowercase();
     let title = entity_title(&entity).map(str::to_lowercase);
-    let text = entity_text(&entity).map(str::to_lowercase);
-    let provenance = serde_json::to_string(&entity.provenance)
-        .expect("memory provenance is serializable")
-        .to_lowercase();
     let (match_kind, score, reason) = if id == query {
         (MemorySearchMatchKind::ExactId, 1.0, "search.exactid")
-    } else if title.as_deref() == Some(query.as_str()) {
+    } else if title.as_deref() == Some(query) {
         (MemorySearchMatchKind::ExactTitle, 0.95, "search.exacttitle")
-    } else if title
-        .as_ref()
-        .is_some_and(|title| title.starts_with(&query))
-    {
+    } else if title.as_ref().is_some_and(|title| title.starts_with(query)) {
         (
             MemorySearchMatchKind::TitlePrefix,
             0.85,
             "search.titleprefix",
         )
-    } else if title.as_ref().is_some_and(|title| title.contains(&query)) {
+    } else if title.as_ref().is_some_and(|title| title.contains(query)) {
         (
             MemorySearchMatchKind::TitleContains,
             0.75,
             "search.titlecontains",
         )
-    } else if text.as_ref().is_some_and(|text| text.contains(&query)) {
+    } else if entity_text(&entity).is_some_and(|text| text.to_lowercase().contains(query)) {
         (
             MemorySearchMatchKind::CuratedTextContains,
             0.65,
             "search.textcontains",
         )
-    } else if provenance.contains(&query) {
+    } else if serde_json::to_string(&entity.provenance)
+        .expect("memory provenance is serializable")
+        .to_lowercase()
+        .contains(query)
+    {
         (
             MemorySearchMatchKind::ProvenanceReference,
             0.55,
@@ -330,9 +327,7 @@ pub(super) fn unsigned(value: i64) -> rusqlite::Result<u64> {
 }
 
 pub(super) fn serialized_len(value: &impl Serialize) -> Result<u64, MemoryQueryError> {
-    serde_json::to_vec(value)
-        .map(|bytes| bytes.len() as u64)
-        .map_err(serialization_error)
+    crate::json_size::serialized_len(value).map_err(serialization_error)
 }
 
 #[derive(Serialize, Deserialize)]

--- a/src/project_memory/query_sqlite_tests.rs
+++ b/src/project_memory/query_sqlite_tests.rs
@@ -513,14 +513,120 @@ fn search_candidate_ranking_stops_when_the_deadline_expires() {
     let entities = query.entities(&revision_id).unwrap();
     let mut deadline_checks = 0;
 
-    let (hits, timed_out) = rank_memory_search_hits(entities, &request, || {
-        deadline_checks += 1;
-        deadline_checks > 1
-    });
+    let (hits, _, timed_out) =
+        rank_memory_search_hits(entities.into_iter().map(Ok), &request, 10, || {
+            deadline_checks += 1;
+            deadline_checks > 1
+        })
+        .unwrap();
 
     assert!(timed_out);
     assert_eq!(deadline_checks, 2);
     assert!(hits.len() <= 1);
+}
+
+#[test]
+fn bounded_ranking_keeps_global_order_without_retaining_every_match() {
+    let (_root, data, project, revision_id) = indexed_fixture();
+    let sidecar = MemorySidecar::open_at(data.path()).unwrap();
+    let limits = QueryLimitsConfig::default();
+    let query = SqliteMemoryQuery::new(&sidecar, limits.clone());
+    let template = query.entities(&revision_id).unwrap().remove(0);
+    let request = MemorySearchRequest {
+        scope: published_scope(project, &limits),
+        text: super::super::domain::MemoryQueryText::new("needle").unwrap(),
+        entity_kinds: vec![],
+        source_categories: vec![],
+        page: MemoryPageRequest::default(),
+    };
+    let entities = (0..10_000).rev().map(|index| {
+        let mut entity = template.clone();
+        entity.id = MemoryEntityId::new(format!("entity-{index:05}")).unwrap();
+        entity.data = MemoryEntityData::Specification {
+            title: super::super::domain::MemoryTitle::new("Needle").unwrap(),
+        };
+        Ok(entity)
+    });
+    let (hits, total, timed_out) =
+        rank_memory_search_hits(entities, &request, 4, || false).unwrap();
+    assert_eq!(total, 10_000);
+    assert!(!timed_out);
+    assert_eq!(
+        hits.iter()
+            .map(|hit| hit.entity.id.as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            "entity-00000",
+            "entity-00001",
+            "entity-00002",
+            "entity-00003"
+        ]
+    );
+}
+
+#[test]
+fn search_filters_before_decoding_and_pages_ranked_unicode_matches() {
+    let (_root, data, project, revision_id) = indexed_fixture();
+    let sidecar = MemorySidecar::open_at(data.path()).unwrap();
+    let limits = QueryLimitsConfig {
+        max_results: 3,
+        ..QueryLimitsConfig::default()
+    };
+    let query = SqliteMemoryQuery::new(&sidecar, limits.clone());
+    let template = query.entities(&revision_id).unwrap().remove(0);
+    let transaction = sidecar.connection().unchecked_transaction().unwrap();
+    for index in 0..20 {
+        let mut entity = template.clone();
+        entity.id = MemoryEntityId::new(format!("needle-{index:03}")).unwrap();
+        entity.data = MemoryEntityData::Specification {
+            title: super::super::domain::MemoryTitle::new("N\u{00e9}edle").unwrap(),
+        };
+        entity.provenance.source_category = MemorySourceCategory::SpecificationStructure;
+        transaction.execute(
+            "INSERT INTO memory_entities(revision_id, id, kind, source_category, entity_json) VALUES (?1, ?2, 'specification', 'specification_structure', ?3)",
+            params![revision_id.as_str(), entity.id.as_str(), serde_json::to_string(&entity).unwrap()],
+        ).unwrap();
+    }
+    for (id, kind, category) in [
+        ("excluded-kind", "decision", "specification_structure"),
+        ("excluded-source", "specification", "runtime_provenance"),
+    ] {
+        transaction.execute(
+            "INSERT INTO memory_entities(revision_id, id, kind, source_category, entity_json) VALUES (?1, ?2, ?3, ?4, 'corrupt JSON')",
+            params![revision_id.as_str(), id, kind, category],
+        ).unwrap();
+    }
+    transaction.commit().unwrap();
+    let query = SqliteMemoryQuery::new(&sidecar, limits.clone());
+    let mut request = MemorySearchRequest {
+        scope: published_scope(project, &limits),
+        text: super::super::domain::MemoryQueryText::new("  N\u{00c9}EDLE  ").unwrap(),
+        entity_kinds: vec![MemoryEntityKind::Specification],
+        source_categories: vec![MemorySourceCategory::SpecificationStructure],
+        page: MemoryPageRequest::default(),
+    };
+    let mut ids = Vec::new();
+    loop {
+        let response = query.search(request.clone()).unwrap();
+        assert!(response.hits.len() <= 3);
+        ids.extend(
+            response
+                .hits
+                .into_iter()
+                .map(|hit| hit.entity.id.as_str().to_string()),
+        );
+        let Some(cursor) = response.page.next_cursor else {
+            break;
+        };
+        assert!(ids.len() < 20);
+        request.page.cursor = Some(cursor);
+    }
+    assert_eq!(
+        ids,
+        (0..20)
+            .map(|index| format!("needle-{index:03}"))
+            .collect::<Vec<_>>()
+    );
 }
 
 #[test]

--- a/src/project_memory/sqlite.rs
+++ b/src/project_memory/sqlite.rs
@@ -805,6 +805,7 @@ fn repository_link_semantics(relationship: &MemoryRelationship) -> Vec<u8> {
 }
 
 mod schema;
+pub(super) use schema::source_category;
 use schema::*;
 
 #[cfg(test)]

--- a/src/project_memory/sqlite/schema.rs
+++ b/src/project_memory/sqlite/schema.rs
@@ -317,7 +317,7 @@ pub(super) fn parse_build_state(value: &str) -> Result<MemoryBuildState, MemoryS
     }
 }
 
-pub(super) fn source_category(
+pub(in crate::project_memory) fn source_category(
     category: &super::super::domain::MemorySourceCategory,
 ) -> &'static str {
     match category {

--- a/src/project_tests/graph_and_schema.rs
+++ b/src/project_tests/graph_and_schema.rs
@@ -2,6 +2,85 @@
 
 use super::*;
 
+#[tokio::test]
+async fn dashboard_reads_work_while_another_connection_holds_the_writer_lock() {
+    let _guard = crate::test_support::cwd_lock().lock().unwrap();
+    let (_dir, previous) = setup_project().await;
+    struct RestoreDirectory(PathBuf);
+    impl Drop for RestoreDirectory {
+        fn drop(&mut self) {
+            std::env::set_current_dir(&self.0).unwrap();
+        }
+    }
+    let _restore = RestoreDirectory(previous);
+    let path = current_database_path().await.unwrap();
+    let writer = Connection::open(&path).unwrap();
+    writer
+        .execute_batch(
+            "CREATE TABLE runtime_metadata (key TEXT PRIMARY KEY, value TEXT); \
+         INSERT INTO runtime_metadata VALUES ('selected_spec', 'docs/specs/legacy.md');",
+        )
+        .unwrap();
+    // Import once, then prove polling neither reruns migration transactions nor
+    // writes timestamps for metadata that has already been imported.
+    assert_eq!(
+        read_project_selection()
+            .await
+            .unwrap()
+            .selected_spec
+            .as_deref(),
+        Some("docs/specs/legacy.md")
+    );
+    writer.execute_batch("BEGIN IMMEDIATE").unwrap();
+    assert_eq!(
+        read_project_selection()
+            .await
+            .unwrap()
+            .selected_spec
+            .as_deref(),
+        Some("docs/specs/legacy.md")
+    );
+    assert_eq!(list_tasks().await.unwrap()[0].id, "t-001");
+    assert!(list_runs(8).await.unwrap().is_empty());
+    assert!(list_human_questions().await.unwrap().is_empty());
+    writer.execute_batch("ROLLBACK").unwrap();
+}
+
+#[test]
+fn runtime_read_open_validates_schema_and_tracks_database_replacement() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("ferrus.db");
+    drop(Connection::open(&path).unwrap());
+    // A valid old database still takes the migration path.
+    let connection = open_runtime_database_for_read(&path).unwrap();
+    assert_eq!(
+        runtime_schema_version(&connection).unwrap(),
+        RUNTIME_SCHEMA_VERSION
+    );
+    drop(connection);
+    std::fs::rename(&path, dir.path().join("old.db")).unwrap();
+    let replacement = Connection::open(&path).unwrap();
+    replacement
+        .pragma_update(None, "user_version", RUNTIME_SCHEMA_VERSION + 1)
+        .unwrap();
+    assert!(open_runtime_database_for_read(&path).is_err());
+    assert_eq!(
+        runtime_schema_version(&replacement).unwrap(),
+        RUNTIME_SCHEMA_VERSION + 1
+    );
+    drop(replacement);
+    std::fs::remove_file(&path).unwrap();
+    std::fs::rename(dir.path().join("old.db"), &path).unwrap();
+    let writer = Connection::open(&path).unwrap();
+    writer
+        .execute(
+            "UPDATE runtime_schema_migrations SET name = 'invalid' WHERE version = 1",
+            [],
+        )
+        .unwrap();
+    assert!(open_runtime_database_for_read(&path).is_err());
+}
+
 #[test]
 fn startup_prepares_runtime_schema_for_read_only_graph_queries() {
     let dir = TempDir::new().unwrap();

--- a/src/repository_graph/extractors/rust.rs
+++ b/src/repository_graph/extractors/rust.rs
@@ -8,6 +8,7 @@
 use std::{
     collections::BTreeMap,
     ops::ControlFlow,
+    rc::Rc,
     time::{Duration, Instant},
 };
 
@@ -149,9 +150,11 @@ impl Extractor for RustSyntaxExtractor {
         let mut timed_out = !push_named_children(
             &mut stack,
             root,
-            root_id.clone(),
-            root_id,
-            vec![root_name],
+            Rc::new(TraversalContext {
+                parent_id: root_id.clone(),
+                module_id: root_id,
+                scope: Rc::new(vec![root_name]),
+            }),
             started,
             budget,
         );
@@ -171,9 +174,7 @@ impl Extractor for RustSyntaxExtractor {
                 diagnostics.push("rust.missing_syntax", Some(span(work.node)));
             }
 
-            let mut child_parent = work.parent_id.clone();
-            let mut child_module = work.module_id.clone();
-            let mut child_scope = work.scope.clone();
+            let mut child_context = Rc::clone(&work.context);
             if let Some(mut declaration) = declaration(work.node, input.content) {
                 if declaration.enforce_source_value_limit() {
                     diagnostics.push("rust.source_value_limit", Some(span(work.node)));
@@ -183,28 +184,22 @@ impl Extractor for RustSyntaxExtractor {
                 if !facts.push_declaration(built.node, built.containment, built.relationship) {
                     break;
                 }
-                child_parent = built.id.clone();
+                let context = Rc::make_mut(&mut child_context);
+                context.parent_id = built.id.clone();
                 if opens_module {
-                    child_module = built.id;
+                    context.module_id = built.id;
                 }
                 if let Some(scope_segment) = built.scope_segment {
-                    child_scope.push(scope_segment);
+                    Rc::make_mut(&mut context.scope).push(scope_segment);
                 }
             } else if work.node.kind() == "block" {
                 // Rust permits block-local items with the same name in separate
                 // blocks. Preserve that otherwise-anonymous lexical scope.
-                child_scope.push(format!("block@{}", work.node.start_byte()));
+                Rc::make_mut(&mut Rc::make_mut(&mut child_context).scope)
+                    .push(format!("block@{}", work.node.start_byte()));
             }
 
-            if !push_named_children(
-                &mut stack,
-                work.node,
-                child_parent,
-                child_module,
-                child_scope,
-                started,
-                budget,
-            ) {
+            if !push_named_children(&mut stack, work.node, child_context, started, budget) {
                 timed_out = true;
             }
         }
@@ -232,17 +227,20 @@ impl Extractor for RustSyntaxExtractor {
 #[derive(Debug)]
 struct WorkItem<'tree> {
     node: Node<'tree>,
+    context: Rc<TraversalContext>,
+}
+
+#[derive(Debug, Clone)]
+struct TraversalContext {
     parent_id: NodeId,
     module_id: NodeId,
-    scope: Vec<String>,
+    scope: Rc<Vec<String>>,
 }
 
 fn push_named_children<'tree>(
     stack: &mut Vec<WorkItem<'tree>>,
     node: Node<'tree>,
-    parent_id: NodeId,
-    module_id: NodeId,
-    scope: Vec<String>,
+    context: Rc<TraversalContext>,
     started: Instant,
     budget: Duration,
 ) -> bool {
@@ -256,9 +254,7 @@ fn push_named_children<'tree>(
         if let Some(child) = node.named_child(index) {
             stack.push(WorkItem {
                 node: child,
-                parent_id: parent_id.clone(),
-                module_id: module_id.clone(),
-                scope: scope.clone(),
+                context: Rc::clone(&context),
             });
         }
     }
@@ -501,13 +497,11 @@ fn build_declaration(
     } else {
         display_name.clone()
     };
-    let qualified_name = work
-        .scope
-        .iter()
-        .chain(std::iter::once(&identity_name))
-        .cloned()
-        .collect::<Vec<_>>()
-        .join("::");
+    let mut qualified_name = work.context.scope.join("::");
+    if !qualified_name.is_empty() {
+        qualified_name.push_str("::");
+    }
+    qualified_name.push_str(&identity_name);
     let semantic_key = format!(
         "rust:{}:{}:{}",
         declaration.kind,
@@ -570,7 +564,7 @@ fn build_declaration(
     let containment = graph_edge(
         input,
         "contains",
-        work.parent_id.clone(),
+        work.context.parent_id.clone(),
         EdgeTarget::Node(id.clone()),
         declaration_span.clone(),
         ResolutionState::Resolved,
@@ -579,7 +573,7 @@ fn build_declaration(
         graph_edge(
             input,
             relationship.kind,
-            work.module_id.clone(),
+            work.context.module_id.clone(),
             EdgeTarget::Unresolved(relationship.target),
             declaration_span,
             ResolutionState::Unresolved,

--- a/src/repository_graph/extractors/rust_tests.rs
+++ b/src/repository_graph/extractors/rust_tests.rs
@@ -232,6 +232,40 @@ fn extraction_is_deterministic() {
 }
 
 #[test]
+fn sibling_declarations_do_not_inherit_each_others_lexical_scopes() {
+    let mut source = String::from("mod outer {\n");
+    for index in 0..100 {
+        source.push_str(&format!(
+            "fn function_{index}() {{ {{ struct Local; }} }}\n"
+        ));
+    }
+    source.push_str("}\nstruct Root;\n");
+    let graph = extract("src/lib.rs", source.as_bytes());
+    let keys: BTreeSet<_> = graph
+        .nodes
+        .iter()
+        .filter_map(|node| node.semantic_key.as_ref())
+        .map(|key| key.as_str())
+        .collect();
+    assert!(keys.contains("rust:struct:src/lib.rs:crate::Root"));
+    for index in 0..100 {
+        assert!(
+            keys.contains(
+                format!("rust:function:src/lib.rs:crate::outer::function_{index}").as_str()
+            )
+        );
+    }
+    assert_eq!(
+        graph
+            .nodes
+            .iter()
+            .filter(|node| node.kind.as_str() == "struct")
+            .count(),
+        101
+    );
+}
+
+#[test]
 fn semantic_keys_disambiguate_impls_and_block_local_items() {
     let source = br#"
 struct Item;

--- a/src/repository_graph/index.rs
+++ b/src/repository_graph/index.rs
@@ -236,6 +236,7 @@ where
                 files: manifest.files.clone(),
                 graph: prepared.graph,
                 cache_writes: prepared.cache_writes,
+                cache_hits: prepared.cache_hits,
                 metrics: prepared.metrics.clone(),
             })
             .map_err(|_| {
@@ -376,6 +377,7 @@ where
                 .map_err(|error| (error, metrics.clone()))?;
         }
         let mut cache_writes = Vec::new();
+        let mut cache_hits = Vec::new();
 
         let generic = GenericExtractor::new();
         let cargo = CargoExtractor::new();
@@ -411,6 +413,7 @@ where
                 if let Some(cached) = cached
                     && cache_fragment_is_valid(&cached, &key)
                 {
+                    cache_hits.push(key);
                     fragments.push(rebase_fragment(cached, &context));
                 } else {
                     missing.push((extractor, key));
@@ -480,6 +483,7 @@ where
         Ok(PreparedIndex {
             graph,
             cache_writes,
+            cache_hits,
             metrics,
         })
     }
@@ -524,6 +528,7 @@ where
 struct PreparedIndex {
     graph: GraphFragment,
     cache_writes: Vec<CachedFragment>,
+    cache_hits: Vec<FragmentCacheKey>,
     metrics: IndexBuildMetrics,
 }
 

--- a/src/repository_graph/index.rs
+++ b/src/repository_graph/index.rs
@@ -188,13 +188,23 @@ where
             None,
             &IndexBuildMetrics::default(),
         );
+        let requested_snapshot = GraphSnapshot {
+            id: snapshot_id.clone(),
+            repository: manifest.revision.repository.clone(),
+            source_revision_id: manifest.revision.id.clone(),
+            source_manifest_digest: manifest.revision.manifest_digest.clone(),
+            graph_model_version: GRAPH_MODEL_VERSION,
+            analysis_config_digest: manifest.revision.analysis_config_digest.clone(),
+            extractor_set_digest: manifest.extractor_set_digest.clone(),
+            completed_by: build.id.clone(),
+        };
 
         let mut prepared = match self.prepare(
             source,
             config,
             manifest,
             &active,
-            &build,
+            &requested_snapshot,
             request.force_full,
             started,
         ) {
@@ -219,21 +229,16 @@ where
         }
 
         prepared.metrics.duration_ms = elapsed_ms(started);
-        let requested_snapshot = GraphSnapshot {
-            id: snapshot_id.clone(),
-            repository: manifest.revision.repository.clone(),
-            source_revision_id: manifest.revision.id.clone(),
-            source_manifest_digest: manifest.revision.manifest_digest.clone(),
-            graph_model_version: GRAPH_MODEL_VERSION,
-            analysis_config_digest: manifest.revision.analysis_config_digest.clone(),
-            extractor_set_digest: manifest.extractor_set_digest.clone(),
-            completed_by: build.id.clone(),
-        };
         let completed = self
             .store
             .complete_index(&IndexCommit {
                 snapshot: requested_snapshot,
-                files: manifest.files.clone(),
+                reuse_completed_snapshot: prepared.reuse_completed_snapshot,
+                files: if prepared.reuse_completed_snapshot {
+                    Vec::new()
+                } else {
+                    manifest.files.clone()
+                },
                 graph: prepared.graph,
                 cache_writes: prepared.cache_writes,
                 cache_hits: prepared.cache_hits,
@@ -350,14 +355,14 @@ where
         config: &RepositoryGraphConfig,
         manifest: &SourceManifest,
         active: &ActiveExtractors,
-        build: &GraphBuild,
+        snapshot: &GraphSnapshot,
         force_full: bool,
         started: Instant,
     ) -> Result<PreparedIndex, (IndexError, IndexBuildMetrics)> {
         let context = ExtractionContext {
-            snapshot_id: build.prospective_snapshot_id.clone(),
-            build_id: build.id.clone(),
-            repository: build.repository.clone(),
+            snapshot_id: snapshot.id.clone(),
+            build_id: snapshot.completed_by.clone(),
+            repository: snapshot.repository.clone(),
             max_facts_per_file: config.index_limits.max_facts_per_file,
             max_parser_duration_ms: config.index_limits.max_parser_duration_ms,
             max_diagnostics: config.index_limits.max_diagnostics,
@@ -367,9 +372,42 @@ where
             skipped_files: manifest.metrics.skipped,
             ..IndexBuildMetrics::default()
         };
+        let generic = GenericExtractor::new();
+        let cargo = CargoExtractor::new();
+        let rust = RustSyntaxExtractor::new();
+        let available: [&dyn DynExtractor; 3] = [&generic, &cargo, &rust];
+        let source_graph = source_diagnostics(&context, manifest);
+        if !force_full
+            && let Some(existing) = self
+                .store
+                .reusable_index_metrics(snapshot, &source_graph.diagnostics)
+                .map_err(|_| (IndexError::StorageRead, metrics.clone()))?
+        {
+            for file in &manifest.files {
+                if available.iter().any(|extractor| {
+                    active.file_ids.contains(extractor.identity().id.as_str())
+                        && extractor.supports(file)
+                }) {
+                    metrics.reused_files += 1;
+                } else {
+                    metrics.skipped_files += 1;
+                }
+            }
+            metrics.nodes = existing.nodes;
+            metrics.edges = existing.edges;
+            metrics.diagnostics = existing.diagnostics;
+            metrics.duration_ms = elapsed_ms(started);
+            return Ok(PreparedIndex {
+                reuse_completed_snapshot: true,
+                graph: source_graph,
+                cache_writes: Vec::new(),
+                cache_hits: Vec::new(),
+                metrics,
+            });
+        }
         let mut merger = FragmentMerger::new();
         merger
-            .merge(source_diagnostics(&context, manifest))
+            .merge(source_graph)
             .map_err(|error| (error, metrics.clone()))?;
         if active.generic_enabled {
             merger
@@ -379,10 +417,6 @@ where
         let mut cache_writes = Vec::new();
         let mut cache_hits = Vec::new();
 
-        let generic = GenericExtractor::new();
-        let cargo = CargoExtractor::new();
-        let rust = RustSyntaxExtractor::new();
-        let available: [&dyn DynExtractor; 3] = [&generic, &cargo, &rust];
         for file in &manifest.files {
             let extractors = available
                 .iter()
@@ -481,6 +515,7 @@ where
         metrics.diagnostics = graph.diagnostics.len() as u64;
         metrics.duration_ms = elapsed_ms(started);
         Ok(PreparedIndex {
+            reuse_completed_snapshot: false,
             graph,
             cache_writes,
             cache_hits,
@@ -526,6 +561,7 @@ where
 }
 
 struct PreparedIndex {
+    reuse_completed_snapshot: bool,
     graph: GraphFragment,
     cache_writes: Vec<CachedFragment>,
     cache_hits: Vec<FragmentCacheKey>,

--- a/src/repository_graph/index_store.rs
+++ b/src/repository_graph/index_store.rs
@@ -26,16 +26,15 @@ impl IndexStore for Sidecar {
     ) -> Result<Option<GraphFragment>, Self::Error> {
         let raw = self
             .connection()
-            .query_row(
+            .prepare_cached(
                 "SELECT fragment_json FROM fragment_cache WHERE \
                  repository_namespace = ?1 AND repository_id = ?2 AND path = ?3 AND \
                  content_algorithm = ?4 AND content_digest = ?5 AND byte_length = ?6 AND \
                  file_mode = ?7 AND analysis_config_algorithm = ?8 AND \
                  analysis_config_digest = ?9 AND extractor_id = ?10 AND \
                  extractor_version = ?11 AND extractor_contract_version = ?12",
-                cache_params(key)?,
-                |row| row.get::<_, String>(0),
-            )
+            )?
+            .query_row(cache_params(key)?, |row| row.get::<_, String>(0))
             .optional()?;
         let Some(raw) = raw else {
             return Ok(None);
@@ -55,29 +54,6 @@ impl IndexStore for Sidecar {
                 return Ok(None);
             }
         };
-        self.connection_mut().execute(
-            "UPDATE fragment_cache SET last_used_at = ?13 WHERE \
-             repository_namespace = ?1 AND repository_id = ?2 AND path = ?3 AND \
-             content_algorithm = ?4 AND content_digest = ?5 AND byte_length = ?6 AND \
-             file_mode = ?7 AND analysis_config_algorithm = ?8 AND \
-             analysis_config_digest = ?9 AND extractor_id = ?10 AND \
-             extractor_version = ?11 AND extractor_contract_version = ?12",
-            params![
-                key.repository.namespace.as_str(),
-                key.repository.repository_id.as_str(),
-                key.path.as_str(),
-                key.content_identity.algorithm(),
-                key.content_identity.value(),
-                integer(key.byte_len, "fragment byte length")?,
-                file_mode(key.file_mode),
-                key.analysis_config_digest.algorithm(),
-                key.analysis_config_digest.value(),
-                key.extractor.id.as_str(),
-                key.extractor.version,
-                i64::from(key.extractor.contract_version),
-                timestamp(),
-            ],
-        )?;
         Ok(Some(fragment))
     }
 
@@ -110,6 +86,7 @@ impl IndexStore for Sidecar {
         for cached in &commit.cache_writes {
             upsert_cached_fragment(&transaction, &cached.key, &cached.fragment)?;
         }
+        touch_cached_fragments(&transaction, &commit.cache_hits)?;
         upsert_metrics(&transaction, &commit.snapshot.completed_by, &commit.metrics)?;
         transaction.execute(
             "UPDATE index_builds SET finished_at = ?2 WHERE id = ?1",
@@ -409,8 +386,9 @@ fn upsert_cached_fragment(
     fragment: &GraphFragment,
 ) -> Result<(), StoreError> {
     let now = timestamp();
-    transaction.execute(
-        "INSERT INTO fragment_cache(\
+    transaction
+        .prepare_cached(
+            "INSERT INTO fragment_cache(\
             repository_namespace, repository_id, path, content_algorithm, content_digest, \
             byte_length, file_mode, analysis_config_algorithm, analysis_config_digest, \
             extractor_id, extractor_version, extractor_contract_version, fragment_json, \
@@ -418,7 +396,8 @@ fn upsert_cached_fragment(
          ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?14) \
          ON CONFLICT DO UPDATE SET fragment_json = excluded.fragment_json, \
             last_used_at = excluded.last_used_at",
-        params![
+        )?
+        .execute(params![
             key.repository.namespace.as_str(),
             key.repository.repository_id.as_str(),
             key.path.as_str(),
@@ -433,8 +412,43 @@ fn upsert_cached_fragment(
             i64::from(key.extractor.contract_version),
             serde_json::to_string(fragment)?,
             now,
-        ],
+        ])?;
+    Ok(())
+}
+
+fn touch_cached_fragments(
+    transaction: &Transaction<'_>,
+    hits: &[FragmentCacheKey],
+) -> Result<(), StoreError> {
+    if hits.is_empty() {
+        return Ok(());
+    }
+    let now = timestamp();
+    let mut statement = transaction.prepare_cached(
+        "UPDATE fragment_cache SET last_used_at = ?13 WHERE \
+         repository_namespace = ?1 AND repository_id = ?2 AND path = ?3 AND \
+         content_algorithm = ?4 AND content_digest = ?5 AND byte_length = ?6 AND \
+         file_mode = ?7 AND analysis_config_algorithm = ?8 AND \
+         analysis_config_digest = ?9 AND extractor_id = ?10 AND \
+         extractor_version = ?11 AND extractor_contract_version = ?12",
     )?;
+    for key in hits {
+        statement.execute(params![
+            key.repository.namespace.as_str(),
+            key.repository.repository_id.as_str(),
+            key.path.as_str(),
+            key.content_identity.algorithm(),
+            key.content_identity.value(),
+            integer(key.byte_len, "fragment byte length")?,
+            file_mode(key.file_mode),
+            key.analysis_config_digest.algorithm(),
+            key.analysis_config_digest.value(),
+            key.extractor.id.as_str(),
+            key.extractor.version,
+            i64::from(key.extractor.contract_version),
+            now,
+        ])?;
+    }
     Ok(())
 }
 

--- a/src/repository_graph/index_store.rs
+++ b/src/repository_graph/index_store.rs
@@ -1,6 +1,8 @@
 //! SQLite persistence for complete index snapshots and reusable raw fragments.
 
-use rusqlite::{OptionalExtension, Transaction, TransactionBehavior, params};
+use std::collections::BTreeSet;
+
+use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
 
 use super::{
     domain::{
@@ -20,6 +22,14 @@ use super::{
 };
 
 impl IndexStore for Sidecar {
+    fn reusable_index_metrics(
+        &self,
+        snapshot: &GraphSnapshot,
+        source_diagnostics: &[GraphDiagnostic],
+    ) -> Result<Option<IndexBuildMetrics>, Self::Error> {
+        reusable_index_metrics(self.connection(), snapshot, source_diagnostics)
+    }
+
     fn load_cached_fragment(
         &mut self,
         key: &FragmentCacheKey,
@@ -72,6 +82,29 @@ impl IndexStore for Sidecar {
         }
         validate_snapshot_for_build(&commit.snapshot, &build)?;
 
+        if commit.reuse_completed_snapshot {
+            if !commit.files.is_empty()
+                || !commit.graph.nodes.is_empty()
+                || !commit.graph.edges.is_empty()
+                || !commit.cache_writes.is_empty()
+                || !commit.cache_hits.is_empty()
+            {
+                return Err(StoreError::IdentityMismatch("reused snapshot payload"));
+            }
+            // Recheck under the completion transaction: retention or another
+            // build may have changed the candidate after source revalidation.
+            let existing =
+                reusable_index_metrics(&transaction, &commit.snapshot, &commit.graph.diagnostics)?
+                    .ok_or(StoreError::IdentityMismatch("reused snapshot eligibility"))?;
+            if existing.discovered_files != commit.metrics.discovered_files
+                || existing.nodes != commit.metrics.nodes
+                || existing.edges != commit.metrics.edges
+                || existing.diagnostics != commit.metrics.diagnostics
+            {
+                return Err(StoreError::IdentityMismatch("reused snapshot metrics"));
+            }
+        }
+
         let completed = if let Some(existing) = load_snapshot(&transaction, &commit.snapshot.id)? {
             validate_equivalent_snapshot(&commit.snapshot, &existing)?;
             existing
@@ -103,6 +136,116 @@ impl IndexStore for Sidecar {
     ) -> Result<(), Self::Error> {
         upsert_metrics(self.connection(), build_id, metrics)
     }
+}
+
+/// Source warnings are not part of snapshot identity. Reuse only when both the
+/// original fact-producing build and the latest diagnostic set match today's
+/// source warnings exactly. Analyzer warnings (including budget exhaustion)
+/// therefore keep the normal extraction/resolution retry path.
+fn reusable_index_metrics(
+    connection: &Connection,
+    requested: &GraphSnapshot,
+    source_diagnostics: &[GraphDiagnostic],
+) -> Result<Option<IndexBuildMetrics>, StoreError> {
+    let Some(snapshot) = load_snapshot(connection, &requested.id)? else {
+        return Ok(None);
+    };
+    validate_equivalent_snapshot(requested, &snapshot)?;
+    let summary = connection
+        .query_row(
+            "SELECT metrics.discovered_files, metrics.nodes, metrics.edges, \
+                (SELECT COUNT(*) FROM files WHERE snapshot_id = ?1), \
+                (SELECT COUNT(*) FROM nodes WHERE snapshot_id = ?1), \
+                (SELECT COUNT(*) FROM edges WHERE snapshot_id = ?1), sets.build_id \
+         FROM build_metrics AS metrics JOIN snapshot_diagnostic_sets AS sets \
+              ON sets.snapshot_id = ?1 WHERE metrics.build_id = ?2",
+            params![snapshot.id.as_str(), snapshot.completed_by.as_str()],
+            |row| {
+                Ok((
+                    unsigned(row.get(0)?)?,
+                    unsigned(row.get(1)?)?,
+                    unsigned(row.get(2)?)?,
+                    unsigned(row.get(3)?)?,
+                    unsigned(row.get(4)?)?,
+                    unsigned(row.get(5)?)?,
+                    row.get::<_, String>(6)?,
+                ))
+            },
+        )
+        .optional()?;
+    let Some((files, nodes, edges, actual_files, actual_nodes, actual_edges, diagnostics_build)) =
+        summary
+    else {
+        // Lifecycle-only snapshots and older/incomplete index metadata cannot
+        // prove that all facts were persisted by complete_index.
+        return Ok(None);
+    };
+    if (files, nodes, edges) != (actual_files, actual_nodes, actual_edges) {
+        return Ok(None);
+    }
+    for build_id in [snapshot.completed_by.as_str(), diagnostics_build.as_str()] {
+        if !diagnostics_match_source(connection, &snapshot, build_id, source_diagnostics)? {
+            return Ok(None);
+        }
+    }
+    Ok(Some(IndexBuildMetrics {
+        discovered_files: files,
+        nodes,
+        edges,
+        diagnostics: source_diagnostics.len() as u64,
+        ..IndexBuildMetrics::default()
+    }))
+}
+
+fn diagnostics_match_source(
+    connection: &Connection,
+    snapshot: &GraphSnapshot,
+    build_id: &str,
+    source_diagnostics: &[GraphDiagnostic],
+) -> Result<bool, StoreError> {
+    if source_diagnostics.iter().any(|diagnostic| {
+        diagnostic.severity != DiagnosticSeverity::Warning
+            || diagnostic
+                .location
+                .as_ref()
+                .is_some_and(|location| location.span.is_some())
+            || !diagnostic.metrics.is_empty()
+            || diagnostic.snapshot_id.as_ref() != Some(&snapshot.id)
+    }) {
+        return Ok(false);
+    }
+    let mut expected: BTreeSet<_> = source_diagnostics
+        .iter()
+        .map(|diagnostic| {
+            (
+                diagnostic.code.as_str().to_string(),
+                diagnostic
+                    .location
+                    .as_ref()
+                    .map(|location| location.path.as_str().to_string()),
+            )
+        })
+        .collect();
+    if expected.len() != source_diagnostics.len() {
+        return Ok(false);
+    }
+    let mut statement = connection.prepare(
+        "SELECT code, path, COALESCE(snapshot_id = ?2 AND severity = 'warning' \
+            AND span_start_byte IS NULL AND span_start_line IS NULL \
+            AND span_start_column IS NULL AND span_end_byte IS NULL \
+            AND span_end_line IS NULL AND span_end_column IS NULL \
+            AND metadata_json = '{}', 0) \
+         FROM diagnostics WHERE build_id = ?1",
+    )?;
+    let mut rows = statement.query(params![build_id, snapshot.id.as_str()])?;
+    while let Some(row) = rows.next()? {
+        let code: String = row.get(0)?;
+        let path: Option<String> = row.get(1)?;
+        if !row.get::<_, bool>(2)? || !expected.remove(&(code, path)) {
+            return Ok(false);
+        }
+    }
+    Ok(expected.is_empty())
 }
 
 impl Sidecar {

--- a/src/repository_graph/index_tests.rs
+++ b/src/repository_graph/index_tests.rs
@@ -186,6 +186,149 @@ fn cold_build_persists_complete_graph_and_no_op_reuses_every_file() {
 }
 
 #[test]
+fn completed_snapshot_reuse_needs_no_fragments_and_full_still_reads_every_file() {
+    let directory = tempfile::tempdir().unwrap();
+    fixture_repository(directory.path());
+    let config = RepositoryGraphConfig::default();
+    let (_sidecar_dir, mut sidecar) = sidecar();
+    let first = run(
+        &mut sidecar,
+        &discover(directory.path(), &config),
+        &config,
+        "cold",
+        false,
+    )
+    .unwrap();
+    let facts = fact_identities(&sidecar, &first.snapshot.id);
+    sidecar
+        .connection()
+        .execute("DELETE FROM fragment_cache", [])
+        .unwrap();
+    let source = FailingReadSource(discover(directory.path(), &config));
+    let reused = run(&mut sidecar, &source, &config, "reused", false).unwrap();
+    assert_eq!(reused.snapshot, first.snapshot);
+    assert_eq!(reused.metrics.reused_files, 3);
+    assert_eq!(reused.metrics.processed_bytes, 0);
+    assert_eq!(reused.metrics.nodes, first.metrics.nodes);
+    assert_eq!(reused.metrics.edges, first.metrics.edges);
+    assert_eq!(fact_identities(&sidecar, &first.snapshot.id), facts);
+    assert_eq!(
+        sidecar
+            .connection()
+            .query_row("SELECT COUNT(*) FROM fragment_cache", [], |row| row
+                .get::<_, i64>(0))
+            .unwrap(),
+        0
+    );
+    assert_eq!(
+        run(&mut sidecar, &source, &config, "full-failed", true).unwrap_err(),
+        IndexError::SourceRead
+    );
+    let full = run(
+        &mut sidecar,
+        &discover(directory.path(), &config),
+        &config,
+        "full",
+        true,
+    )
+    .unwrap();
+    assert_eq!(full.metrics.parsed_files, 3);
+    assert_eq!(full.metrics.reused_files, 0);
+    assert_eq!(fact_identities(&sidecar, &full.snapshot.id), facts);
+}
+
+#[test]
+fn snapshot_reuse_revalidates_before_completion_and_before_publication() {
+    let directory = tempfile::tempdir().unwrap();
+    fixture_repository(directory.path());
+    let config = RepositoryGraphConfig::default();
+    let (_sidecar_dir, mut sidecar) = sidecar();
+    let first = run(
+        &mut sidecar,
+        &discover(directory.path(), &config),
+        &config,
+        "cold",
+        false,
+    )
+    .unwrap();
+    for (initial_calls, build, state) in [
+        (1, "before-completion", BuildState::Failed),
+        (0, "before-publication", BuildState::Superseded),
+    ] {
+        let source = SequencedSource {
+            inner: discover(directory.path(), &config),
+            revalidations: Cell::new(initial_calls),
+        };
+        assert_eq!(
+            run(&mut sidecar, &source, &config, build, false).unwrap_err(),
+            IndexError::SourceChanged
+        );
+        assert_eq!(
+            sidecar
+                .build(&BuildId::new(build).unwrap())
+                .unwrap()
+                .unwrap()
+                .state,
+            state
+        );
+        assert_eq!(
+            sidecar
+                .published_view(&repository(), &PublishedViewName::new("canonical").unwrap())
+                .unwrap()
+                .unwrap()
+                .snapshot_id,
+            first.snapshot.id
+        );
+        assert_eq!(source.revalidations.get(), 2);
+    }
+}
+
+#[test]
+fn analyzer_diagnostics_prevent_completed_snapshot_reuse() {
+    let directory = tempfile::tempdir().unwrap();
+    fixture_repository(directory.path());
+    write(&directory.path().join("src/lib.rs"), b"pub fn broken( {\n");
+    let config = RepositoryGraphConfig::default();
+    let (_sidecar_dir, mut sidecar) = sidecar();
+    let first = run(
+        &mut sidecar,
+        &discover(directory.path(), &config),
+        &config,
+        "cold",
+        false,
+    )
+    .unwrap();
+    assert!(
+        sidecar
+            .diagnostics_for_build(&first.build_id)
+            .unwrap()
+            .iter()
+            .any(|diagnostic| diagnostic.code.as_str().starts_with("rust."))
+    );
+    sidecar
+        .connection()
+        .execute("DELETE FROM fragment_cache", [])
+        .unwrap();
+    let second = run(
+        &mut sidecar,
+        &discover(directory.path(), &config),
+        &config,
+        "retry",
+        false,
+    )
+    .unwrap();
+    assert_eq!(second.metrics.parsed_files, 3);
+    assert_eq!(second.metrics.reused_files, 0);
+    assert!(
+        sidecar
+            .diagnostics_for_build(&second.build_id)
+            .unwrap()
+            .iter()
+            .any(|diagnostic| diagnostic.code.as_str().starts_with("rust."))
+    );
+}
+
+#[test]
 fn cache_hits_are_touched_only_when_snapshot_completion_commits() {
     let directory = tempfile::tempdir().unwrap();
     fixture_repository(directory.path());
@@ -204,6 +347,8 @@ fn cache_hits_are_touched_only_when_snapshot_completion_commits() {
         .execute("UPDATE fragment_cache SET last_used_at = 'old'", [])
         .unwrap();
 
+    // A changed manifest exercises fragment reuse rather than snapshot reuse.
+    write(&directory.path().join("README.md"), b"# Added\n");
     let source = CacheObservedSource {
         inner: discover(directory.path(), &config),
         sidecar_path: sidecar.path().to_path_buf(),
@@ -215,7 +360,8 @@ fn cache_hits_are_touched_only_when_snapshot_completion_commits() {
     let (distinct, unchanged): (i64, i64) = sidecar
         .connection()
         .query_row(
-            "SELECT COUNT(DISTINCT last_used_at), SUM(last_used_at = 'old') FROM fragment_cache",
+            "SELECT COUNT(DISTINCT last_used_at), SUM(last_used_at = 'old') FROM fragment_cache \
+             WHERE path != 'README.md'",
             [],
             |row| Ok((row.get(0)?, row.get(1)?)),
         )
@@ -241,6 +387,7 @@ fn failed_builds_do_not_leave_partial_cache_touches() {
         .connection()
         .execute("UPDATE fragment_cache SET last_used_at = 'old'", [])
         .unwrap();
+    write(&directory.path().join("README.md"), b"# Added\n");
     let changed = SequencedSource {
         inner: discover(directory.path(), &config),
         revalidations: Cell::new(1),
@@ -260,7 +407,7 @@ fn failed_builds_do_not_leave_partial_cache_touches() {
             .unwrap()
     };
     assert_eq!(touched(), 0);
-    // Fail the second touch so this also detects autocommit or partial batches.
+    // Abort a touch after the new fragment write to detect partial transactions.
     sidecar
         .connection()
         .execute_batch(
@@ -387,6 +534,36 @@ fn overlapping_publication_supersedes_the_completed_loser() {
             .build_id
             .as_str(),
         "build-winner"
+    );
+}
+
+#[test]
+fn completed_snapshot_reuse_cannot_overwrite_a_concurrent_publication() {
+    let directory = tempfile::tempdir().unwrap();
+    fixture_repository(directory.path());
+    let config = RepositoryGraphConfig::default();
+    let (_sidecar_dir, mut sidecar) = sidecar();
+    run(
+        &mut sidecar,
+        &discover(directory.path(), &config),
+        &config,
+        "cold",
+        false,
+    )
+    .unwrap();
+    let source = PublishingRaceSource {
+        inner: discover(directory.path(), &config),
+        sidecar_path: sidecar.path().to_path_buf(),
+        revalidations: Cell::new(0),
+    };
+    let outcome = run(&mut sidecar, &source, &config, "reuse-loser", false).unwrap();
+    assert!(outcome.reused_existing_snapshot);
+    assert_eq!(outcome.metrics.parsed_files, 0);
+    assert!(matches!(outcome.publication,
+        PublicationOutcome::Superseded { ref current } if current.build_id.as_str() == "build-winner"));
+    assert_eq!(
+        sidecar.build(&outcome.build_id).unwrap().unwrap().state,
+        BuildState::Superseded
     );
 }
 
@@ -601,6 +778,12 @@ fn corrupt_fragment_cache_is_treated_as_rebuildable_miss() {
         .execute("UPDATE fragment_cache SET fragment_json = '{invalid'", [])
         .unwrap();
 
+    // New discovery warnings require normal indexing even for equivalent facts.
+    write(
+        &repository_dir.path().join(".ferrus/project.toml"),
+        b"local=true\n",
+    );
+
     let second_source = discover(repository_dir.path(), &config);
     let second = run(&mut sidecar, &second_source, &config, "build-2", false).unwrap();
     assert_eq!(second.metrics.reused_files, 0);
@@ -711,6 +894,76 @@ struct SequencedSource {
     revalidations: Cell<u32>,
 }
 
+#[test]
+fn snapshot_collected_during_revalidation_is_not_recreated_without_facts() {
+    let directory = tempfile::tempdir().unwrap();
+    fixture_repository(directory.path());
+    let config = RepositoryGraphConfig::default();
+    let (_sidecar_dir, mut sidecar) = sidecar();
+    let first = run(
+        &mut sidecar,
+        &discover(directory.path(), &config),
+        &config,
+        "cold",
+        false,
+    )
+    .unwrap();
+    sidecar
+        .connection()
+        .execute("DELETE FROM published_views", [])
+        .unwrap();
+    let source = CollectedSnapshotSource {
+        inner: discover(directory.path(), &config),
+        sidecar_path: sidecar.path().to_path_buf(),
+    };
+    assert_eq!(
+        run(&mut sidecar, &source, &config, "collected", false).unwrap_err(),
+        IndexError::Commit
+    );
+    assert!(sidecar.snapshot(&first.snapshot.id).unwrap().is_none());
+    assert_eq!(
+        sidecar
+            .build(&BuildId::new("collected").unwrap())
+            .unwrap()
+            .unwrap()
+            .state,
+        BuildState::Failed
+    );
+}
+
+struct CollectedSnapshotSource {
+    inner: FilesystemRepositorySource,
+    sidecar_path: PathBuf,
+}
+
+impl RepositorySource for CollectedSnapshotSource {
+    type Error = SourceError;
+
+    fn repository(&self) -> &RepositoryRef {
+        self.inner.repository()
+    }
+    fn manifest(&self) -> &SourceManifest {
+        self.inner.manifest()
+    }
+    fn read_verified(&self, _file: &SourceFileDescriptor) -> Result<SourceContent, Self::Error> {
+        panic!("a reusable snapshot must not read individual source files");
+    }
+    fn revalidate(&self) -> Result<bool, Self::Error> {
+        let OpenSidecarResult::Ready(sidecar) = open_for_build_at(&self.sidecar_path).unwrap()
+        else {
+            panic!("sidecar is current");
+        };
+        sidecar
+            .connection()
+            .execute(
+                "DELETE FROM snapshots WHERE id = ?1",
+                [snapshot_identity(self.inner.manifest()).as_str()],
+            )
+            .unwrap();
+        self.inner.revalidate()
+    }
+}
+
 struct PublishingRaceSource {
     inner: FilesystemRepositorySource,
     sidecar_path: PathBuf,
@@ -810,12 +1063,22 @@ impl RepositorySource for PublishingRaceSource {
                     completed_by: winner.id.clone(),
                 })
                 .unwrap();
+            let expected = sidecar
+                .published_view(
+                    &winner.repository,
+                    &PublishedViewName::new("canonical").unwrap(),
+                )
+                .unwrap()
+                .map(|view| PublicationVersion {
+                    snapshot_id: view.snapshot_id,
+                    generation: view.generation,
+                });
             sidecar
                 .publish(&PublishRequest {
                     repository: winner.repository,
                     view_name: PublishedViewName::new("canonical").unwrap(),
                     build_id: winner.id,
-                    expected: None,
+                    expected,
                 })
                 .unwrap();
         }

--- a/src/repository_graph/index_tests.rs
+++ b/src/repository_graph/index_tests.rs
@@ -186,6 +186,174 @@ fn cold_build_persists_complete_graph_and_no_op_reuses_every_file() {
 }
 
 #[test]
+fn cache_hits_are_touched_only_when_snapshot_completion_commits() {
+    let directory = tempfile::tempdir().unwrap();
+    fixture_repository(directory.path());
+    let config = RepositoryGraphConfig::default();
+    let (_sidecar_dir, mut sidecar) = sidecar();
+    run(
+        &mut sidecar,
+        &discover(directory.path(), &config),
+        &config,
+        "cold",
+        false,
+    )
+    .unwrap();
+    sidecar
+        .connection()
+        .execute("UPDATE fragment_cache SET last_used_at = 'old'", [])
+        .unwrap();
+
+    let source = CacheObservedSource {
+        inner: discover(directory.path(), &config),
+        sidecar_path: sidecar.path().to_path_buf(),
+        revalidations: Cell::new(0),
+    };
+    let outcome = run(&mut sidecar, &source, &config, "cached", false).unwrap();
+    assert_eq!(outcome.metrics.reused_files, 3);
+    assert_eq!(source.revalidations.get(), 2);
+    let (distinct, unchanged): (i64, i64) = sidecar
+        .connection()
+        .query_row(
+            "SELECT COUNT(DISTINCT last_used_at), SUM(last_used_at = 'old') FROM fragment_cache",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!((distinct, unchanged), (1, 0));
+}
+
+#[test]
+fn failed_builds_do_not_leave_partial_cache_touches() {
+    let directory = tempfile::tempdir().unwrap();
+    fixture_repository(directory.path());
+    let config = RepositoryGraphConfig::default();
+    let (_sidecar_dir, mut sidecar) = sidecar();
+    let initial = run(
+        &mut sidecar,
+        &discover(directory.path(), &config),
+        &config,
+        "cold",
+        false,
+    )
+    .unwrap();
+    sidecar
+        .connection()
+        .execute("UPDATE fragment_cache SET last_used_at = 'old'", [])
+        .unwrap();
+    let changed = SequencedSource {
+        inner: discover(directory.path(), &config),
+        revalidations: Cell::new(1),
+    };
+    assert_eq!(
+        run(&mut sidecar, &changed, &config, "source-changed", false).unwrap_err(),
+        IndexError::SourceChanged
+    );
+    let touched = || {
+        sidecar
+            .connection()
+            .query_row(
+                "SELECT COUNT(*) FROM fragment_cache WHERE last_used_at != 'old'",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap()
+    };
+    assert_eq!(touched(), 0);
+    // Fail the second touch so this also detects autocommit or partial batches.
+    sidecar
+        .connection()
+        .execute_batch(
+            "CREATE TRIGGER fail_cache_touch BEFORE UPDATE OF last_used_at ON fragment_cache \
+         WHEN EXISTS (SELECT 1 FROM fragment_cache WHERE last_used_at != 'old') \
+         BEGIN SELECT RAISE(ABORT, 'injected cache touch failure'); END;",
+        )
+        .unwrap();
+    assert_eq!(
+        run(
+            &mut sidecar,
+            &discover(directory.path(), &config),
+            &config,
+            "commit-failed",
+            false
+        )
+        .unwrap_err(),
+        IndexError::Commit
+    );
+    let touched: i64 = sidecar
+        .connection()
+        .query_row(
+            "SELECT COUNT(*) FROM fragment_cache WHERE last_used_at != 'old'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(touched, 0);
+    assert_eq!(
+        sidecar
+            .published_view(&repository(), &PublishedViewName::new("canonical").unwrap())
+            .unwrap()
+            .unwrap()
+            .snapshot_id,
+        initial.snapshot.id
+    );
+    sidecar
+        .connection()
+        .execute_batch("DROP TRIGGER fail_cache_touch")
+        .unwrap();
+    let retry = run(
+        &mut sidecar,
+        &discover(directory.path(), &config),
+        &config,
+        "retry",
+        false,
+    )
+    .unwrap();
+    assert_eq!(retry.metrics.reused_files, 3);
+}
+
+struct CacheObservedSource {
+    inner: FilesystemRepositorySource,
+    sidecar_path: PathBuf,
+    revalidations: Cell<u32>,
+}
+
+impl RepositorySource for CacheObservedSource {
+    type Error = SourceError;
+
+    fn repository(&self) -> &RepositoryRef {
+        self.inner.repository()
+    }
+    fn manifest(&self) -> &SourceManifest {
+        self.inner.manifest()
+    }
+    fn read_verified(&self, file: &SourceFileDescriptor) -> Result<SourceContent, Self::Error> {
+        self.inner.read_verified(file)
+    }
+    fn revalidate(&self) -> Result<bool, Self::Error> {
+        let connection = rusqlite::Connection::open(&self.sidecar_path).unwrap();
+        connection.busy_timeout(std::time::Duration::ZERO).unwrap();
+        connection
+            .execute_batch("BEGIN IMMEDIATE; ROLLBACK")
+            .unwrap();
+        let touched: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM fragment_cache WHERE last_used_at != 'old'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        if self.revalidations.get() == 0 {
+            assert_eq!(touched, 0);
+        } else {
+            assert!(touched > 0);
+        }
+        self.revalidations.set(self.revalidations.get() + 1);
+        self.inner.revalidate()
+    }
+}
+
+#[test]
 fn overlapping_publication_supersedes_the_completed_loser() {
     let repository_dir = tempfile::tempdir().unwrap();
     fixture_repository(repository_dir.path());

--- a/src/repository_graph/ports.rs
+++ b/src/repository_graph/ports.rs
@@ -263,6 +263,9 @@ pub struct IndexCommit {
     pub files: Vec<SourceFileDescriptor>,
     pub graph: GraphFragment,
     pub cache_writes: Vec<CachedFragment>,
+    /// Validated cache hits touched atomically with snapshot completion. A build
+    /// that fails before completion leaves their retention timestamps unchanged.
+    pub cache_hits: Vec<FragmentCacheKey>,
     pub metrics: IndexBuildMetrics,
 }
 

--- a/src/repository_graph/ports.rs
+++ b/src/repository_graph/ports.rs
@@ -260,6 +260,9 @@ pub struct IndexBuildMetrics {
 #[derive(Debug, Clone)]
 pub struct IndexCommit {
     pub snapshot: GraphSnapshot,
+    /// Reuse persisted facts, with no file, fact, or fragment payload. The store
+    /// must recheck eligibility atomically before completing this attempt.
+    pub reuse_completed_snapshot: bool,
     pub files: Vec<SourceFileDescriptor>,
     pub graph: GraphFragment,
     pub cache_writes: Vec<CachedFragment>,
@@ -359,6 +362,14 @@ pub trait GraphStore {
 /// Persistence operations needed by the indexing coordinator. The DTOs remain
 /// backend-neutral so a remote implementation can preserve the same workflow.
 pub trait IndexStore: GraphStore {
+    /// Return fact counts only for a complete index with unchanged source
+    /// diagnostics and no analyzer diagnostics. A miss uses normal indexing.
+    fn reusable_index_metrics(
+        &self,
+        snapshot: &GraphSnapshot,
+        source_diagnostics: &[GraphDiagnostic],
+    ) -> Result<Option<IndexBuildMetrics>, Self::Error>;
+
     fn load_cached_fragment(
         &mut self,
         key: &FragmentCacheKey,

--- a/src/repository_graph/query_sqlite/support.rs
+++ b/src/repository_graph/query_sqlite/support.rs
@@ -334,10 +334,7 @@ pub(super) fn unsigned(value: i64) -> rusqlite::Result<u64> {
 }
 
 pub(super) fn serialized_len<T: Serialize>(value: &T) -> Result<u64, QueryError> {
-    let len = serde_json::to_vec(value)
-        .map_err(|_| backend_error())?
-        .len();
-    Ok(u64::try_from(len).unwrap_or(u64::MAX))
+    crate::json_size::serialized_len(value).map_err(|_| backend_error())
 }
 
 pub(super) fn escape_like(value: &str) -> String {

--- a/src/server/tools/check_gate.rs
+++ b/src/server/tools/check_gate.rs
@@ -1,7 +1,6 @@
 //! Run configured review checks and persist full logs with bounded feedback for the agent.
 
 use anyhow::Result;
-use std::collections::VecDeque;
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -40,20 +39,28 @@ async fn run_with_cwd(
     log_scope: &str,
     cwd: Option<&Path>,
 ) -> Result<CheckGateResult> {
-    let result = match cwd {
-        Some(cwd) => runner::run_checks_in(&config.checks.commands, cwd).await?,
-        None => runner::run_checks(&config.checks.commands).await?,
-    };
-    if result.passed {
+    if config.checks.commands.is_empty() {
         return Ok(CheckGateResult::Passed);
     }
-
     let ts = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs();
-    let log_content = build_full_log(&result.commands);
-    let log_path = store::write_check_log(attempt, ts, log_scope, &log_content).await?;
+    static LOG_SEQUENCE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let sequence = LOG_SEQUENCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let scope = format!("{log_scope}-{}-{sequence}", std::process::id());
+    let log_path = store::write_check_log(attempt, ts, &scope, "").await?;
+    let result = runner::run_checks_logged(
+        &config.checks.commands,
+        cwd,
+        &log_path,
+        config.limits.max_feedback_lines,
+    )
+    .await?;
+    if result.passed {
+        let _ = tokio::fs::remove_file(&log_path).await;
+        return Ok(CheckGateResult::Passed);
+    }
 
     let failed_commands: Vec<&str> = result
         .commands
@@ -74,30 +81,6 @@ async fn run_with_cwd(
     }))
 }
 
-fn build_full_log(commands: &[CommandResult]) -> String {
-    let mut out = String::new();
-    for cmd in commands {
-        let status = if cmd.passed { "PASS" } else { "FAIL" };
-        out.push_str(&format!("=== [{status}] {}\n\n", cmd.command));
-        if !cmd.stdout.trim().is_empty() {
-            out.push_str("--- stdout ---\n");
-            out.push_str(&cmd.stdout);
-            if !cmd.stdout.ends_with('\n') {
-                out.push('\n');
-            }
-        }
-        if !cmd.stderr.trim().is_empty() {
-            out.push_str("--- stderr ---\n");
-            out.push_str(&cmd.stderr);
-            if !cmd.stderr.ends_with('\n') {
-                out.push('\n');
-            }
-        }
-        out.push('\n');
-    }
-    out
-}
-
 fn build_report(commands: &[CommandResult], max_lines: usize, log_path: &Path) -> String {
     let failed: Vec<&CommandResult> = commands.iter().filter(|c| !c.passed).collect();
 
@@ -109,14 +92,12 @@ fn build_report(commands: &[CommandResult], max_lines: usize, log_path: &Path) -
 
     for cmd in &failed {
         out.push_str(&format!("`{}`\n", cmd.command));
-        let combined = format!("{}{}", cmd.stdout, cmd.stderr);
-        let total_lines = combined.lines().count();
-        let tail = last_n_lines(&combined, max_lines);
-        if total_lines > max_lines {
-            out.push_str(&format!("(last {max_lines} of {total_lines} lines)\n"));
+        let tail = &cmd.output.tail;
+        if cmd.output.truncated {
+            out.push_str(&format!("(bounded tail of {} lines; up to {max_lines} lines and 64 KiB of output retained)\n", cmd.output.total_lines));
         }
         out.push_str("```\n");
-        out.push_str(&tail);
+        out.push_str(tail);
         if !tail.ends_with('\n') {
             out.push('\n');
         }
@@ -127,43 +108,25 @@ fn build_report(commands: &[CommandResult], max_lines: usize, log_path: &Path) -
     out
 }
 
-fn last_n_lines(s: &str, n: usize) -> String {
-    if n == 0 {
-        return String::new();
-    }
-
-    let mut tail = VecDeque::with_capacity(n);
-    for line in s.lines() {
-        if tail.len() == n {
-            tail.pop_front();
-        }
-        tail.push_back(line);
-    }
-    tail.into_iter().collect::<Vec<_>>().join("\n")
-}
-
 #[cfg(test)]
 mod tests {
-    //! Bounded feedback selects the requested number of trailing log lines.
-
     use super::*;
 
     #[test]
-    fn last_n_lines_returns_only_tail() {
-        let input = "one\ntwo\nthree\nfour";
-
-        assert_eq!(last_n_lines(input, 2), "three\nfour");
-    }
-
-    #[test]
-    fn last_n_lines_handles_longer_limit() {
-        let input = "one\ntwo";
-
-        assert_eq!(last_n_lines(input, 10), "one\ntwo");
-    }
-
-    #[test]
-    fn last_n_lines_zero_limit_is_empty() {
-        assert_eq!(last_n_lines("one\ntwo", 0), "");
+    fn failure_report_uses_bounded_feedback_and_full_log_link() {
+        let commands = vec![CommandResult {
+            command: "check".into(),
+            passed: false,
+            output: crate::checks::runner::CapturedOutput {
+                tail: "last failure".into(),
+                total_lines: 100_000,
+                truncated: true,
+            },
+        }];
+        let report = build_report(&commands, 30, Path::new(".ferrus/logs/check.txt"));
+        assert!(report.contains("last failure"));
+        assert!(report.contains("100000 lines"));
+        assert!(report.contains("Full log: `.ferrus/logs/check.txt`"));
+        assert!(report.len() < 512);
     }
 }


### PR DESCRIPTION
## Summary

Reduce repeated work and peak memory use across HQ polling, TUI rendering, repository indexing, project-memory search, and check execution.

The TUI now selects visible transcript blocks from a bounded history, and current-schema HQ reads avoid migration write transactions. Graph indexing batches fragment-cache touches and reuses eligible completed snapshots while preserving source revalidation, diagnostics, `--full`, retention, and publication compare-and-set behavior. Memory and federated queries filter earlier, retain bounded ranking state, count serialized bytes without allocating complete JSON buffers, and share Rust AST traversal context. Check output streams to scoped files while only a bounded tail remains in memory.

Release builds now use ThinLTO, one codegen unit, and symbol stripping while retaining `opt-level = 3`. The optional, default-enabled `update-check` feature allows a smaller build without the HTTP/TLS dependency tree, and Ferrus now shares `sha2` 0.11 with `neva`.

Measured on macOS arm64 with Rust 1.98.0:

- completed-snapshot no-op indexing: 38.127 ms -> 24.134 ms in the quick Criterion run;
- release executable: 21.91 MiB -> 13.74 MiB;
- `dist --no-default-features`: 9.13 MiB.

The quick Criterion sample did not establish statistical significance for the no-op timing, so the benchmark is recorded as a development measurement rather than a performance guarantee.

Closes #71.

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Enhancement
- [x] Performance
- [x] Documentation
- [x] Refactor
- [ ] Security
- [ ] Breaking change

## Workflow impact (if applicable)

Does this change affect the Supervisor -> Executor -> Reviewer flow?

- [ ] No impact
- [x] Minor change (does not alter lifecycle semantics)
- [ ] Changes behavior of an existing step
- [ ] Introduces new state/transition

If yes, briefly explain:

Configured checks keep the same ordering, exit-status handling, retry accounting, and submission gate. Full output is spooled to scoped log files, while agent feedback retains at most `max_feedback_lines` and 64 KiB per failed command. Task states, leases, review transitions, and approval behavior are unchanged.

## Checklist

- [x] I added/updated tests where it makes sense
- [x] I updated docs/examples if needed
- [x] This change is backwards-compatible (or clearly marked as breaking)
- [x] I ran formatting/lints locally (if applicable)

## Notes for reviewers

Local validation:

- `cargo fmt --check`
- `cargo clippy --offline --locked -- -D warnings`
- `cargo test --offline --locked` - 895 tests passed
- `cargo clippy --offline --locked --no-default-features -- -D warnings`
- `cargo test --offline --locked --no-default-features` - 890 tests passed
- `cargo bench --offline --locked --bench repository_graph -- --quick`
- `cargo bench --offline --locked --profile dist --bench repository_graph -- --quick`

The completed-snapshot fast path is deliberately conservative: it requires matching snapshot identity, persisted fact counts, unchanged source diagnostics, and no analyzer diagnostics. Eligibility is rechecked transactionally before completion, and publication still uses the captured compare-and-set expectation. Any mismatch falls back to normal incremental indexing.

The `update-check` feature remains enabled by default. `dist` keeps `opt-level = "z"`; the measured `s` build was faster on the graph fixture but 19% larger. Binary-size methodology and profile tradeoffs are documented in `docs/binary-size.md`.
