### PR TITLE
Add Ferrus Nano architecture and runtime support

### DIFF
--- a/docs/ferrus-nano-architecture.md
+++ b/docs/ferrus-nano-architecture.md
@@ -1,0 +1,665 @@
+# Ferrus Nano: Native Agent Harness
+
+Status: accepted implementation plan, updated 2026-09-07. The #73 session foundation is
+implemented; the engine, provider, launcher, and subsequent slices remain planned. No measured
+performance claim.
+
+Working product name: `ferrus-nano`. Ferrus backend name: `nano`.
+
+Related documents: [roadmap](milestones.md), [repository graph](repository-graph-architecture.md),
+[project memory](project-memory-architecture.md).
+
+## 1. Decision
+
+Build a small Rust coding-agent runtime with native access to existing Ferrus operations and
+repository context. Ship the first version as a headless Executor launched by HQ. Keep the agent
+engine independent of the terminal, scheduler, MCP transport, and LLM provider so that an HQ
+conversation view and a standalone frontend can drive the same engine later.
+
+The first launch path is `ferrus nano run`, using the current Ferrus executable as a child process.
+Inside that child, Ferrus operations are ordinary Rust calls. There is no loopback `ferrus serve`
+process, MCP client, or JSON-RPC hop for native operations. External integrations use a neva MCP
+client through a separate tool adapter.
+
+Keep one package and ordinary Rust modules initially. Do not introduce a plugin SDK, independently
+versioned crate family, second orchestrator, or model-routing framework. Nano means a small harness,
+not a requirement to use a small model.
+
+Keep new harness code under `src/nano/` and preserve the existing Ferrus layout. Reuse operations
+where they live, with small callable helpers where needed. An optional `src/shared/` is reserved
+for concrete components used by both HQ and nano; introducing nano does not require a general
+application-layer extraction or moving the existing runtime into the library.
+
+Use `ferrus-nano` for a future standalone executable; avoid installing a bare `nano` executable
+alongside the existing terminal editor.
+
+## 2. Verified starting point
+
+The initial implementation lives in `src/nano/ferrus.rs`: `LaunchContext` captures trusted HQ
+environment/cwd, and `FerrusSession` resolves explicit project registration and a task-scoped
+Executor run. Its claim/status/heartbeat methods return existing project types, not MCP text.
+The scoped project entry points validate the exact run, role, agent, task, and workspace within
+the same SQLite transaction as effects. They never select the latest run or another task by agent.
+Status remains read-only, including before claim or after lease loss. Claim preserves pending
+promotion and retry semantics; heartbeat cannot renew outside an Executor work phase.
+
+The Git baseline is checked against HQ's existing task baseline metadata independently of optional
+graph snapshot IDs. The database is opened without create/migrate behavior: HQ must prepare it and
+persist the run binding before the child uses the adapter. The later launcher (#80) must account
+for run-start ordering; the current external launcher writes the run after spawning. This slice
+adds no runnable backend or automatic launch retry. The nano module's temporary dead-code allowance
+can be removed when the launcher makes these entry points reachable.
+
+Audit base: Ferrus commit `4f52783d6f5efa64ea1a2adf48b55c8b27c565be`.
+
+| Area | Available now | Work needed for nano |
+| --- | --- | --- |
+| Graph and memory domains | Public library modules, bounded queries, immutable identities, source verification | Native context projection and session working set |
+| Task graph routing | `LocalGraphContext`, task baselines/overlays, submitted snapshots | Explicit session context instead of ambient environment lookup |
+| Lifecycle | SQLite claims, leases, checks, submit, consultation, human questions, review | Expose native helpers in existing modules where needed; retain one implementation |
+| Workspace lifecycle | HQ worktrees, baseline preparation, process supervision and recovery | Native launch capabilities and structured output |
+| Checks | Ordered commands, log spooling, bounded feedback, final submit gate | Reuse the existing check path, with cancellation support |
+| Agent adapters | `ExecutorAgent` and `SupervisorAgent`, model overrides, stdin prompts | Executor-only/headless-only capability declarations; native registration |
+| UI | Crossterm HQ, `UiMessage`, transcript and question handling | A session-event adapter and, later, a conversation view |
+| MCP | neva 0.5.6 with `server`, `di`, `legacy-spec` | Add client features for external tools, preserve protocol compatibility |
+| Agent engine | No Ferrus-owned inference loop or provider implementation | Provider streaming, tool execution, context budgeting, session recovery |
+| Instructions | Ferrus role prompts, project guidance, and embedded skill templates | A bounded native instruction loader with explicit precedence and provenance |
+| Coding tools | Graph source readers, check runner and process primitives | General bounded reads/search, patch editing, command sessions |
+
+Important source locations:
+
+- `src/lib.rs` exports graph, memory, and distributed modules. Project runtime, HQ, and MCP
+  composition currently belong to `src/main.rs`; they are not an existing reusable runtime library.
+- `src/server/tools/{wait_for_task,check,submit}.rs` contain lifecycle behavior as well as MCP
+  wrappers. `handler_for_agent` still returns serialized text and neva errors.
+- `src/server/tools/repository_context.rs` adapts JSON inputs and serializes typed graph responses.
+- `src/repository_graph_runtime.rs` owns project configuration, routing, freshness, and verified
+  content adaptation. Native access must preserve this boundary.
+- `src/hq/agent_manager.rs` launches processes, logs stdout/stderr, and closes stdin after sending
+  a headless prompt. This is not yet a bidirectional session protocol.
+- `src/agents/mod.rs` defaults version discovery to an interactive command and assumes MCP
+  registration. These defaults do not fit an Executor-only native backend unchanged.
+
+The current extractor set covers generic files, Cargo, Rust syntax, and relationship resolution.
+It is useful structural evidence, not complete compiler semantics or universal language coverage.
+
+## 3. What should improve, and why
+
+Native invocation removes local transport and serialization work around Ferrus operations. The LLM
+still receives tool definitions and emits tool arguments; those tokens do not disappear with MCP.
+Remote inference, graph refresh, source reads, and checks may dominate elapsed time.
+
+The stronger hypotheses are:
+
+1. A bounded graph query can replace several exploratory searches and whole-file reads.
+2. A session working set can avoid sending the same source ranges and facts repeatedly.
+3. Host-owned claims, heartbeat, waiting, and completion gates remove mechanical model turns.
+4. Stable tool schemas and context ordering can improve provider prompt-cache reuse.
+5. Explicit effects, edit preconditions, and recoverable tool records can reduce avoidable retries.
+
+Determinism means reproducible context selection and control flow for recorded model responses,
+tool results, configuration, and source identities. It does not mean identical model output on
+repeated live requests. Pin model identifiers where supported and record effective settings.
+
+## 4. Boundaries and dependencies
+
+```text
+Ferrus HQ scheduler
+  |
+  +-- process supervisor --> ferrus nano run
+                               |
+                          Session engine <--> LLM provider
+                               |
+                     Tool registry and policy
+                       /        |         \
+               Ferrus host   Workspace   External MCP
+                   |           tools       (neva)
+          Existing Ferrus operations
+             /             \
+       Project runtime   Local graph/memory adapters
+             |                    |
+         ferrus.db          Existing domain APIs
+
+External agents --> Ferrus MCP wrappers --> same existing operations
+
+Session commands --> Session engine --> Session events
+                                       |-- JSONL/headless output
+                                       |-- HQ conversation adapter (later)
+                                       `-- Standalone frontend (later)
+```
+
+Use only a few substitution boundaries: model provider, tool execution, session storage, and
+command/event delivery. Context selection and managed Executor behavior are concrete modules,
+not independently configurable plugin pipelines.
+
+Existing operation implementations retain role/session guards and lifecycle behavior. Nano's
+Ferrus adapter supplies validated session identity and calls those implementations. Native tools
+must not manipulate SQLite rows or artifact files directly. Graph and memory domains remain
+unaware of nano, LLMs, HQ, and network clients. Session history does not become project memory.
+
+The child-process boundary preserves HQ's existing process ownership, worktree cwd, stop/recovery,
+and dispatch accounting. It also isolates remaining legacy uses of process environment and cwd.
+Do not embed several nano sessions inside the HQ process while those ambient dependencies remain.
+
+### Reusing existing operations
+
+Connect the operations needed by the Executor incrementally:
+
+- claim/attach and scoped context loading;
+- status and lease renewal;
+- check and final submit;
+- consultation and human-question request/wait;
+- graph status/search/context and memory/federated retrieval;
+- scoped reads of task, rejection, templates, and other currently authorized resources.
+
+Keep the existing files and ownership of these operations. If a handler combines transport
+formatting with lifecycle logic, separate a small `pub(crate)` helper in that same module as the
+native caller is added. Use typed outcomes for native callers and retain the MCP formatter around
+the helper. Reuse existing project/graph/check APIs directly when they already provide the needed
+operation; do not create another forwarding layer for every API.
+
+The nano host keeps an explicit validated session context binding project, agent, role, task, run,
+workspace, and baseline. It resolves that context from HQ launch data and SQLite; the model cannot
+select another task or root. Pass the identity and inputs required by each operation, using
+existing types where possible. Revalidate ownership and lifecycle at effect boundaries, rather
+than trusting a startup snapshot. Add explicit-context entry points only where ambient lookup
+would otherwise make native execution incorrect; no repository-wide signature rewrite is needed.
+
+MCP wrappers retain their current names, input shapes, textual compatibility, and manual
+`app.map_tool()` registration. They translate to and from the same operations nano uses.
+Role visibility is also enforced inside the operations, since native invocation bypasses MCP
+listing. Do not use `handler_for_agent` as nano's permanent API or copy its behavior into nano.
+
+All Ferrus capabilities should ultimately have a native path. The initial Executor tool set
+contains only Executor and shared operations. Supervisor, Reviewer, Consultant, archive, and
+compatibility-only tools are exposed only when their corresponding host profile is implemented.
+
+## 5. Engine, providers, and execution policy
+
+The engine owns one session and one active model turn. Start with sequential tool execution.
+Later, independently authorized read-only calls may run concurrently against the same pinned
+view, with results committed in model-call order. Workspace mutations, checks, submit, and
+lifecycle transitions remain serial barriers. External tools are not assumed read-only from
+untrusted annotations.
+
+Load a compact native role policy, the current task/rejection context, and applicable project
+instructions with their paths and content digests. Preserve Ferrus's existing rule that supporting
+`AGENTS.md`, `ROLE.md`, and skill documents cannot override runtime authority or the active task.
+Apply nested project guidance by workspace path and load selected skill bodies on demand, under
+explicit context limits. Do not load every external agent's configuration or every skill into the
+prompt. Keep active constraints through compaction and refresh guidance when its source changes.
+This needs an instruction loader, not a plugin/hook framework. The native role prompt describes
+host-owned claim/heartbeat/wait behavior instead of asking the model to perform it over MCP.
+
+An ordinary turn is:
+
+```text
+accept command -> assemble bounded context -> stream model response
+  -> validate completed tool calls -> authorize -> persist intent
+  -> execute -> persist outcome -> update working set -> next turn
+```
+
+Never execute partial streamed arguments. Reject unknown tools and invalid schemas with bounded,
+typed feedback. Stop malformed-call loops, repeated no-progress calls, and provider retries with
+explicit budgets. A final model message alone does not complete a managed Ferrus task.
+
+The provider interface covers streaming text and tool calls, terminal reasons, cancellation,
+usage, context limits, and provider-specific continuation data. Keep provider wire types inside
+adapters; preserve opaque signed/reasoning blocks where the provider requires them. Do not invent
+a common format that silently loses tool-call IDs or continuation requirements.
+
+Choose one real provider for the first end-to-end slice, plus a scripted provider for tests. The
+first production provider is still open. A second adapter is a later compatibility check, not a
+prerequisite for the engine. An OpenAI-compatible endpoint is a candidate adapter, not a guarantee
+that local servers implement identical tool calling, streaming, usage, or context limits.
+
+Load credentials through host configuration or environment references. Keep credentials out of
+project files, command arguments, transcript events, tool children, and MCP child environments.
+Separate provider inference transport from workspace command execution and external MCP access.
+
+Budgets include model turns, total input/output tokens, tool calls, command duration, provider
+retries, context bytes, and elapsed time. Charge compaction and retries to the same session budget.
+Persist consumption across recovery of that session; HQ's existing task dispatch limit still
+bounds fresh attempts. Budget exhaustion ends the agent attempt with a typed reason and uses
+existing HQ recovery behavior; nano does not invent new task statuses.
+
+## 6. Native coding tools
+
+Prefer familiar, narrow tools with typed results over a single arbitrary `ferrus_call` dispatcher.
+Use one authoritative descriptor per tool, with provider-specific schema encoding at the edge.
+Expose only schemas relevant to the session; model tokens still matter for native tools.
+
+| Surface | Initial behavior |
+| --- | --- |
+| `repository_graph_status`, `repository_search`, `repository_context` | Existing bounded graph semantics, native typed results |
+| `project_memory_status`, `project_context_search`, `project_context` | Existing curated memory semantics and explicit domains |
+| `read_file` | Bounded line/range reads with path, content digest, and source identity |
+| `search_text` | Bounded lexical/path search for literals, unsupported syntax, and missing graph coverage |
+| `apply_patch` | Create/update/delete with explicit base-content preconditions and conflict results |
+| `exec`, `read_process`, `stop_process` | Bounded noninteractive commands, cancellation, persisted output handles |
+| `read_output` | Retrieve a bounded range from an authorized session output artifact |
+| `check`, `submit`, `consult`, `ask_human`, `status` | Native Ferrus operations, preserving existing lifecycle behavior |
+
+Claims, heartbeat, and wait operations are native host operations, usually absent from the model's
+tool catalog. They remain available to the runtime without spending inference turns.
+
+File tools confine paths to authorized roots, handle symlinks safely, preserve unrelated edits,
+and check the expected content before writing. Validate all patch hunks before applying a patch;
+report any partial filesystem failure precisely rather than promising a multi-file transaction.
+Keep original/new digests sufficient to reconcile an interrupted edit. Do not silently apply a
+stale edit with fuzzy matching. Binary and oversized content return explicit limitations.
+
+Use existing process lifecycle helpers and bounded check-output primitives where appropriate.
+General command sessions still need duration limits, process-tree cancellation, output cursors,
+and disk quotas. Build/test commands in managed mode continue through Ferrus `check`; a generic
+shell success is not a check receipt. Ferrus retains ownership of Git staging, history, and final
+integration. Native file tools cannot modify runtime databases or `.ferrus/` lifecycle artifacts.
+
+For the first release, declare a trusted-local command mode explicitly. Root-confined file tools
+and an isolated Git worktree are not an OS sandbox for arbitrary shell code. A policy can deny
+commands, but it cannot make allowed shell code unable to access the host. Keep an execution
+backend boundary for future enforced sandboxing; do not label the initial backend sandboxed.
+
+In headless managed mode, missing human input is routed through existing `ask_human`/answer
+handling. The tool layer must not wait on an invisible terminal prompt.
+
+## 7. Repository context as a native working set
+
+This is the distinguishing part of nano. Implement it as a concrete context manager using the
+existing graph query and verified-content boundaries.
+
+Maintain three separate representations:
+
+1. An append-only session journal with model messages, tool calls, outcomes, and provenance.
+2. A working set of evidence handles, source ranges, edits, check outcomes, and active intent.
+3. A bounded model-context projection assembled from those records for the next request.
+
+A working-set entry identifies its repository, task view, immutable snapshot/overlay, optional
+memory revision/link set, path or node, source digest/span, inclusion reason, and freshness.
+Evidence handles are lookup keys, not replacements for source text needed to make an edit.
+
+### Retrieval flow
+
+1. The managed host obtains task intent and rejection feedback through the normal claim path.
+2. Check graph availability once. Resolve explicit task paths/symbols into small bounded queries;
+   without usable seeds, let the model choose a search instead of building a speculative repo map.
+3. Search exact paths/symbols first, then expand relevant structural neighbors under a hard budget.
+4. Include verified source ranges when needed for reasoning or editing. Merge overlapping ranges
+   only when their content identity and snapshot match.
+5. Keep selected evidence in the working set and reuse it while its validity and context presence
+   are known. A result evicted by compaction must be materialized again when requested.
+6. Fall back to authorized current-workspace reads and lexical search when the graph is disabled,
+   missing, stale for the requested file, ambiguous, or lacks coverage. Label this as workspace
+   evidence, not evidence from the old graph snapshot.
+
+Graph results never enter persisted task/review prompts or task artifacts. An optional initial
+prefetch is a logged native retrieval operation with a separately identified evidence observation
+in the session context. It must not fabricate an assistant tool call to satisfy provider message
+formatting. The context projection encodes host observations in the provider's supported format
+with their origin intact. Prefetch can be disabled for evaluation and is subject to the same
+read-only and budget rules as model-requested retrieval.
+
+Start with deterministic ranking: explicit seeds, requested relationships, stable relevance
+scores, and a stable path/ID tie-breaker. No embeddings, hidden planner model, speculative full
+graph expansion, or automatic project-memory writes are required. Missing edges remain unknown;
+they are not proof of no callers, no dependencies, or safe deletion.
+
+### Freshness and invalidation
+
+Graph queries stay read-only. Workspace mutation tracking schedules refresh through the existing
+refresh coordinator outside the retrieval operation, under existing sidecar leases.
+
+- Successful native edits advance a session workspace generation and invalidate affected source
+  entries and derived context packets. The returned changed-path set drives a debounced overlay
+  refresh after an edit batch, with a finite refresh time budget.
+- Shell commands and checks may edit arbitrary files. Treat their mutation scope as unknown unless
+  verified, invalidate the relevant workspace observation, and reconcile before trusting it again.
+- Background processes keep the workspace potentially mutable while they run. Do not run final
+  checks/submit until nano-owned writers are stopped or joined. Capture and compare source identity
+  around the check/freeze boundary and report a concurrent-change outcome if it changed.
+- Other editors and processes are not fully covered by nano's generation counter. File watchers
+  are advisory; retain `Freshness::Unknown` without reliable comparison. Verify bytes at reads and
+  patch application. A session counter must never make globally unverified data appear fresh.
+- A failed refresh preserves the last publication and reports its age/limitations. Existing check
+  and submit refresh/freeze semantics remain the final lifecycle integration points.
+
+Resolve a mutable graph publication once for a context assembly, then pin every query in that
+assembly to the immutable target. Cache keys include project/repository, task-view identity,
+snapshot/overlay, effective query shape, budgets, source-policy version, and content identities
+where relevant. Memory caches additionally bind the exact memory revision and link-set pair.
+Do not reuse cursors after a view changes. Invalid task bindings and missing Reviewer freezes
+are routing errors, never reasons to fall back to canonical data.
+
+### Context budget and compaction
+
+Compute available input space from the provider's context limit minus reserved output, tool
+schemas, instructions, protocol overhead, and a safety margin. Admit bounded evidence only within
+that space. Track estimated tokens separately from provider-reported usage.
+
+Prioritize active instructions and task intent, recent edits/check failures, directly selected
+source, then optional neighbors and historical context. Keep a stable prefix where possible;
+changing the tool catalog or rewriting earlier messages can reduce prompt-cache reuse.
+
+First compact deterministically: remove superseded evidence from the projection, replace large
+old outputs with retrievable handles, and retain recent complete call/result groups. If necessary,
+summarize older reasoning/intent into a checkpoint with evidence references. Preserve unresolved
+questions, current constraints, edit preconditions, and verification gaps. A summary cannot grant
+tool authority or overwrite SQLite state. Do not compact a partially executed tool group or
+rewrite opaque provider data that must remain intact. The original journal remains available.
+
+## 8. Managed Executor lifecycle
+
+The managed host, not the model, carries out the mechanical workflow:
+
+```text
+validate launch -> claim task -> start lease renewal -> run model/tool loop
+  |                                   |
+  |                                   +-- consult/ask_human -> native wait -> resume
+  |
+  `-- model requests submit
+        -> quiesce writes -> check -> submit's final gate and freeze
+        -> confirm SQLite Reviewing handoff -> stop session
+```
+
+Claim occurs before the first inference request. Renew only the caller-owned lease on the
+configured schedule, independently of provider streams, commands, and native waits. On ownership
+loss, stop new effects, cancel running work where possible, and re-resolve runtime state; do not
+continue writing under a stale claim.
+
+After `consult` or `ask_human`, invoke the corresponding wait operation immediately. The host
+handles bounded polling timeouts without model calls and delivers the actual answer once ready.
+Resume/recovery must also recognize an already paused task, reconstruct its pending request, and
+wait for that request instead of claiming fresh work or issuing a duplicate question.
+
+The public native `submit` tool is a managed sequence: run `check` immediately before invoking
+the existing submit operation, which runs the final gate again. This preserves today's required
+workflow. Deduplicating those gates is a separate lifecycle change requiring evidence and tests.
+Failed checks return bounded feedback to the model while preserving Ferrus retry accounting.
+
+Stop after a confirmed Reviewing handoff; the Executor never approves its own work. If the model
+ends without a handoff, report an incomplete attempt and let existing HQ dispatch/recovery rules
+handle it. Do not infer task completion from a model sentence, process exit code, or journal event.
+After a lost submit response, query SQLite and reconcile artifacts/pins before attempting again.
+
+When a native operation commits a lifecycle effect, cancellation must reconcile its outcome before
+ending the session. A stop request cannot simply forget an in-flight submit transaction.
+
+## 9. Session journal and crash recovery
+
+Use one versioned, single-writer JSONL journal per nano session plus bounded output artifacts.
+Managed location proposal:
+
+```text
+<project-data>/nano/sessions/<session-id>/
+  events.jsonl
+  outputs/<output-id>
+  checkpoints/<checkpoint-id>.json
+```
+
+Resolve `<project-data>` from project metadata. Link the nano session to its Ferrus task and run;
+do not put provider transcripts into `ferrus.db`, `repo-graph.db`, or `project-memory.db`. Existing
+`.ferrus/logs/` can contain the normal human-readable session log and a journal locator.
+Session bodies are local operational artifacts excluded from default project-memory ingestion.
+Define retention/quotas and owner-only file permissions alongside the journal, not after release.
+
+Persist completed messages and tool intent/outcomes with sequence numbers and stable call IDs.
+Flush intent before effects and flush the outcome before acknowledging completion. Token deltas
+may be ephemeral UI events; persist the completed message. Recover a truncated final journal
+record safely and write checkpoints atomically. A journal failure stops new unrecorded effects.
+
+On resume, validate workspace, source changes, role, run/task binding, and current lease. A new
+HQ run may reference a prior session checkpoint as context but does not inherit its authority.
+Reconcile completed native lifecycle operations against Ferrus state and deterministic edits
+against their before/after digests. An interrupted command or external MCP effect has an unknown
+outcome unless the tool provides reliable reconciliation; do not replay it automatically.
+
+Recorded replay tests reproduce engine decisions with scripted model/tool inputs. They do not
+re-execute real shell commands, external effects, or provider calls. Live resume is a separate
+operation that rechecks current authority and source state.
+
+## 10. External MCP through neva
+
+Keep MCP at the extension boundary. The native Ferrus catalog must not contain a second MCP copy
+of the same Ferrus operations.
+
+MVP: explicitly configured stdio servers, connect/list/call/disconnect, namespace isolation,
+schema validation, bounded results, timeouts, and cancellation. Use a provider-safe deterministic
+tool-name encoding with a reversible mapping to server/tool identity. Pin the enabled catalog
+and schema hashes for an active turn. Large catalogs can later use explicit search/enable, rather
+than sending every external schema on every turn.
+
+Treat server content and tool descriptions as data. Apply local permissions independently of
+server annotations. Keep credentials scoped to the configured server. Advertise only supported
+client capabilities: sampling is disabled initially; elicitation is either routed through the
+host's human-input path or explicitly unsupported, with no headless terminal prompt.
+
+Ferrus currently enables neva's `legacy-spec` and serves MCP `2025-03-26`. Adding client features
+to that dependency retains the legacy build profile. Cargo feature unification means putting
+a client in another crate of the same dependency graph does not isolate the protocol generation.
+Use that compatible profile for the first stdio integration and test actual supported peers.
+
+Supporting a new protocol generation requires a deliberate migration of Ferrus's existing server
+surface or a separately built bridge process. Do not silently remove `legacy-spec` while adding
+nano. Streamable HTTP, OAuth, resources/prompts, and richer external interactions can follow
+without changing the engine/tool boundary. neva manages protocol details, not model inference.
+
+## 11. HQ and standalone evolution
+
+Introduce explicit adapter capabilities covering role, interaction mode, Ferrus integration
+(`native` or `mcp`), and output format. For nano v1:
+
+```text
+executor/headless: supported
+supervisor/reviewer/consultant: unsupported
+interactive: unsupported
+Ferrus integration: native
+output: versioned session events
+```
+
+Reject unsupported modes before worktree/process setup. Override version discovery explicitly.
+`ferrus register --executor nano` validates native configuration and selects the backend without
+writing self-referential MCP configuration. Keep external adapters' current behavior as defaults.
+The requested Executor-only rollout is intentional; do not add a fake Supervisor implementation.
+
+Define `SessionCommand` and `SessionEvent` independently of `UiMessage`:
+
+- Commands: start, cancel, resume, and later user input/steering/approval response.
+- Events: session/turn started, text delta, tool started/completed, context selected, usage,
+  check outcome, input required, error, and session ended.
+- Every durable event has a version, sequence, session identity, and optional task/run/call IDs.
+
+Add a native launch/output mode alongside the current raw-output/stdin-prompt modes. In that mode,
+stdin carries bounded JSONL commands and remains open; stdout carries JSONL events; stderr carries
+diagnostics. Child commands and MCP servers never write to the protocol stdout. Debug mode must
+preserve the same protocol. Unknown versions and oversized frames produce explicit errors.
+
+The HQ adapter translates events into its current transcript, status, and question presentation;
+it does not parse prose to infer checks, completion, or costs. Start with coarse session/tool
+events. Coalesce token deltas and bound UI queues so a slow renderer cannot block lease renewal
+or durable tool outcomes. Recovery uses the journal, not the display stream.
+
+Interactive phase: add an HQ conversation view and command producer, with one active inference
+turn per session and a defined steering queue. Adapt the current HQ transcript/input/rendering in
+place first. Move a component into `shared/` only when both frontends need that implementation.
+The current HQ renderer is not an existing reusable chat widget. Test geometry, scrolling,
+cancellation, and long tool output.
+
+Standalone phase: compose the same engine with a `StandaloneHost` supplying an explicit workspace,
+local tools, configuration, session storage, and optional local graph/memory. It must run without
+an HQ daemon, selected spec, task claim, or `ferrus.db`. Reuse graph domains with explicit local
+scope; do not call today's `LocalGraphContext::load_for_agent` in an unregistered directory.
+Standalone completion is a session result, while managed completion remains Ferrus submit.
+
+A future `ferrus-nano` binary can reuse the nano engine and selected frontend components without
+spawning a `ferrus serve` process. Decide library exports when adding that binary; the initial
+headless integration does not require them. Supervisor support is another host capability/profile
+with its own planning, review, consultation, and archive policies; adding a UI alone does not
+grant those operations.
+
+## 12. Initial code organization
+
+All new harness implementation lives under one directory. This is a possible internal split,
+not a requirement to create every file before the first working slice:
+
+```text
+src/
+  nano/
+    mod.rs
+    cli.rs                 # Headless entry point and JSONL command/event delivery
+    agent.rs               # ExecutorAgent implementation used by HQ
+    engine.rs              # Bounded turn loop and commands/events
+    ferrus.rs              # Managed host and native calls to existing Ferrus operations
+    config.rs              # Nano settings and provider selection
+    provider.rs            # Provider contract and streaming normalization
+    providers/             # First provider plus scripted test provider
+    context.rs             # Working set, projection, invalidation, compaction
+    instructions.rs        # Scoped guidance and selected skill loading
+    tools.rs               # Descriptors, authorization and tool execution contract
+    workspace.rs           # Local file, patch, process and output tools
+    session.rs             # Journal, checkpoints, recovery
+    mcp.rs                 # Optional neva client adapter
+  shared/                  # Optional: concrete components shared by HQ and nano
+```
+
+Start with `mod nano` in the existing binary, optionally feature-gated. The engine depends on its
+provider/tool/host contracts; `nano/ferrus.rs` binds them to the current project, graph, checks,
+and tool modules. Workspace adapters can reuse `platform` and output helpers in place. Keep
+Ferrus-specific imports out of the engine itself so later standalone composition needs another
+host, not a rewrite of the loop. Public library exports and crate splitting can wait for a real
+standalone consumer.
+
+Limit changes outside `nano/` to the integration points actually required:
+
+- `src/main.rs`: declare the nano module.
+- `src/cli/mod.rs`: add command routing to `nano::cli`.
+- `src/agents/mod.rs` and existing registration/config code: select `nano::agent`, validate
+  capabilities, and skip self-MCP registration for the native backend.
+- `src/hq/agent_manager.rs` and the existing UI path: launch nano and consume its events.
+- Existing operation modules: expose small native helpers and the guards needed by their callers.
+- `Cargo.toml`: add the necessary optional provider/client dependencies and features.
+
+Keep `project/`, `server/`, `checks/`, graph/memory adapters, and external-agent implementations in
+their current locations. There is no new `application/`, root-level `nano_host.rs`, or mandatory
+library migration. The conceptual native-operation boundary does not require a new directory.
+
+Create `shared/` only when an implementation has two actual consumers and no suitable existing
+owner. A reusable conversation renderer is a possible later example. Keep nano session events in
+`nano` initially; HQ can consume that public-to-the-crate contract. Do not move existing utilities
+or domain operations into `shared/` merely because nano calls them.
+
+Parse nano-specific settings only when nano is selected/invoked. Unrelated CLI, graph, and existing
+external-agent operations must not initialize providers or external MCP clients. Keep provider
+dependencies optional and session limits distinct from Ferrus task/review retry limits.
+
+## 13. Delivery slices and acceptance
+
+| Slice | Deliverable | Acceptance evidence |
+| --- | --- | --- |
+| N0: Native integration seam | Add `nano/ferrus.rs`; expose the first required helpers in place | Native/MCP parity for the touched operations and their role/lease guards; no broad module moves |
+| N1: Smallest agent | Scripted and one real provider, core tools, bounded loop, journal, managed host | HQ launches nano; it edits an isolated task, checks, submits and exits; unsupported modes fail early |
+| N2: Native context | Working set, verified snippets, invalidation, bounded projection and compaction | Stale source/edit conflicts handled; graph-disabled and unsupported-language tasks still work; benchmark ablations recorded |
+| N3: Extensions and recovery | External stdio MCP, cancellation, interrupted-effect reconciliation | Namespaces, timeouts, unsupported capabilities, no duplicate effects, lease loss and process cleanup verified |
+| N4: Interactive HQ | Shared command/event flow plus conversation/input UI | Same engine works headlessly and interactively; input wait and terminal geometry tested |
+| N5: Standalone and roles | Standalone host/binary, then individual Supervisor role profiles | Works without Ferrus runtime registration; each added role preserves its lifecycle and authority |
+
+N1 connects the remaining Executor operations incrementally and includes parity coverage for
+claims, check failures, submit, paused flows, and graph routing. It also includes basic graph
+calls; N2 makes graph use efficient and systematic. The first usable
+headless MVP is N0-N3. It includes compactable sessions and minimal external MCP support, not just
+a demo inference loop. N4/N5 are subsequent releases. Break each slice into reviewable changes;
+keep each helper adjustment with the native use case that needs it instead of scheduling a
+repository-wide preparatory refactor.
+
+### Planned PRs and GitHub issues
+
+Each row tracks one implementation PR. PRs 01-13 cover the first headless release, including
+comparative evaluation; PRs 14-18 cover interactive HQ, standalone, and Supervisor profiles.
+Dependencies identify prerequisites and allow independent work to proceed separately.
+The [first issue](https://github.com/ferrus-dev/ferrus/issues/73) also contains this index and the architectural baseline.
+
+| PR | Phase | Issue | Depends on |
+| --- | --- | --- | --- |
+| 01 | N0 | [#73: add native Ferrus session binding and operation entry points](https://github.com/ferrus-dev/ferrus/issues/73) | None |
+| 02 | N1 | [#74: implement the bounded session engine and durable event journal](https://github.com/ferrus-dev/ferrus/issues/74) | #73 |
+| 03 | N1 | [#75: add the first streaming LLM provider](https://github.com/ferrus-dev/ferrus/issues/75) | #74 |
+| 04 | N1 | [#76: add bounded file search, reading, and patch tools](https://github.com/ferrus-dev/ferrus/issues/76) | #74 |
+| 05 | N1 | [#77: add cancellable command sessions and bounded output](https://github.com/ferrus-dev/ferrus/issues/77) | #74 |
+| 06 | N1 | [#78: load scoped instructions and expose native repository context tools](https://github.com/ferrus-dev/ferrus/issues/78) | #73, #74, #76 |
+| 07 | N1 | [#79: implement the managed Executor lifecycle](https://github.com/ferrus-dev/ferrus/issues/79) | #73, #74, #76, #77, #78 |
+| 08 | N1 | [#80: integrate headless launch and structured events with HQ](https://github.com/ferrus-dev/ferrus/issues/80) | #75, #79 |
+| 09 | N2 | [#81: add a revision-aware repository working set](https://github.com/ferrus-dev/ferrus/issues/81) | #77, #78, #79 |
+| 10 | N2 | [#82: add token-budgeted context projection and compaction](https://github.com/ferrus-dev/ferrus/issues/82) | #74, #75, #78, #81 |
+| 11 | N3 | [#83: connect external stdio MCP tools through neva](https://github.com/ferrus-dev/ferrus/issues/83) | #74, #77, #79 |
+| 12 | N3 | [#84: resume interrupted sessions and reconcile tool effects](https://github.com/ferrus-dev/ferrus/issues/84) | #77, #79, #80, #82, #83 |
+| 13 | MVP validation (N0-N3) | [#85: add comparative evaluations and headless release gates](https://github.com/ferrus-dev/ferrus/issues/85) | #80, #81, #82, #83, #84 |
+| 14 | N4 | [#86: add an interactive conversation view to Ferrus HQ](https://github.com/ferrus-dev/ferrus/issues/86) | #85 |
+| 15 | N5 | [#87: add a standalone host and ferrus-nano executable](https://github.com/ferrus-dev/ferrus/issues/87) | #85 |
+| 16 | N5 | [#88: reuse the conversation UI in the standalone executable](https://github.com/ferrus-dev/ferrus/issues/88) | #86, #87 |
+| 17 | N5 roles | [#89: support Supervisor planning, specification, and archive sessions](https://github.com/ferrus-dev/ferrus/issues/89) | #86 |
+| 18 | N5 roles | [#90: support Reviewer and Consultant session profiles](https://github.com/ferrus-dev/ferrus/issues/90) | #89 |
+
+Minimum failure cases: graph unavailable; stale snippet; changed edit base; invalid task binding;
+oversized output; malformed or repeated tool call; provider timeout/rate limit; compaction around
+tool results; cancellation during commands/checks/submit; lease loss; consultation/answer recovery;
+crash before/after an effect; stdout protocol corruption; and external MCP name/schema changes.
+
+Run focused tests and the repository's required `cargo fmt --check`, `cargo clippy -- -D warnings`,
+and `cargo test`. Add feature-specific gates for nano when implemented, including provider protocol
+fixtures and a local MCP peer. Test the legacy/default neva profiles intentionally rather than
+assuming `--all-features` selects the desired protocol. Keep real provider smoke tests explicit and
+separate from deterministic CI; they require credentials and incur inference cost.
+
+## 14. Evaluation before performance claims
+
+Use a small fixed task suite with pinned starting trees: local bug fix, cross-file Rust change,
+rename/refactor, configuration/docs change, unsupported-language change, graph-disabled task,
+and recovery from stale context. Include independent review and resulting tests, not only whether
+the agent invoked submit. Use repeated attempts and report quality and variance alongside cost.
+
+Separate these comparisons:
+
+| Variant | What it isolates |
+| --- | --- |
+| External Executor with Ferrus graph over MCP | Practical current baseline |
+| Nano with the same graph requests/context formatting through a test MCP adapter | Harness behavior while retaining transport |
+| Nano with equivalent native graph requests/context formatting | Transport contribution, compared with the previous row |
+| Nano with native working-set/context policy | Retrieval/context contribution, compared with the previous row |
+| Nano with graph disabled | Whether the graph contributes on the chosen tasks |
+
+Keep model/version/settings, tools, task, checks, permissions, and initial repository state as
+similar as each experiment permits. External integrations may differ in hidden prompts, model
+availability, caching, or billing; disclose those differences and do not attribute the entire
+delta to MCP. Run cold and warm index/cache cases and include indexing/refresh cost.
+
+Record success/review acceptance, review cycles, input/output and cached tokens, provider cost
+when available, model turns, tool calls, duplicate source bytes, graph/fallback usage, stale
+evidence events, context assembly time, refresh time, tool latency, total time, and peak memory.
+Report latency distributions and sample counts rather than a single fastest run.
+
+There is no defensible percentage improvement yet. A useful first result is comparable task
+quality with demonstrably lower token use or elapsed time on a stated workload, without weaker
+checks or relaxed workspace rules. Keep the native context policy independently disableable so
+the claimed benefit remains testable.
+
+## 15. Reference designs
+
+Read on 2026-09-06. These are sources for design ideas, not dependencies or copied implementations.
+
+| Project | Observed idea to reuse | Keep outside nano MVP |
+| --- | --- | --- |
+| [Pi agent core](https://github.com/earendil-works/pi/blob/9767ba275f3e9a5ee0f5c5342249b629ab1b2282/packages/agent/README.md) | Separate stored agent messages from the model projection; stream session/tool events | Broad extension/package system and runtime customization surface |
+| [Codex session protocol](https://github.com/openai/codex/blob/ac192cd7937b0d73edc6dffe009940ae53782dd4/codex-rs/protocol/src/protocol.rs) | Submission and event queues decouple clients from agent execution | Reproducing the full application protocol and product feature set |
+| [Goose state-machine module](https://github.com/aaif-goose/goose/blob/5e90925962f05acf8e255032de44d16c4a7768a2/crates/goose/src/agents/state_machine/mod.rs) | Explicit operations/effects over persisted conversation state; the inspected module has a runtime environment flag | A general-purpose configurable operation pipeline |
+| [Grok Build layout](https://github.com/xai-org/grok-build/blob/72a61251fcffb464bcc687aeb5a998e5a98ec0c9/README.md#repository-layout) | Separate runtime, tools, workspace, and frontend composition | Its large crate hierarchy and TUI scope |
+
+## 16. Decisions still open
+
+- First production provider/model and its credential configuration. The engine contract can be
+  designed now; select and test the wire adapter before claiming N1 complete.
+- Concrete token/time/output defaults, calibrated with the task suite rather than guessed savings.
+- Which platform gets the first enforced command sandbox after the trusted-local MVP.
+- Whether standalone first ships a shared terminal UI or a headless executable before that UI.
+
+The proposed defaults are fixed native Ferrus tools, one production provider, a sequential engine,
+local session journals, optional graph acceleration with explicit fallbacks, and the existing
+Ferrus lifecycle as the authority.

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -3,7 +3,7 @@
 This document tracks the current direction for `ferrus` and the status of the
 major roadmap areas. It is not a date-based roadmap.
 
-Last reviewed against the repository: 2026-07-05.
+Last reviewed against the repository: 2026-09-07.
 
 ## Guiding principles
 
@@ -18,13 +18,14 @@ Last reviewed against the repository: 2026-07-05.
 | Area | Status | Notes |
 |---|---|---|
 | Windows support | Mostly implemented | Windows platform hooks, shell execution, installer, Windows CI, and smoke tests exist. Real agent-loop validation and support-policy docs still need tightening. |
-| Storage layer and SQLite backend | Done | SQLite is the runtime source of truth for tasks, runs, events, leases, counters, selected spec state, and recovery. Markdown remains scoped human-readable artifacts. |
+| Storage layer and SQLite backend | Done | Versioned SQLite migrations, tasks, runs, events, leases, counters, selected spec state, and recovery. Markdown remains scoped human-readable artifacts. |
 | Event log and observability | Baseline done | Runtime events, task/run/event CLI views, HQ dashboard panels, and recovery inspection are implemented. Replay/export and richer historical views remain future work. |
-| Pluggable agent adapters | Partially done | Shared `SupervisorAgent`/`ExecutorAgent` traits and adapters for Codex, Claude Code, Qwen Code, goose, and opencode exist. Capability contracts and native ferrus agents remain future work. |
-| Multi-agent flow | Partially done | `/run`, queued tasks, `max_parallel_tasks`, per-task leases, worktree isolation, independent review, patch application, and integration-error reporting exist. Full task graph, decomposition contracts, and final integration policy remain open. |
-| Spec closure and project memory | Baseline done | `/archive-spec` summarizes completed spec work into a durable `## Outcome` section and moves raw task/run artifacts into the machine-local project archive. `/spec` offers this archive step first when the selected spec is already complete. |
-| Repository graph and indexed context | Not started | No reusable repository index or query API exists yet. |
-| Ferrus nano-agent | Not started | Local-model-friendly external adapters exist, but no ferrus-native lightweight agent runtime exists yet. |
+| Pluggable agent adapters | Partially done | Shared `SupervisorAgent`/`ExecutorAgent` traits and adapters for Codex, Claude Code, Qwen Code, goose, and opencode exist. Explicit capability contracts and runnable native agents remain future work. |
+| Multi-agent flow | Partially done | `/run`, queued tasks, `max_parallel_tasks`, per-task leases, worktree isolation, independent review, frozen submissions, three-way integration with rollback, and integration-error reporting exist. Full task graph, decomposition contracts, and final integration policy remain open. |
+| Spec closure and project memory | Local baseline implemented | Outcome archival, curated memory indexing, revision-pinned queries, and evidence-backed repository links exist. Raw runtime bodies are excluded from default ingestion. |
+| Repository graph and indexed context | Local baseline implemented | Optional SQLite sidecar, incremental extraction, bounded CLI/MCP retrieval, task overlays, and frozen review views. Rust/Cargo and generic file structure are supported. |
+| Distributed context data plane | Prototype implemented | Opt-in contracts and local prototype adapters for authorized jobs, encrypted storage, publication, queries, and maintenance. No deployed remote service is implied. |
+| Ferrus nano-agent | Foundation implemented; runtime planned | #73 adds native managed-session binding and claim/status/heartbeat. Provider, engine, HQ launch, interactive UI, and standalone delivery remain later slices. |
 
 ## Milestone 1: Windows Support
 
@@ -62,39 +63,54 @@ What is implemented:
 - `.ferrus/tasks/<task-id>.md` and `.ferrus/runs/<task-id>/` are scoped human-readable artifacts, not the runtime state machine;
 - `ferrus init`, `migrate`, `doctor`, `recover`, `projects list`, `tasks list`, `runs list`, and `events list` operate on the SQLite-backed runtime;
 - MCP tools resolve scoped runtime task context from SQLite and update task rows transactionally;
-- legacy `STATE.json` is only an import source for migration and is removed by migration paths.
+- legacy `STATE.json` is only an import source for migration and is removed by migration paths;
+- ordered SQLite schema migrations record their history and validate the current schema version.
 
 What remains:
 
-- schema versioning and migrations should become explicit before the database grows much further;
 - richer event querying, export, and replay remain future observability work.
 
 ## Milestone 3: Repository Graph and Indexed Context
 
-Status: not started.
+Status: local baseline implemented; broader language coverage and operational evaluation continue.
 
-Goal: build a repository graph during initialization and keep it available as reusable structured context
-so agents can navigate the codebase faster and spend fewer tokens rediscovering the same information.
+Goal: reuse structured repository context through bounded queries, with explicit identity and
+freshness, while keeping source files and Git authoritative.
 
-What the repository graph should eventually capture:
+What is implemented:
 
-- file and module structure;
-- symbols and their relationships where available;
-- dependency edges between components;
-- documentation and configuration entry points;
-- a compact representation that can be queried incrementally rather than regenerated from scratch every run.
+- backend-neutral graph contracts and a rebuildable `repo-graph.db` sidecar independent of `ferrus.db`;
+- incremental indexing with Rust, Cargo, and generic file/document/configuration extraction;
+- CLI index/status/show/neighbors/search/context commands and read-only MCP retrieval tools;
+- bounded responses and pagination, evidence-backed relationships, and hash-verified snippets;
+- task baseline plus changed-file overlays, refresh after checks, and frozen submission/review views;
+- scoped refresh leases, retention, recovery, and best-effort refresh after canonical integration;
+- local retrieval fixtures and performance/evaluation tooling.
 
-Open architectural direction:
+What remains:
 
-- add a stable indexing abstraction first, then decide whether the initial backend is SQLite tables, a sidecar file index, or a hybrid;
-- expose context through Ferrus MCP resources/tools instead of embedding index-specific behavior in agent prompts;
-- keep the index optional and rebuildable so `ferrus init` remains lightweight.
+- expand language-specific extraction and cross-file resolution beyond Rust/Cargo;
+- broaden task-level quality and token/cost evaluation on realistic repositories;
+- consume graph and memory APIs natively from nano in #78, then add working-set policy in #81;
+- keep graph failures independent of task lifecycle, and retain explicit fallback when context is unavailable.
 
-Definition of done:
+See [graph architecture](repository-graph-architecture.md),
+[retrieval](repository-graph-retrieval.md), and [evaluations](repository-graph-evaluations.md).
+Missing graph relationships remain unknown, not proof that no relationship exists.
 
-- `ferrus init` or a follow-up indexing command can build repository context ahead of agent execution;
-- agents can query this context instead of rescanning the entire repo by default;
-- context retrieval is cheap enough to improve both token efficiency and practical task throughput.
+### Distributed context data plane
+
+Status: optional prototype implemented under `src/distributed/`.
+
+The prototype includes scoped identity and authorization, source packaging, encrypted object/fact
+storage, durable coordinator leases and retries, bounded workers, atomic publication, pinned query
+APIs, and resumable maintenance. Repository and memory revisions remain independent. Local HQ,
+indexing, and retrieval do not initialize cloud clients or implicitly upload source.
+
+Production network/storage adapters, deployment, credentials, enforced worker isolation, and
+operational validation remain separate work. The prototype's secure worker requirements are a
+contract for such adapters, not evidence of a deployed sandbox or cloud service.
+See [distributed contracts](distributed-indexing-architecture.md).
 
 ## Milestone 4: Multi-Agent Flow
 
@@ -113,8 +129,10 @@ What is implemented:
 - HQ schedules pending/executing/addressing tasks up to `limits.max_parallel_tasks`;
 - each task has its own lease, run records, scoped artifacts, and check logs;
 - executor sessions run in managed git worktrees under the project runtime directory;
-- submissions preserve `PATCH.diff`, review context exposes that patch, and approval applies it to the canonical checkout;
-- failed patch application or post-approve checks create scoped `INTEGRATION_ERROR.md`, update SQLite failure state, and are surfaced to review.
+- submissions preserve `PATCH.diff`, a reachable immutable Git tree, and best-effort frozen graph context;
+- approval integrates baseline, current canonical tree, and frozen submitted tree using three-way merge semantics;
+- conflicts and failed integration checks produce scoped `INTEGRATION_ERROR.md`; rollback restores the captured canonical tree;
+- Executor respawns are bounded per work phase by `max_executor_dispatches`.
 
 What remains:
 
@@ -132,30 +150,44 @@ Definition of done:
 
 ## Milestone 5: Ferrus Nano-Agent
 
-Status: not started.
+Status: native session foundation implemented (#73); the runnable harness is not available yet.
 
-Goal: add lightweight ferrus-native agents that `ferrus` can manage directly,
-using local or remote LLMs without depending only on external coding agents.
+Goal: build `ferrus-nano` (backend `nano`) as a minimal Rust coding-agent harness. Start with a
+headless managed Executor, using Ferrus operations, repository graph, and project memory through
+direct Rust calls. Use neva for external MCP extensions. Keep the engine independent of the UI
+so interactive HQ, standalone delivery, and additional roles can follow.
 
-What exists today:
+The accepted layout adds `src/nano/`. Existing project, checks, graph/memory adapters, and MCP
+tool files retain their responsibilities. Extract small typed helpers in place where needed;
+add `src/shared/` only for implementations actually shared by HQ and nano. No broad reorganization
+or mandatory library migration is part of this track.
 
-- the agent layer is already trait-based (`SupervisorAgent` and `ExecutorAgent`);
-- multiple external backends are supported, including local-model-friendly goose and opencode adapters;
-- goose can be useful with local providers, but it is still an external agent backend, not a ferrus-native nano-agent runtime;
-- opencode is currently reliable for supervisor/reviewer use only, not isolated executor workflows.
+Implemented foundation:
 
-What remains:
+- host-owned project/agent/task/run/workspace/baseline binding from launch data and registered runtime state;
+- native typed claim, status, and heartbeat, with exact run validation at transaction boundaries;
+- regression coverage for invalid bindings, lease ownership, existing claims, and MCP parity.
 
-- define a minimal ferrus-native agent runtime;
-- support local and remote model providers behind a clear provider interface;
-- define a capability model for what nano-agents can read, edit, check, or submit;
-- add evaluation and quality gates for small or specialized tasks;
-- integrate nano-agents as first-class orchestration participants without weakening the existing external-agent loop.
+Delivery is tracked in [Ferrus nano-agents](https://github.com/ferrus-dev/ferrus/milestone/6).
+The [architecture and complete PR index](ferrus-nano-architecture.md#planned-prs-and-github-issues)
+contains one issue per planned PR, dependencies, and acceptance criteria:
 
-Definition of done:
+| Stage | Issues | Remaining scope |
+| --- | --- | --- |
+| N0/N1: headless Executor | #74-#80 | Engine/journal, first streaming provider, coding tools, command sessions, native context, lifecycle operations, and HQ launch/events |
+| N2: context efficiency | #81-#82 | Working-set invalidation, budgets, and compaction |
+| N3: reliability and extensions | #83-#85 | External MCP via neva, resume/reconciliation, comparative evaluation, and headless release gates |
+| N4/N5: interactive and standalone | #86-#88 | HQ interaction, standalone host/binary, and shared UI |
+| N5: additional roles | #89-#90 | Supervisor planning/spec/archive, Reviewer, and Consultant |
 
-- `ferrus` can launch its own mini-agents as first-class orchestration participants;
-- there is at least one practical workflow where nano-agents improve cost, speed, or quality.
+Definition of done for the first headless release:
+
+- HQ can launch nano as an Executor, with existing checks, submit, review, lease, and workspace rules;
+- graph-disabled, stale-context, cancellation, and recovery cases have explicit behavior;
+- a fixed task suite measures quality, token use, cost, and elapsed time against external integrations.
+
+Lower cost, higher determinism, and better throughput are hypotheses until evaluated. Interactive
+and standalone delivery remain planned extensions, not requirements to ship the headless Executor.
 
 ## Supporting Tracks
 
@@ -186,8 +218,8 @@ can safely run as executor, reviewer, consultant, or nano-agent provider.
 Status: partially implemented.
 
 Spec milestones already provide a coarse decomposition model, and `/run` can turn ready milestones
-into queued tasks. Approval applies each accepted patch into the canonical checkout and records
-recoverable integration errors.
+into queued tasks. Approval merges each frozen submission into the current canonical tree and
+records recoverable integration errors, preserving unrelated canonical changes.
 
 Future work should define decomposition and integration as first-class policies, not just scheduler behavior:
 task contracts, file ownership hints, dependency edges, conflict routing, merge ordering, and how a supervisor
@@ -195,62 +227,38 @@ should re-plan when one parallel branch fails.
 
 ### Spec closure and project memory
 
-Status: not started.
+Status: local baseline implemented.
 
-Completed specs should leave behind compact project memory instead of forcing future agents to read every raw
-task and run artifact. The HQ command is `/archive-spec`.
+`/archive-spec` requires completed work, uses Supervisor spec-closure mode to prepare an approved
+`## Outcome`, and archives scoped task/run artifacts into machine-local project history. SQLite
+retains task/run provenance; the tracked spec retains the compact outcome. `/spec` offers archival
+before switching away from a completed selected spec.
 
-Implemented baseline:
-
-- require that the selected spec has no non-terminal tasks and all intended milestones are complete;
-- launch the Supervisor in a spec-closure mode that reviews related task descriptions, submissions, reviews,
-  integration errors, and check evidence;
-- append or update a `## Outcome` section in the spec with concise implementation notes, deviations from the
-  original spec, validation evidence, follow-up work, and useful context for future agents;
-- move raw task and run artifacts for that spec out of the checkout after user confirmation;
-- store archive metadata in SQLite so task/run history remains queryable even after files move.
-
-The archive should default to a machine-local directory tree, not a compressed file:
-
-```text
-~/.ferrus/projects/<project-id>/archive/specs/<spec-slug>-<closed-at>/
-  manifest.toml
-  spec.md
-  tasks/
-    <task-id>.md
-  runs/
-    <task-id>/
-      SUBMISSION.md
-      REVIEW.md
-      PATCH.diff
-      INTEGRATION_ERROR.md
-```
-
-This is portable across Windows, macOS, and Linux, easy to inspect by hand, and avoids depending on platform
-archive tools. Compression can be added later as an optional export format, with `.zip` as the most portable
-human-facing option if a single file is needed.
-
-By default, raw artifacts should move to `~/.ferrus/projects/<project-id>/archive/...` rather than stay under
-the repository's `.ferrus/` directory. The repository should keep the spec and its `## Outcome` memory, while
-machine-local runtime history keeps detailed forensic artifacts. A future option can support keeping archives
-inside the repository for teams that explicitly want to version task/run history.
+The independent `project-memory.db` sidecar indexes tracked specification structure, approved
+Outcomes, sanitized archive metadata, and read-only terminal runtime provenance. Default adapters
+exclude raw submissions, reviews, patches, logs, questions, answers, and consultations. Repository
+cross-links identify exact memory revision and graph snapshot pairs; similarity is not authority.
+CLI and MCP support memory and federated retrieval with independent freshness reporting. Memory
+refresh after archival is best-effort and cannot turn a completed archive into a failure.
 
 Remaining work:
 
-- add richer archive inspection commands;
-- support optional single-file export, most likely `.zip`;
-- decide whether repo-local archives should be a configurable team workflow;
-- connect `## Outcome` and archive manifests to the future repository context index.
+- richer archive inspection and optional portable export;
+- wider evaluation of retrieval quality and stale/unresolved cross-links;
+- native context consumption in nano (#78).
+
+See [project memory](project-memory.md), [architecture](project-memory-architecture.md), and
+[evaluations](project-memory-evaluations.md).
 
 ## Proposed order
 
-1. Close the Windows support gap: real agent-loop validation and support documentation.
-2. Add explicit SQLite schema versioning/migrations and richer runtime event queries.
-3. Finish the multi-agent integration policy around task graphs, conflicts, and partial failures.
-4. Build repository graph and indexed context on top of the SQLite/runtime abstractions, including `## Outcome` memory.
-5. Add archive inspection/export polish for `/archive-spec`.
-6. Formalize backend capability metadata for external agents.
-7. Design and prototype ferrus-native nano-agents.
+1. Complete the nano headless Executor sequence (#73-#85), then evaluate it before performance claims.
+2. Continue graph language coverage and repository/memory retrieval quality work alongside that sequence.
+3. Close real Windows agent-loop validation and support-documentation gaps.
+4. Define task dependency, decomposition, conflict-routing, and partial-failure policies beyond current milestone scheduling.
+5. Improve runtime history, archive inspection/export, and explicit external-backend capability metadata.
+6. Add nano interaction and standalone delivery (#86-#88), then additional roles (#89-#90).
+7. Evolve the distributed prototype only through explicit deployment and security/operational acceptance gates.
 
 ## Non-goals for now
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,9 @@ mod cli;
 mod config;
 mod hq;
 mod legacy_state;
+// Native session entry points are wired into the HQ launcher in nano PR 08 (#80).
+#[allow(dead_code)]
+mod nano;
 mod platform;
 mod project;
 mod project_memory_runtime;

--- a/src/nano/ferrus.rs
+++ b/src/nano/ferrus.rs
@@ -1,0 +1,168 @@
+//! Managed Ferrus host: capture launch authority once, then call typed operations.
+//! Model tool arguments must never supply project, agent, task, run, or workspace identity.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, ensure};
+
+use crate::{
+    agent_id::{ENV_AGENT_ID, ENV_BASELINE_TREE, ENV_PROJECT_ROOT, ENV_RUN_ID, ENV_TASK_ID},
+    config::Config,
+    project::{self, ExecutorSessionScope, LeaseRenewal, ReadyTaskClaim, RuntimeTaskContext},
+};
+
+/// Trusted HQ launch input, deliberately not serializable as a model tool schema.
+#[derive(Debug, Clone)]
+pub(crate) struct LaunchContext {
+    pub project_root: PathBuf,
+    pub workspace: PathBuf,
+    pub agent_id: String,
+    pub task_id: String,
+    pub run_id: String,
+    pub baseline_tree: Option<String>,
+}
+
+impl LaunchContext {
+    pub(crate) fn from_env() -> Result<Self> {
+        Self::capture(|key| std::env::var(key).ok(), std::env::current_dir()?)
+    }
+
+    fn capture(get: impl Fn(&str) -> Option<String>, workspace: PathBuf) -> Result<Self> {
+        let required = |key| {
+            get(key)
+                .filter(|value| !value.trim().is_empty())
+                .with_context(|| format!("Missing managed launch context: {key}"))
+        };
+        let baseline_tree = get(ENV_BASELINE_TREE);
+        ensure!(
+            baseline_tree
+                .as_ref()
+                .is_none_or(|value| !value.trim().is_empty()),
+            "Empty managed baseline tree"
+        );
+        Ok(Self {
+            project_root: PathBuf::from(required(ENV_PROJECT_ROOT)?),
+            workspace,
+            agent_id: required(ENV_AGENT_ID)?,
+            task_id: required(ENV_TASK_ID)?,
+            run_id: required(ENV_RUN_ID)?,
+            baseline_tree,
+        })
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct FerrusSession {
+    scope: ExecutorSessionScope,
+    project_id: String,
+    project_root: PathBuf,
+    baseline_tree: Option<String>,
+    baseline_path: PathBuf,
+    ttl_secs: u64,
+}
+
+impl FerrusSession {
+    pub(crate) async fn bind(launch: LaunchContext) -> Result<Self> {
+        ensure!(
+            !launch.agent_id.trim().is_empty()
+                && !launch.task_id.trim().is_empty()
+                && !launch.run_id.trim().is_empty(),
+            "Missing managed launch identity"
+        );
+        ensure!(
+            launch.project_root.is_absolute() && launch.workspace.is_absolute(),
+            "Managed launch paths must be absolute"
+        );
+        let project_root = tokio::fs::canonicalize(&launch.project_root).await?;
+        let workspace = tokio::fs::canonicalize(&launch.workspace).await?;
+        let registration = project::read_project_registration_at(&project_root).await?;
+        let workspace_registration = project::read_project_registration_at(&workspace).await?;
+        ensure!(
+            registration.metadata.id == workspace_registration.metadata.id
+                && registration.data_dir == workspace_registration.data_dir
+                && tokio::fs::canonicalize(&registration.metadata.workspace_dir).await?
+                    == project_root,
+            "Managed project binding mismatch"
+        );
+        // Task IDs also name baseline metadata files. Accept one normal path component only.
+        ensure!(
+            PathBuf::from(&launch.task_id).components().count() == 1
+                && !matches!(launch.task_id.as_str(), "." | "..")
+                && !launch.task_id.contains(['/', '\\']),
+            "Invalid managed task ID"
+        );
+        let baseline_path = registration
+            .data_dir
+            .join("worktrees/.baseline-trees")
+            .join(format!("{}.txt", launch.task_id));
+        let session = Self {
+            scope: ExecutorSessionScope {
+                database_path: registration.database_path,
+                agent_id: launch.agent_id,
+                task_id: launch.task_id,
+                run_id: launch.run_id,
+                workspace_path: workspace,
+            },
+            project_id: registration.metadata.id,
+            ttl_secs: Config::load_from(&project_root).await?.lease.ttl_secs,
+            project_root,
+            baseline_tree: launch.baseline_tree,
+            baseline_path,
+        };
+        session.status().await?;
+        Ok(session)
+    }
+
+    pub(crate) fn project_id(&self) -> &str {
+        &self.project_id
+    }
+    pub(crate) fn project_root(&self) -> &std::path::Path {
+        &self.project_root
+    }
+    pub(crate) fn baseline_tree(&self) -> Option<&str> {
+        self.baseline_tree.as_deref()
+    }
+
+    /// One nonblocking claim attempt; the future engine owns polling and cancellation.
+    pub(crate) async fn claim(&self) -> Result<ReadyTaskClaim> {
+        self.validate_baseline().await?;
+        project::claim_executor_session(&self.scope, self.ttl_secs).await
+    }
+
+    pub(crate) async fn status(&self) -> Result<RuntimeTaskContext> {
+        self.validate_baseline().await?;
+        project::executor_session_status(&self.scope).await
+    }
+
+    pub(crate) async fn heartbeat(&self) -> Result<LeaseRenewal> {
+        self.validate_baseline().await?;
+        project::renew_executor_session_lease(&self.scope, self.ttl_secs).await
+    }
+
+    async fn validate_baseline(&self) -> Result<()> {
+        // The Git baseline predates graph support and is stored by HQ separately
+        // from optional snapshot IDs in SQLite. Do not infer one from the other.
+        let recorded = match tokio::fs::read_to_string(&self.baseline_path).await {
+            Ok(value) => Some(value.trim().to_string()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => return Err(error.into()),
+        };
+        ensure!(
+            recorded.as_ref().is_none_or(|value| !value.is_empty())
+                && recorded == self.baseline_tree,
+            "Managed baseline binding mismatch"
+        );
+        // HQ only omits the baseline for a non-Git canonical workspace.
+        ensure!(
+            self.baseline_tree.is_some()
+                || (self.scope.workspace_path == self.project_root
+                    && !tokio::fs::try_exists(self.project_root.join(".git")).await?),
+            "Managed Git workspace requires a baseline tree"
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[path = "tests.rs"]
+mod tests;

--- a/src/nano/mod.rs
+++ b/src/nano/mod.rs
@@ -1,0 +1,4 @@
+//! Native coding-agent harness. The first slice binds a managed Executor session;
+//! engine, provider, and frontend composition are added independently.
+
+pub(crate) mod ferrus;

--- a/src/nano/tests.rs
+++ b/src/nano/tests.rs
@@ -1,0 +1,524 @@
+//! Managed authority failures must not change tasks, leases, runs, or events.
+
+use super::*;
+use crate::project::{LocalProjectRef, ProjectMetadata, TaskStatus};
+use rusqlite::Connection;
+use serde_json::Value;
+use tempfile::TempDir;
+
+const AGENT: &str = "executor:nano:1";
+const TASK: &str = "t-001";
+const RUN: &str = "nano-run-001";
+
+struct Fixture {
+    _dir: TempDir,
+    previous: PathBuf,
+    root: PathBuf,
+    data: PathBuf,
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        std::env::set_current_dir(&self.previous).unwrap();
+    }
+}
+
+impl Fixture {
+    async fn new() -> Self {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        let data = root.join(".ferrus/projects/test-project");
+        std::fs::create_dir_all(&data).unwrap();
+        std::fs::create_dir_all(root.join(".ferrus/tasks")).unwrap();
+        let fixture = Self {
+            previous: std::env::current_dir().unwrap(),
+            _dir: dir,
+            root,
+            data,
+        };
+        std::env::set_current_dir(&fixture.root).unwrap();
+        let local_ref = LocalProjectRef {
+            project_id: "test-project".into(),
+            name: "test".into(),
+            data_dir: fixture.data.to_string_lossy().into_owned(),
+        };
+        std::fs::write(".ferrus/project.toml", toml::to_string(&local_ref).unwrap()).unwrap();
+        let metadata = ProjectMetadata {
+            id: local_ref.project_id,
+            name: local_ref.name,
+            workspace_dir: fixture.root.to_string_lossy().into_owned(),
+            ferrus_dir: fixture.root.join(".ferrus").to_string_lossy().into_owned(),
+            vcs: None,
+            origin_repo: None,
+            default_branch: None,
+            current_head: None,
+            created_at: "2026-09-07T00:00:00Z".into(),
+            last_opened_at: "2026-09-07T00:00:00Z".into(),
+            version: 1,
+        };
+        std::fs::write(
+            fixture.data.join("project.toml"),
+            toml::to_string(&metadata).unwrap(),
+        )
+        .unwrap();
+        std::fs::write(
+            "ferrus.toml",
+            "[checks]\ncommands = []\n[limits]\nmax_check_retries = 20\nmax_review_cycles = 3\nmax_feedback_lines = 30\nwait_timeout_secs = 1\n[lease]\nttl_secs = 60\n",
+        )
+        .unwrap();
+        std::fs::write(".ferrus/tasks/t-001.md", "Implement the fixture task.\n").unwrap();
+        project::record_task_status(TASK, ".ferrus/tasks/t-001.md", TaskStatus::Pending)
+            .await
+            .unwrap();
+        project::record_run_started_for_task_with_workspace(
+            RUN,
+            "executor",
+            AGENT,
+            std::process::id(),
+            Some(TASK),
+            fixture.root.to_string_lossy().into_owned(),
+        )
+        .await
+        .unwrap();
+        fixture
+    }
+
+    fn launch(&self) -> LaunchContext {
+        LaunchContext {
+            project_root: self.root.clone(),
+            workspace: self.root.clone(),
+            agent_id: AGENT.into(),
+            task_id: TASK.into(),
+            run_id: RUN.into(),
+            baseline_tree: None,
+        }
+    }
+
+    fn connection(&self) -> Connection {
+        Connection::open(self.data.join("ferrus.db")).unwrap()
+    }
+
+    fn events(&self) -> Vec<(String, Value)> {
+        let connection = self.connection();
+        connection
+            .prepare("SELECT type, payload_json FROM events ORDER BY id")
+            .unwrap()
+            .query_map([], |row| Ok((row.get(0)?, row.get::<_, String>(1)?)))
+            .unwrap()
+            .map(|row| {
+                let (kind, body) = row.unwrap();
+                (kind, serde_json::from_str(&body).unwrap())
+            })
+            .collect()
+    }
+
+    async fn assert_no_effect(
+        &self,
+        tasks: Vec<project::TaskRecord>,
+        events: Vec<(String, Value)>,
+    ) {
+        assert_eq!(project::list_tasks().await.unwrap(), tasks);
+        assert_eq!(self.events(), events);
+        crate::test_support::assert_no_state_json();
+    }
+}
+
+#[test]
+fn launch_capture_requires_host_identity() {
+    let env = [
+        (ENV_PROJECT_ROOT, "/project"),
+        (ENV_AGENT_ID, AGENT),
+        (ENV_TASK_ID, TASK),
+        (ENV_RUN_ID, RUN),
+    ];
+    for missing in [ENV_PROJECT_ROOT, ENV_AGENT_ID, ENV_TASK_ID, ENV_RUN_ID] {
+        let result = LaunchContext::capture(
+            |key| {
+                env.iter()
+                    .find(|(name, _)| *name == key && key != missing)
+                    .map(|(_, value)| value.to_string())
+            },
+            PathBuf::from("/workspace"),
+        );
+        assert!(result.unwrap_err().to_string().contains(missing));
+    }
+    let context = LaunchContext::capture(
+        |key| {
+            env.iter()
+                .find(|(name, _)| *name == key)
+                .map(|(_, value)| value.to_string())
+        },
+        PathBuf::from("/workspace"),
+    )
+    .unwrap();
+    assert_eq!(context.run_id, RUN);
+    assert!(context.baseline_tree.is_none());
+}
+
+#[tokio::test]
+async fn native_claim_status_and_heartbeat_match_mcp() {
+    let _guard = crate::test_support::cwd_lock().lock().unwrap();
+    let fixture = Fixture::new().await;
+    let events = fixture.events();
+    let session = FerrusSession::bind(fixture.launch()).await.unwrap();
+    assert_eq!(fixture.events(), events, "binding must be read-only");
+    assert_eq!(session.project_id(), "test-project");
+    assert_eq!(session.project_root(), fixture.root);
+    assert_eq!(session.baseline_tree(), None);
+    assert!(matches!(
+        session.claim().await.unwrap(),
+        ReadyTaskClaim::Claimed(_)
+    ));
+    let existing = match session.claim().await.unwrap() {
+        ReadyTaskClaim::AlreadyClaimed(lease) => lease,
+        other => panic!("expected existing claim: {other:?}"),
+    };
+    let mcp: Value = serde_json::from_str(
+        &crate::server::tools::wait_for_task::handler_for_agent(AGENT)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(mcp["task_id"], existing.task_id);
+    assert_eq!(mcp["task_path"], existing.task_path);
+    assert_eq!(mcp["claimed_by"], existing.claimed_by);
+    assert_eq!(
+        mcp["lease_until"],
+        serde_json::to_value(existing.lease_until).unwrap()
+    );
+    assert_eq!(mcp["state"], "Executing");
+    let events = fixture.events();
+    let status = session.status().await.unwrap();
+    let mcp = crate::server::tools::status::handler_for_agent(AGENT)
+        .await
+        .unwrap();
+    for line in [
+        format!("**Task:** {}", status.task_id),
+        format!("**State:** {}", status.status),
+        format!("**Run:** {}", status.run_id.unwrap()),
+        format!("**Workspace:** {}", status.workspace_path.unwrap()),
+        format!("**Run dir:** {}", status.run_dir),
+    ] {
+        assert!(mcp.contains(&line), "{line}");
+    }
+    assert_eq!(fixture.events(), events);
+    assert!(
+        matches!(session.heartbeat().await.unwrap(), LeaseRenewal::Renewed { task_id, .. } if task_id == TASK)
+    );
+    let mcp: Value = serde_json::from_str(
+        &crate::server::tools::heartbeat::handler_for_agent(AGENT)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(mcp["status"], "renewed");
+    assert_eq!(mcp["task_id"], TASK);
+    let events = fixture.events();
+    assert_eq!(
+        events
+            .iter()
+            .filter(|(kind, _)| kind == "task_claimed")
+            .count(),
+        1
+    );
+    let renewals: Vec<_> = events
+        .iter()
+        .filter(|(kind, _)| kind == "task_lease_renewed")
+        .collect();
+    assert_eq!(renewals.len(), 2);
+    for (_, payload) in renewals {
+        assert_eq!(payload["task_id"], TASK);
+        assert_eq!(payload["claimed_by"], AGENT);
+    }
+    crate::test_support::assert_no_state_json();
+}
+
+#[tokio::test]
+async fn binding_rejects_missing_or_mismatched_context_without_effects() {
+    let _guard = crate::test_support::cwd_lock().lock().unwrap();
+    let fixture = Fixture::new().await;
+    let tasks = project::list_tasks().await.unwrap();
+    let events = fixture.events();
+    for field in ["agent", "task", "run", "workspace", "project", "baseline"] {
+        let mut launch = fixture.launch();
+        match field {
+            "agent" => launch.agent_id = "executor:nano:2".into(),
+            "task" => launch.task_id = "t-other".into(),
+            "run" => launch.run_id = "missing-run".into(),
+            "workspace" => {
+                let other = fixture.root.join("other");
+                std::fs::create_dir_all(other.join(".ferrus")).unwrap();
+                std::fs::copy(
+                    fixture.root.join(".ferrus/project.toml"),
+                    other.join(".ferrus/project.toml"),
+                )
+                .unwrap();
+                launch.workspace = other;
+            }
+            "project" => launch.project_root = fixture.data.clone(),
+            "baseline" => launch.baseline_tree = Some("unrecorded-tree".into()),
+            _ => unreachable!(),
+        }
+        assert!(FerrusSession::bind(launch).await.is_err(), "{field}");
+    }
+    fixture.assert_no_effect(tasks, events).await;
+}
+
+#[tokio::test]
+async fn every_operation_revalidates_the_bound_run() {
+    let _guard = crate::test_support::cwd_lock().lock().unwrap();
+    let fixture = Fixture::new().await;
+    let session = FerrusSession::bind(fixture.launch()).await.unwrap();
+    session.claim().await.unwrap();
+    project::record_task_status(
+        "other-task",
+        ".ferrus/tasks/other-task.md",
+        TaskStatus::Pending,
+    )
+    .await
+    .unwrap();
+    let tasks = project::list_tasks().await.unwrap();
+    let events = fixture.events();
+    for (column, value, original) in [
+        ("role", "supervisor", "executor"),
+        ("agent", "executor:nano:2", AGENT),
+        ("task_id", "other-task", TASK),
+        ("status", "exited", "running"),
+        (
+            "workspace_path",
+            fixture.data.to_str().unwrap(),
+            fixture.root.to_str().unwrap(),
+        ),
+    ] {
+        // Only fixed fixture column names are interpolated; values remain bound parameters.
+        let sql = format!("UPDATE runs SET {column} = ?1 WHERE id = ?2");
+        fixture.connection().execute(&sql, [value, RUN]).unwrap();
+        assert!(session.claim().await.is_err(), "claim: {column}");
+        assert!(session.heartbeat().await.is_err(), "heartbeat: {column}");
+        assert!(session.status().await.is_err(), "status: {column}");
+        assert!(
+            FerrusSession::bind(fixture.launch()).await.is_err(),
+            "bind: {column}"
+        );
+        fixture.connection().execute(&sql, [original, RUN]).unwrap();
+    }
+    fixture.assert_no_effect(tasks, events).await;
+}
+
+#[tokio::test]
+async fn worktree_binding_uses_explicit_paths_and_requires_its_baseline() {
+    let _guard = crate::test_support::cwd_lock().lock().unwrap();
+    let fixture = Fixture::new().await;
+    let workspace = fixture.data.join("worktrees/t-001");
+    std::fs::create_dir_all(workspace.join(".ferrus")).unwrap();
+    std::fs::copy(
+        fixture.root.join(".ferrus/project.toml"),
+        workspace.join(".ferrus/project.toml"),
+    )
+    .unwrap();
+    fixture
+        .connection()
+        .execute(
+            "UPDATE runs SET workspace_path = ?1 WHERE id = ?2",
+            [workspace.to_str().unwrap(), RUN],
+        )
+        .unwrap();
+    let mut launch = fixture.launch();
+    launch.workspace = workspace.clone();
+    assert!(FerrusSession::bind(launch.clone()).await.is_err());
+    let baseline_path = fixture.data.join("worktrees/.baseline-trees/t-001.txt");
+    std::fs::create_dir_all(baseline_path.parent().unwrap()).unwrap();
+    std::fs::write(&baseline_path, "tree-a\n").unwrap();
+    launch.baseline_tree = Some("tree-a".into());
+    // Neither binding nor later effects may depend on ambient project resolution.
+    std::env::set_current_dir(&fixture.data).unwrap();
+    let session = FerrusSession::bind(launch).await.unwrap();
+    assert!(matches!(
+        session.claim().await.unwrap(),
+        ReadyTaskClaim::Claimed(_)
+    ));
+    let context = session.status().await.unwrap();
+    assert_eq!(context.workspace_path.as_deref(), workspace.to_str());
+    assert_eq!(context.task_path, ".ferrus/tasks/t-001.md");
+    assert_eq!(context.run_dir, ".ferrus/runs/t-001");
+    assert!(matches!(
+        session.heartbeat().await.unwrap(),
+        LeaseRenewal::Renewed { .. }
+    ));
+}
+
+#[tokio::test]
+async fn heartbeat_stops_at_handoff_and_claim_accepts_addressing_only_when_ready() {
+    let _guard = crate::test_support::cwd_lock().lock().unwrap();
+    let fixture = Fixture::new().await;
+    let session = FerrusSession::bind(fixture.launch()).await.unwrap();
+    session.claim().await.unwrap();
+    fixture
+        .connection()
+        .execute(
+            "UPDATE tasks SET status = 'reviewing' WHERE id = ?1",
+            [TASK],
+        )
+        .unwrap();
+    let tasks = project::list_tasks().await.unwrap();
+    let events = fixture.events();
+    assert_eq!(session.status().await.unwrap().status, "reviewing");
+    assert!(session.heartbeat().await.is_err());
+    assert!(matches!(
+        session.claim().await.unwrap(),
+        ReadyTaskClaim::NoAvailable
+    ));
+    fixture.assert_no_effect(tasks, events).await;
+    fixture.connection().execute("UPDATE tasks SET status = 'addressing', check_retries = 2, review_cycles = 1 WHERE id = ?1", [TASK]).unwrap();
+    match session.claim().await.unwrap() {
+        ReadyTaskClaim::AlreadyClaimed(lease) => {
+            assert_eq!(lease.status, "addressing");
+            assert_eq!(lease.check_retries, 2);
+            assert_eq!(lease.review_cycles, 1);
+        }
+        other => panic!("unexpected claim: {other:?}"),
+    }
+    assert!(matches!(
+        session.heartbeat().await.unwrap(),
+        LeaseRenewal::Renewed { .. }
+    ));
+}
+
+#[tokio::test]
+async fn native_operations_cannot_take_or_renew_another_agents_live_lease() {
+    let _guard = crate::test_support::cwd_lock().lock().unwrap();
+    let fixture = Fixture::new().await;
+    let session = FerrusSession::bind(fixture.launch()).await.unwrap();
+    project::claim_task(TASK, ".ferrus/tasks/t-001.md", "executor:codex:2", 60)
+        .await
+        .unwrap();
+    let tasks = project::list_tasks().await.unwrap();
+    let events = fixture.events();
+    assert!(matches!(
+        session.claim().await.unwrap(),
+        ReadyTaskClaim::NoAvailable
+    ));
+    assert!(matches!(
+        session.heartbeat().await.unwrap(),
+        LeaseRenewal::NotClaimed
+    ));
+    // The same claim primitive must also leave another owner's pending task untouched.
+    assert!(matches!(
+        project::claim_ready_task_by_id(TASK, AGENT, 60)
+            .await
+            .unwrap(),
+        ReadyTaskClaim::NoAvailable
+    ));
+    fixture.assert_no_effect(tasks, events).await;
+}
+
+#[tokio::test]
+async fn explicit_scope_never_follows_another_task_or_latest_run_for_the_agent() {
+    let _guard = crate::test_support::cwd_lock().lock().unwrap();
+    let fixture = Fixture::new().await;
+    let session = FerrusSession::bind(fixture.launch()).await.unwrap();
+    session.claim().await.unwrap();
+    project::record_task_status("t-002", ".ferrus/tasks/t-002.md", TaskStatus::Executing)
+        .await
+        .unwrap();
+    project::claim_task("t-002", ".ferrus/tasks/t-002.md", AGENT, 3600)
+        .await
+        .unwrap();
+    project::record_run_started_for_task_with_workspace(
+        "later-run",
+        "executor",
+        AGENT,
+        std::process::id(),
+        Some("t-002"),
+        fixture.root.to_string_lossy().into_owned(),
+    )
+    .await
+    .unwrap();
+    let other = project::list_tasks()
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|task| task.id == "t-002")
+        .unwrap();
+    assert_eq!(session.status().await.unwrap().run_id.as_deref(), Some(RUN));
+    assert!(
+        matches!(session.heartbeat().await.unwrap(), LeaseRenewal::Renewed { task_id, .. } if task_id == TASK)
+    );
+    assert_eq!(
+        project::list_tasks()
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|task| task.id == "t-002")
+            .unwrap(),
+        other
+    );
+    fixture
+        .connection()
+        .execute(
+            "UPDATE tasks SET lease_until = '2000-01-01T00:00:00Z' WHERE id = ?1",
+            [TASK],
+        )
+        .unwrap();
+    let events = fixture.events();
+    assert!(matches!(
+        session.heartbeat().await.unwrap(),
+        LeaseRenewal::Expired
+    ));
+    assert_eq!(fixture.events(), events);
+    assert!(matches!(
+        session.claim().await.unwrap(),
+        ReadyTaskClaim::Claimed(_)
+    ));
+}
+
+#[tokio::test]
+async fn baseline_is_bound_independently_of_optional_graph_state() {
+    let _guard = crate::test_support::cwd_lock().lock().unwrap();
+    let fixture = Fixture::new().await;
+    let baseline_path = fixture.data.join("worktrees/.baseline-trees/t-001.txt");
+    std::fs::create_dir_all(baseline_path.parent().unwrap()).unwrap();
+    std::fs::write(&baseline_path, "tree-a\n").unwrap();
+    let mut launch = fixture.launch();
+    assert!(FerrusSession::bind(launch.clone()).await.is_err());
+    launch.baseline_tree = Some("tree-a".into());
+    let session = FerrusSession::bind(launch).await.unwrap();
+    assert_eq!(session.baseline_tree(), Some("tree-a"));
+    session.claim().await.unwrap();
+    let tasks = project::list_tasks().await.unwrap();
+    let events = fixture.events();
+    std::fs::write(&baseline_path, "tree-b\n").unwrap();
+    assert!(session.claim().await.is_err());
+    assert!(session.heartbeat().await.is_err());
+    assert!(session.status().await.is_err());
+    fixture.assert_no_effect(tasks, events).await;
+}
+
+#[tokio::test]
+async fn missing_database_is_not_created_and_old_schema_is_not_migrated() {
+    let _guard = crate::test_support::cwd_lock().lock().unwrap();
+    let fixture = Fixture::new().await;
+    let session = FerrusSession::bind(fixture.launch()).await.unwrap();
+    let database = fixture.data.join("ferrus.db");
+    let saved = fixture.data.join("saved.db");
+    std::fs::rename(&database, &saved).unwrap();
+    assert!(session.status().await.is_err());
+    assert!(session.claim().await.is_err());
+    assert!(session.heartbeat().await.is_err());
+    assert!(!database.exists());
+    std::fs::rename(&saved, &database).unwrap();
+    let events = fixture.events();
+    fixture
+        .connection()
+        .pragma_update(None, "user_version", 0)
+        .unwrap();
+    assert!(session.status().await.is_err());
+    assert!(session.claim().await.is_err());
+    assert!(session.heartbeat().await.is_err());
+    let version: u32 = fixture
+        .connection()
+        .pragma_query_value(None, "user_version", |row| row.get(0))
+        .unwrap();
+    assert_eq!(version, 0);
+    assert_eq!(fixture.events(), events);
+}

--- a/src/project/claims.rs
+++ b/src/project/claims.rs
@@ -2,6 +2,189 @@
 
 use super::*;
 
+/// Host-owned authority for one managed Executor run. Never deserialize tool arguments into this.
+#[derive(Debug, Clone)]
+pub(crate) struct ExecutorSessionScope {
+    pub database_path: PathBuf,
+    pub agent_id: String,
+    pub task_id: String,
+    pub run_id: String,
+    pub workspace_path: PathBuf,
+}
+
+pub(crate) async fn claim_executor_session(
+    scope: &ExecutorSessionScope,
+    ttl_secs: u64,
+) -> Result<ReadyTaskClaim> {
+    with_executor_session(scope, true, move |transaction, scope, _| {
+        claim_ready_task_in_transaction(
+            transaction,
+            &scope.task_id,
+            &scope.agent_id,
+            ttl_secs,
+            &[
+                TaskStatus::Pending,
+                TaskStatus::Executing,
+                TaskStatus::Addressing,
+            ],
+            true,
+        )
+    })
+    .await
+}
+
+pub(crate) async fn executor_session_status(
+    scope: &ExecutorSessionScope,
+) -> Result<RuntimeTaskContext> {
+    with_executor_session(scope, false, |_, _, context| Ok(context)).await
+}
+
+pub(crate) async fn renew_executor_session_lease(
+    scope: &ExecutorSessionScope,
+    ttl_secs: u64,
+) -> Result<LeaseRenewal> {
+    with_executor_session(scope, true, move |transaction, scope, _| {
+        let task =
+            task_candidate_by_id(transaction, &scope.task_id)?.context("Bound task is missing")?;
+        if task.claimed_by.as_deref() != Some(&scope.agent_id) {
+            return Ok(LeaseRenewal::NotClaimed);
+        }
+        anyhow::ensure!(
+            matches!(
+                task.status.as_str(),
+                "executing" | "addressing" | "consultation" | "awaiting_human"
+            ),
+            "Bound task is outside the Executor work phase"
+        );
+        let Some(lease_until) = renew_task_lease_in_transaction(
+            transaction,
+            &scope.task_id,
+            &scope.agent_id,
+            ttl_secs,
+            task.lease_until.as_deref(),
+        )?
+        else {
+            return Ok(LeaseRenewal::Expired);
+        };
+        Ok(LeaseRenewal::Renewed {
+            task_id: task.id,
+            task_path: task.path,
+            claimed_by: scope.agent_id.clone(),
+            lease_until,
+        })
+    })
+    .await
+}
+
+// Validate the exact run in the same transaction as its effects. Looking up the
+// latest run or lease by agent alone can silently retarget an old child process.
+async fn with_executor_session<T, F>(
+    scope: &ExecutorSessionScope,
+    write: bool,
+    operation: F,
+) -> Result<T>
+where
+    T: Send + 'static,
+    F: FnOnce(&Transaction<'_>, &ExecutorSessionScope, RuntimeTaskContext) -> Result<T>
+        + Send
+        + 'static,
+{
+    let scope = scope.clone();
+    tokio::task::spawn_blocking(move || {
+        let flags = if write {
+            OpenFlags::SQLITE_OPEN_READ_WRITE
+        } else {
+            OpenFlags::SQLITE_OPEN_READ_ONLY
+        };
+        // HQ owns database preparation. A missing or old database is not a cue
+        // for a child to create state or import legacy runtime artifacts.
+        let mut connection = Connection::open_with_flags(&scope.database_path, flags)?;
+        connection.busy_timeout(Duration::from_secs(5))?;
+        connection.pragma_update(None, "foreign_keys", true)?;
+        let transaction = connection.transaction_with_behavior(if write {
+            TransactionBehavior::Immediate
+        } else {
+            TransactionBehavior::Deferred
+        })?;
+        validate_runtime_migration_history(&transaction)?;
+        anyhow::ensure!(
+            runtime_schema_version(&transaction)? == RUNTIME_SCHEMA_VERSION,
+            "Managed session requires the current runtime schema"
+        );
+        let context = executor_context_in_transaction(&transaction, &scope)?;
+        let result = operation(&transaction, &scope, context)?;
+        transaction.commit()?;
+        Ok(result)
+    })
+    .await?
+}
+
+fn executor_context_in_transaction(
+    transaction: &Transaction<'_>,
+    scope: &ExecutorSessionScope,
+) -> Result<RuntimeTaskContext> {
+    let run = transaction
+        .query_row(
+            "SELECT task_id, agent, role, status, workspace_path FROM runs WHERE id = ?1",
+            [&scope.run_id],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, String>(4)?,
+                ))
+            },
+        )
+        .optional()?
+        .context("Bound run is missing")?;
+    anyhow::ensure!(run.0 == scope.task_id, "Run task binding mismatch");
+    anyhow::ensure!(run.1 == scope.agent_id, "Run agent binding mismatch");
+    anyhow::ensure!(
+        run.2 == crate::agent_id::ROLE_EXECUTOR,
+        "Run role must be executor"
+    );
+    anyhow::ensure!(
+        matches!(run.3.as_str(), "running" | "checking"),
+        "Bound run is no longer active"
+    );
+    anyhow::ensure!(
+        Path::new(&run.4).is_absolute() && std::fs::canonicalize(&run.4)? == scope.workspace_path,
+        "Run workspace binding mismatch"
+    );
+    transaction
+        .query_row(
+            "SELECT path, spec_path, milestone_id, status, paused_status, check_retries,
+                review_cycles, failure_reason, baseline_snapshot_id, overlay_revision_id,
+                repository_view_snapshot_id, repository_view_tree_algorithm,
+                repository_view_tree_digest, repository_view_lifecycle, repository_view_status
+         FROM tasks WHERE id = ?1",
+            [&scope.task_id],
+            |row| {
+                Ok(RuntimeTaskContext {
+                    task_id: scope.task_id.clone(),
+                    task_path: row.get(0)?,
+                    spec_path: row.get(1)?,
+                    milestone_id: row.get(2)?,
+                    status: row.get(3)?,
+                    paused_status: row.get(4)?,
+                    check_retries: row.get::<_, i64>(5)? as u32,
+                    review_cycles: row.get::<_, i64>(6)? as u32,
+                    failure_reason: row.get(7)?,
+                    run_dir: run_dir_for_task(&scope.task_id),
+                    run_id: Some(scope.run_id.clone()),
+                    run_role: Some(run.2.clone()),
+                    workspace_path: Some(run.4.clone()),
+                    repository_workspace_path: Some(run.4.clone()),
+                    repository_view: graph::repository_view_reference_from_row(row, 8)?,
+                })
+            },
+        )
+        .optional()?
+        .context("Bound task is missing")
+}
+
 pub async fn claim_task(
     task_id: &str,
     task_path: &str,
@@ -78,52 +261,52 @@ async fn claim_task_by_id_with_statuses(
     tokio::task::spawn_blocking(move || -> Result<ReadyTaskClaim> {
         let mut connection = open_runtime_database(&database_path)?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
-        let now = Utc::now();
-        let Some(mut candidate) = task_candidate_by_id(&transaction, &task_id)? else {
-            transaction.commit()?;
-            return Ok(ReadyTaskClaim::NoAvailable);
-        };
-
-        if !allowed_statuses
-            .iter()
-            .any(|status| status.as_str() == candidate.status)
-        {
-            transaction.commit()?;
-            return Ok(ReadyTaskClaim::NoAvailable);
-        }
-
-        if promote_pending && candidate.status == TaskStatus::Pending.as_str() {
-            promote_pending_task_in_transaction(&transaction, &mut candidate)?;
-        }
-
-        let lease_until = parse_lease_until(candidate.lease_until.as_deref());
-        let lease_active = lease_until
-            .as_ref()
-            .is_some_and(|lease_until| now < *lease_until);
-        if lease_active && candidate.claimed_by.as_deref() == Some(agent_id.as_str()) {
-            transaction.commit()?;
-            return Ok(ReadyTaskClaim::AlreadyClaimed(TaskLease {
-                task_id: candidate.id,
-                task_path: candidate.path,
-                status: candidate.status,
-                paused_status: candidate.paused_status,
-                check_retries: candidate.check_retries,
-                review_cycles: candidate.review_cycles,
-                failure_reason: candidate.failure_reason,
-                claimed_by: agent_id,
-                lease_until: lease_until.expect("active lease exists"),
-            }));
-        }
-        if lease_active {
-            transaction.commit()?;
-            return Ok(ReadyTaskClaim::NoAvailable);
-        }
-
-        let lease_until =
-            now + chrono::Duration::try_seconds(ttl_secs as i64).unwrap_or(chrono::Duration::MAX);
-        claim_task_in_transaction(&transaction, &candidate.id, &agent_id, lease_until, now)?;
+        let claim = claim_ready_task_in_transaction(
+            &transaction,
+            &task_id,
+            &agent_id,
+            ttl_secs,
+            &allowed_statuses,
+            promote_pending,
+        )?;
         transaction.commit()?;
-        Ok(ReadyTaskClaim::Claimed(TaskLease {
+        Ok(claim)
+    })
+    .await?
+}
+
+fn claim_ready_task_in_transaction(
+    transaction: &Transaction<'_>,
+    task_id: &str,
+    agent_id: &str,
+    ttl_secs: u64,
+    allowed_statuses: &[TaskStatus],
+    promote_pending: bool,
+) -> Result<ReadyTaskClaim> {
+    let now = Utc::now();
+    let Some(mut candidate) = task_candidate_by_id(transaction, task_id)? else {
+        return Ok(ReadyTaskClaim::NoAvailable);
+    };
+
+    if !allowed_statuses
+        .iter()
+        .any(|status| status.as_str() == candidate.status)
+    {
+        return Ok(ReadyTaskClaim::NoAvailable);
+    }
+
+    let lease_until = parse_lease_until(candidate.lease_until.as_deref());
+    let lease_active = lease_until
+        .as_ref()
+        .is_some_and(|lease_until| now < *lease_until);
+    if lease_active && candidate.claimed_by.as_deref() != Some(agent_id) {
+        return Ok(ReadyTaskClaim::NoAvailable);
+    }
+    if promote_pending && candidate.status == TaskStatus::Pending.as_str() {
+        promote_pending_task_in_transaction(transaction, &mut candidate)?;
+    }
+    if lease_active && candidate.claimed_by.as_deref() == Some(agent_id) {
+        return Ok(ReadyTaskClaim::AlreadyClaimed(TaskLease {
             task_id: candidate.id,
             task_path: candidate.path,
             status: candidate.status,
@@ -131,11 +314,24 @@ async fn claim_task_by_id_with_statuses(
             check_retries: candidate.check_retries,
             review_cycles: candidate.review_cycles,
             failure_reason: candidate.failure_reason,
-            claimed_by: agent_id,
-            lease_until,
-        }))
-    })
-    .await?
+            claimed_by: agent_id.to_string(),
+            lease_until: lease_until.expect("active lease exists"),
+        }));
+    }
+    let lease_until =
+        now + chrono::Duration::try_seconds(ttl_secs as i64).unwrap_or(chrono::Duration::MAX);
+    claim_task_in_transaction(transaction, &candidate.id, agent_id, lease_until, now)?;
+    Ok(ReadyTaskClaim::Claimed(TaskLease {
+        task_id: candidate.id,
+        task_path: candidate.path,
+        status: candidate.status,
+        paused_status: candidate.paused_status,
+        check_retries: candidate.check_retries,
+        review_cycles: candidate.review_cycles,
+        failure_reason: candidate.failure_reason,
+        claimed_by: agent_id.to_string(),
+        lease_until,
+    }))
 }
 
 pub async fn claim_next_review_task(agent_id: &str, ttl_secs: u64) -> Result<ReadyTaskClaim> {

--- a/src/project/registry.rs
+++ b/src/project/registry.rs
@@ -317,6 +317,33 @@ pub async fn current_project_id() -> Result<String> {
     Ok(local_ref.project_id)
 }
 
+/// Resolve an explicit checkout without changing cwd or touching runtime state.
+pub(crate) async fn read_project_registration_at(workspace: &Path) -> Result<ProjectRegistration> {
+    let contents = tokio::fs::read_to_string(workspace.join(LOCAL_PROJECT_TOML)).await?;
+    let local_ref: LocalProjectRef = toml::from_str(&contents)?;
+    validate_project_id(&local_ref.project_id)?;
+    anyhow::ensure!(
+        Path::new(&local_ref.data_dir).is_absolute(),
+        "Registered data directory must be absolute"
+    );
+    let data_dir = tokio::fs::canonicalize(&local_ref.data_dir).await?;
+    let metadata = read_project_metadata_from(&data_dir.join("project.toml")).await?;
+    anyhow::ensure!(
+        Path::new(&metadata.workspace_dir).is_absolute(),
+        "Registered workspace must be absolute"
+    );
+    anyhow::ensure!(
+        metadata.id == local_ref.project_id,
+        "Project identity mismatch"
+    );
+    Ok(ProjectRegistration {
+        database_path: data_dir.join("ferrus.db"),
+        local_ref,
+        metadata,
+        data_dir,
+    })
+}
+
 pub async fn create_pending_task_artifact(
     description: &str,
     spec_path: Option<&str>,


### PR DESCRIPTION
## Summary

Add the first native Nano session adapter so a managed Executor can call typed Ferrus claim, status, and heartbeat operations directly. Bind project, agent, task, run, workspace, and baseline from trusted launch context and registered runtime state; validate the exact run inside the transaction that performs lease effects.

Reuse existing project operations and keep new harness code under `src/nano/`. Document the architecture and PR sequence, and update the roadmap to reflect implemented graph, project-memory, migration, and integration capabilities.

Closes #73.

## Type

- [x] Bug fix
- [x] Feature
- [ ] Enhancement
- [ ] Performance
- [x] Documentation
- [ ] Refactor
- [ ] Security
- [ ] Breaking change

## Workflow impact (if applicable)

- [ ] No impact
- [ ] Minor change (does not alter lifecycle semantics)
- [x] Changes behavior of an existing step
- [ ] Introduces new state/transition

The shared claim-by-ID operation now checks another agent's active lease before promoting a pending task to executing. A failed claim therefore leaves that task untouched. Existing lifecycle states, retry counters, scoped artifacts, and MCP response formats are preserved.

Nano receives explicit session-scoped entry points. The inference loop, CLI command, and HQ launcher remain subsequent slices; this PR does not expose a runnable Nano backend.

## Checklist

- [x] I added/updated tests where it makes sense
- [x] I updated docs/examples if needed
- [x] This change is backwards-compatible (or clearly marked as breaking)
- [x] I ran formatting/lints locally (if applicable)

## Notes for reviewers

- Review transaction-scoped run/role/task/workspace validation and lease ownership checks. An older session must never follow another task or the latest run merely because the agent ID matches.
- Git baseline metadata is validated independently of optional graph identities. Managed operations require an existing current-schema database and never create or migrate it.
- HQ must persist the run before the child binds. Launch ordering and removal of the temporary Nano dead-code allowance belong to #80.
- Added 10 tests covering invalid bindings, separate worktrees, existing and foreign claims, expired leases, handoff, baseline changes, missing/old databases, and native/MCP parity.
- Local validation passed: `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test nano::`, and `cargo test` (907 tests: 405 library, 501 binary, 1 integration).
