### PR TITLE
Add bounded Nano session engine and durable journal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,7 +543,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferrus"
-version = "0.4.1-alpha.1"
+version = "0.5.0-alpha.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ windows-sys = { version = "0.61.2", features = ["Wdk_Foundation", "Wdk_Storage_F
 [dev-dependencies]
 criterion = { version = "0.8.2", default-features = false, features = ["cargo_bench_support"] }
 tempfile = "3.27.0"
+tokio = { version = "1.52.3", features = ["test-util"] }
 
 [[bench]]
 name = "repository_graph"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferrus"
-version = "0.4.1-alpha.1"
+version = "0.5.0-alpha.1"
 edition = "2024"
 rust-version = "1.95.0"
 license = "Apache-2.0"
@@ -58,7 +58,7 @@ errno = "0.3.14"
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61.2", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Win32_Foundation", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_Diagnostics_ToolHelp", "Win32_System_IO", "Win32_System_JobObjects", "Win32_System_Threading"] }
+windows-sys = { version = "0.61.2", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_Diagnostics_ToolHelp", "Win32_System_IO", "Win32_System_JobObjects", "Win32_System_Threading"] }
 
 [dev-dependencies]
 criterion = { version = "0.8.2", default-features = false, features = ["cargo_bench_support"] }

--- a/docs/ferrus-nano-architecture.md
+++ b/docs/ferrus-nano-architecture.md
@@ -1,12 +1,12 @@
 # Ferrus Nano: Native Agent Harness
 
-Status: accepted implementation plan, updated 2026-09-07. The #73 session foundation is
-implemented; the engine, provider, launcher, and subsequent slices remain planned. No measured
+Status: accepted implementation plan, updated 2026-09-07. The #73 managed-session binding and
+#74 bounded engine/journal are implemented; live providers, launcher, and later slices remain planned. No measured
 performance claim.
 
 Working product name: `ferrus-nano`. Ferrus backend name: `nano`.
 
-Related documents: [roadmap](milestones.md), [repository graph](repository-graph-architecture.md),
+Related documents: [session engine and journal](ferrus-nano-sessions.md), [roadmap](milestones.md), [repository graph](repository-graph-architecture.md),
 [project memory](project-memory-architecture.md).
 
 ## 1. Decision
@@ -62,7 +62,7 @@ Audit base: Ferrus commit `4f52783d6f5efa64ea1a2adf48b55c8b27c565be`.
 | Agent adapters | `ExecutorAgent` and `SupervisorAgent`, model overrides, stdin prompts | Executor-only/headless-only capability declarations; native registration |
 | UI | Crossterm HQ, `UiMessage`, transcript and question handling | A session-event adapter and, later, a conversation view |
 | MCP | neva 0.5.6 with `server`, `di`, `legacy-spec` | Add client features for external tools, preserve protocol compatibility |
-| Agent engine | No Ferrus-owned inference loop or provider implementation | Provider streaming, tool execution, context budgeting, session recovery |
+| Agent engine | Sequential bounded core, provider/tool/host interfaces, durable journal, pure replay, and scripted tests | Live provider adapter, managed tool wiring, compaction, and live resume |
 | Instructions | Ferrus role prompts, project guidance, and embedded skill templates | A bounded native instruction loader with explicit precedence and provenance |
 | Coding tools | Graph source readers, check runner and process primitives | General bounded reads/search, patch editing, command sessions |
 
@@ -385,6 +385,9 @@ When a native operation commits a lifecycle effect, cancellation must reconcile 
 ending the session. A stop request cannot simply forget an in-flight submit transaction.
 
 ## 9. Session journal and crash recovery
+
+The #74 implementation and current defaults are documented in [session storage](ferrus-nano-sessions.md).
+Recorded replay is implemented; live resume and reconciliation remain #84.
 
 Use one versioned, single-writer JSONL journal per nano session plus bounded output artifacts.
 Managed location proposal:

--- a/docs/ferrus-nano-sessions.md
+++ b/docs/ferrus-nano-sessions.md
@@ -75,6 +75,13 @@ reservation as estimated usage, since actual billing is unknown. Counters, reser
 no-progress count, and elapsed time are persisted with records and checkpoints. Recovery does not
 reset budgets or treat estimates as provider billing data.
 
+The active attempt uses a process-local monotonic clock. After a crash, time since the last
+committed record is unknown. Recovery conservatively consumes the remaining elapsed allowance
+and durably ends an unfinished attempt with `Limit(Elapsed)`, including one at a complete
+checkpoint. This charge is a recovery bound, not a measured duration. Pending effects and token
+reservations remain available for reconciliation. Continuing work requires a new session;
+reopening an already ended session preserves its recorded duration and reason.
+
 ## Storage and recovery
 
 The host passes the registered machine-local project data directory:
@@ -106,6 +113,8 @@ copies; #82 and #84 add compaction and live recovery.
 `FileJournal::recover` acquires the writer lock, enforces quotas, validates version/identity/order,
 and removes only an unterminated final line. A malformed newline-terminated record is an error.
 It returns recorded state, pending intents, and unknown effects without invoking tools or providers.
+For an unfinished attempt it appends the elapsed-budget charge and ending before returning; if
+that write fails, recovery fails. Repeated recovery preserves the same ending and budget.
 `Replay::from_records` is pure and reconstructs messages, ordering, and budget state from recorded
 inputs; it has no external effect ports.
 

--- a/docs/ferrus-nano-sessions.md
+++ b/docs/ferrus-nano-sessions.md
@@ -1,0 +1,114 @@
+# Nano Session Engine and Journal
+
+Status: implemented foundation for #74. There is no live provider, CLI command, HQ launcher,
+or automatic effect resume in this slice. See the [architecture and PR index](ferrus-nano-architecture.md).
+
+## Boundaries
+
+`src/nano/engine.rs` owns one sequential attempt. It accepts `SessionCommand::Start` or `Cancel`,
+uses a clonable cancellation handle during an active attempt, and returns a typed `SessionEnd`.
+A final model message ends the attempt with `ModelFinished`; only existing Ferrus operations can
+change task/run lifecycle. One engine cannot be started twice.
+
+The engine imports transport-neutral provider, tool, host, and journal interfaces:
+
+- `Provider` starts a request and emits fragments followed by one completed response. Fragments
+  never execute tools. Adapters own wire parsing and bounded response assembly; completed responses
+  preserve provider call IDs and opaque continuation data, including signed blocks. Truncated
+  model responses and duplicate call IDs end the attempt before any tool executes.
+- `Tools` describes the enabled catalog, validates parsed argument objects against each tool's
+  schema, and executes validated calls sequentially. Unknown tools and malformed arguments produce
+  typed feedback. The catalog is captured once per model turn.
+- `Host` revalidates authority immediately before an effect and receives committed records.
+  Managed Ferrus binding remains in `nano/ferrus.rs`; the engine imports no HQ, MCP, or project types.
+- `Journal` commits versioned records and complete-group checkpoints. The file implementation is
+  independent of orchestration, repository graph, and project memory databases.
+
+Tool adapters must clean up owned processes when execution is interrupted. Dropping an effect
+future does not prove rollback: cancellation or deadline during execution records `Unknown` and
+ends the attempt. No subsequent effect runs. Native critical sections and later resume adapters
+must reconcile the outcome against the effect's authority; #79 and #84 provide that integration.
+
+## Durable order
+
+```text
+Started -> ModelStarted -> ModelCompleted
+  -> ToolIntent -> ToolResult
+  -> ... remaining calls in model order ...
+  -> checkpoint -> next model turn or Ended
+```
+
+`ModelFailed` terminates a failed model attempt before a bounded retry. Unknown/malformed calls
+also receive an intent/result pair, but never reach execution. The journal flushes intent before
+calling the tool, and flushes the result before notifying the host. A write, quota, or checkpoint
+failure stops the engine. If an effect ran but its result could not be committed, the previous
+intent remains pending and no completion notification is emitted. `SessionEnd.durable = false`
+means the returned ending itself could not be persisted.
+
+## Budgets
+
+Defaults are initial safety limits, not calibrated performance targets:
+
+| Resource | Default |
+| --- | --- |
+| Model attempts, including retries | 64 |
+| Total reported/estimated/reserved tokens | 200,000 |
+| Tool calls, including rejected calls | 256 |
+| Provider retries | 3 |
+| Consecutive failed or repeated calls / empty model turns | 3 |
+| Elapsed time | 30 minutes |
+| Serialized context | 256 KiB |
+| Completed response and streamed fragments | 64 KiB |
+| Tool result | 32 KiB |
+
+Empty streaming fragments consume a minimum byte of the streaming allowance; buffered fragments
+also yield so cancellation can run. The host checks context, call, and token budgets before new
+work. Provider and tool waits observe cancellation and the attempt deadline. Synchronous durable
+storage and adapter cleanup still depend on the underlying OS and implementation; these are not
+hard real-time guarantees.
+
+Before contacting a provider, `ModelStarted` records input and output reservations. The local
+input estimate uses one token per serialized byte; the request receives an explicit output cap.
+A complete response replaces the reservation with reported usage, or a separately marked local
+estimate when usage is absent. An interrupted/failed request conservatively charges its entire
+reservation as estimated usage, since actual billing is unknown. Counters, reservations,
+no-progress count, and elapsed time are persisted with records and checkpoints. Recovery does not
+reset budgets or treat estimates as provider billing data.
+
+## Storage and recovery
+
+The host passes the registered machine-local project data directory:
+
+```text
+<project-data>/nano/sessions/<session-id>/
+  writer.lock
+  events.jsonl
+  outputs/<output-id>
+  checkpoints/<sequence>.json
+```
+
+Session identity contains the project and optional task/run pair. IDs are bounded path-safe
+ASCII tokens. Directories and files are owner-only: Unix uses 0700/0600 and verifies effective
+ownership; Windows uses a protected owner-rights DACL without inherited grants. Reopen rejects
+symlinks, unexpected file types, and broad permissions. The writer holds an OS file lock.
+
+Per-session defaults are 512 KiB per JSON record, 16 MiB journal, 1 MiB per artifact, 32 MiB total
+storage, and 256 files. Artifacts and checkpoints share the byte/file quota. Serialization is
+bounded while writing into memory. Artifact writes are immutable; this slice performs no automatic
+retention/deletion or raw-session ingestion into project memory.
+
+Checkpoints identify a complete journal prefix by sequence, SHA-256 digest, and budget snapshot.
+They cannot split a model response's tool-call/result group. Files are flushed before atomic
+publication; Unix also syncs directories, and Windows uses write-through rename. Storage durability
+ultimately depends on the filesystem. Checkpoints are prefix markers, not compacted conversation
+copies; #82 and #84 add compaction and live recovery.
+
+`FileJournal::recover` acquires the writer lock, enforces quotas, validates version/identity/order,
+and removes only an unterminated final line. A malformed newline-terminated record is an error.
+It returns recorded state, pending intents, and unknown effects without invoking tools or providers.
+`Replay::from_records` is pure and reconstructs messages, ordering, and budget state from recorded
+inputs; it has no external effect ports.
+
+An oversized initial command is rejected before its body is journaled. Other limits produce typed
+end reasons when the journal remains writable. Session files contain operational context and must
+remain outside default project-memory ingestion.

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -25,7 +25,7 @@ Last reviewed against the repository: 2026-09-07.
 | Spec closure and project memory | Local baseline implemented | Outcome archival, curated memory indexing, revision-pinned queries, and evidence-backed repository links exist. Raw runtime bodies are excluded from default ingestion. |
 | Repository graph and indexed context | Local baseline implemented | Optional SQLite sidecar, incremental extraction, bounded CLI/MCP retrieval, task overlays, and frozen review views. Rust/Cargo and generic file structure are supported. |
 | Distributed context data plane | Prototype implemented | Opt-in contracts and local prototype adapters for authorized jobs, encrypted storage, publication, queries, and maintenance. No deployed remote service is implied. |
-| Ferrus nano-agent | Foundation implemented; runtime planned | #73 adds native managed-session binding and claim/status/heartbeat. Provider, engine, HQ launch, interactive UI, and standalone delivery remain later slices. |
+| Ferrus nano-agent | Foundation implemented; runtime planned | #73 adds native binding and claim/status/heartbeat; #74 adds the bounded engine and durable journal. Live provider, HQ launch, interactive UI, and standalone delivery remain later slices. |
 
 ## Milestone 1: Windows Support
 
@@ -150,7 +150,7 @@ Definition of done:
 
 ## Milestone 5: Ferrus Nano-Agent
 
-Status: native session foundation implemented (#73); the runnable harness is not available yet.
+Status: native session and engine/journal foundations implemented (#73, #74); the runnable harness is not available yet.
 
 Goal: build `ferrus-nano` (backend `nano`) as a minimal Rust coding-agent harness. Start with a
 headless managed Executor, using Ferrus operations, repository graph, and project memory through
@@ -166,7 +166,8 @@ Implemented foundation:
 
 - host-owned project/agent/task/run/workspace/baseline binding from launch data and registered runtime state;
 - native typed claim, status, and heartbeat, with exact run validation at transaction boundaries;
-- regression coverage for invalid bindings, lease ownership, existing claims, and MCP parity.
+- sequential provider/tool/host boundaries, persisted budgets, cancellation, a private single-writer journal, and pure recorded replay;
+- regression coverage for bindings, lease ownership, MCP parity, engine limits, effect ordering, and journal recovery.
 
 Delivery is tracked in [Ferrus nano-agents](https://github.com/ferrus-dev/ferrus/milestone/6).
 The [architecture and complete PR index](ferrus-nano-architecture.md#planned-prs-and-github-issues)
@@ -174,7 +175,7 @@ contains one issue per planned PR, dependencies, and acceptance criteria:
 
 | Stage | Issues | Remaining scope |
 | --- | --- | --- |
-| N0/N1: headless Executor | #74-#80 | Engine/journal, first streaming provider, coding tools, command sessions, native context, lifecycle operations, and HQ launch/events |
+| N1: headless Executor | #75-#80 | First live streaming provider, coding tools, command sessions, native context, lifecycle operations, and HQ launch/events |
 | N2: context efficiency | #81-#82 | Working-set invalidation, budgets, and compaction |
 | N3: reliability and extensions | #83-#85 | External MCP via neva, resume/reconciliation, comparative evaluation, and headless release gates |
 | N4/N5: interactive and standalone | #86-#88 | HQ interaction, standalone host/binary, and shared UI |

--- a/src/nano/core_tests.rs
+++ b/src/nano/core_tests.rs
@@ -594,6 +594,115 @@ async fn recorded_replay_is_deterministic_preserves_budgets_and_has_no_effect_po
 }
 
 #[tokio::test]
+async fn replay_requires_a_final_response_from_the_latest_model_attempt() {
+    for case in [
+        "started",
+        "failed",
+        "empty",
+        "whitespace",
+        "length",
+        "tool_calls",
+        "tools_done",
+        "stale",
+        "valid",
+    ] {
+        let (_dir, mut engine) = setup(
+            scripted(vec![
+                response("", vec![call("a", 1)]),
+                response("Done", vec![]),
+            ]),
+            limits(),
+        );
+        run(&mut engine, &Cancellation::default()).await;
+        let mut records = engine.host.records.clone();
+        records.pop(); // Replace the engine's ending with an owner-written one.
+        match case {
+            "started" => records.truncate(1),
+            "tools_done" => {
+                let next = records
+                    .iter()
+                    .position(|r| matches!(r.event, SessionEvent::ModelStarted { turn: 2 }))
+                    .unwrap();
+                records.truncate(next);
+            }
+            "stale" => {
+                let mut next = records.last().unwrap().clone();
+                next.sequence += 1;
+                next.budget.model_turns += 1;
+                next.budget.reserved_input_tokens = 10;
+                next.budget.reserved_output_tokens = 5;
+                next.event = SessionEvent::ModelStarted {
+                    turn: next.budget.model_turns,
+                };
+                records.push(next.clone());
+                next.sequence += 1;
+                next.budget.reserved_input_tokens = 0;
+                next.budget.reserved_output_tokens = 0;
+                let usage = Usage {
+                    input_tokens: 10,
+                    output_tokens: 5,
+                    reported: true,
+                };
+                next.budget.charge(&usage);
+                next.event = SessionEvent::ModelFailed {
+                    retryable: false,
+                    usage,
+                };
+                records.push(next);
+            }
+            "valid" => (),
+            _ => {
+                let record = records.last_mut().unwrap();
+                let SessionEvent::ModelCompleted { response, usage } = &mut record.event else {
+                    panic!("Expected final response")
+                };
+                match case {
+                    "failed" => {
+                        record.event = SessionEvent::ModelFailed {
+                            retryable: false,
+                            usage: usage.clone(),
+                        }
+                    }
+                    "empty" => response.text.clear(),
+                    "whitespace" => response.text = " \t\n".into(),
+                    "length" => response.finish = FinishReason::Length,
+                    "tool_calls" => response.finish = FinishReason::ToolCalls,
+                    _ => unreachable!(),
+                }
+            }
+        }
+        // The prefix remains valid; only the fabricated successful ending is invalid.
+        Replay::from_records(&records).unwrap();
+        let mut end = records.last().unwrap().clone();
+        end.sequence += 1;
+        end.event = SessionEvent::Ended {
+            reason: EndReason::ModelFinished,
+        };
+        records.push(end);
+        assert_eq!(
+            Replay::from_records(&records).is_ok(),
+            case == "valid",
+            "{case}"
+        );
+        let directory = engine.journal.directory().to_path_buf();
+        drop(engine);
+        let mut bytes = Vec::new();
+        for record in &records {
+            serde_json::to_writer(&mut bytes, record).unwrap();
+            bytes.push(b'\n');
+        }
+        let path = directory.join("events.jsonl");
+        std::fs::write(&path, &bytes).unwrap();
+        assert_eq!(
+            FileJournal::recover(&directory, Quotas::default()).is_ok(),
+            case == "valid",
+            "{case}"
+        );
+        assert_eq!(std::fs::read(&path).unwrap(), bytes);
+    }
+}
+
+#[tokio::test]
 async fn truncated_or_duplicate_call_responses_never_execute() {
     for truncated in [false, true] {
         let mut event = response("Partial", vec![call("duplicate", 1), call("duplicate", 2)]);

--- a/src/nano/core_tests.rs
+++ b/src/nano/core_tests.rs
@@ -1,0 +1,638 @@
+//! Scripted engine/replay tests never call a shell, MCP peer, or inference service.
+
+use super::{
+    engine::Engine,
+    journal::{FileJournal, Journal, Quotas},
+    provider::*,
+    replay::Replay,
+    session::*,
+    tools::*,
+};
+use anyhow::Result;
+use serde_json::json;
+use std::{
+    collections::VecDeque,
+    sync::{Arc, Mutex},
+};
+use tempfile::TempDir;
+
+type Script = VecDeque<Result<VecDeque<ProviderEvent>, ProviderError>>;
+#[derive(Default)]
+struct ScriptedProvider {
+    turns: Script,
+    active: VecDeque<ProviderEvent>,
+    requests: Vec<ModelRequest>,
+    stall: bool,
+}
+
+impl Provider for ScriptedProvider {
+    async fn start(&mut self, request: ModelRequest) -> Result<(), ProviderError> {
+        self.requests.push(request);
+        self.active = self
+            .turns
+            .pop_front()
+            .unwrap_or(Err(ProviderError { retryable: false }))?;
+        Ok(())
+    }
+
+    async fn next_event(&mut self) -> Result<Option<ProviderEvent>, ProviderError> {
+        if self.stall {
+            std::future::pending::<()>().await;
+        }
+        Ok(self.active.pop_front())
+    }
+}
+
+#[derive(Default)]
+struct FakeTools {
+    effects: Arc<Mutex<Vec<String>>>,
+    fail: bool,
+    stall: bool,
+    huge: bool,
+}
+
+impl Tools for FakeTools {
+    fn descriptors(&self) -> Vec<ToolDescriptor> {
+        vec![ToolDescriptor {
+            name: "edit".into(),
+            description: "Fixture edit".into(),
+            input_schema: json!({"type":"object","required":["value"],"properties":{"value":{"type":"integer"}},"additionalProperties":false}),
+        }]
+    }
+
+    fn validate(&self, _: &str, arguments: &serde_json::Value) -> Result<(), ToolError> {
+        if arguments
+            .as_object()
+            .is_some_and(|obj| obj.len() == 1 && obj.get("value").is_some_and(|v| v.is_i64()))
+        {
+            Ok(())
+        } else {
+            Err(ToolError::InvalidArguments)
+        }
+    }
+
+    async fn execute(&mut self, call: &ValidatedCall, _: &Cancellation) -> ToolOutcome {
+        self.effects.lock().unwrap().push(call.call_id.clone());
+        if self.stall {
+            std::future::pending::<()>().await;
+        }
+
+        if self.fail {
+            ToolOutcome::Failed(ToolError::Failed)
+        } else if self.huge {
+            ToolOutcome::Success(json!("x".repeat(4096)))
+        } else {
+            ToolOutcome::Success(call.arguments.clone())
+        }
+    }
+}
+
+#[derive(Default)]
+struct FakeHost {
+    records: Vec<Record>,
+    deny: bool,
+    cancel_on_intent: Option<Cancellation>,
+}
+
+impl Host for FakeHost {
+    async fn authorize(&mut self, _: &ValidatedCall) -> Result<(), ToolError> {
+        if self.deny {
+            Err(ToolError::Denied)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn committed(&mut self, record: &Record) {
+        if matches!(record.event, SessionEvent::ToolIntent { .. }) {
+            if let Some(cancel) = &self.cancel_on_intent {
+                cancel.cancel();
+            }
+        }
+        self.records.push(record.clone());
+    }
+}
+
+struct FailingJournal {
+    inner: FileJournal,
+    fail_intent: bool,
+    fail_result: bool,
+}
+
+impl Journal for FailingJournal {
+    fn append(&mut self, event: SessionEvent, budget: &Budget) -> Result<Record> {
+        anyhow::ensure!(
+            !(self.fail_intent && matches!(event, SessionEvent::ToolIntent { .. }))
+                && !(self.fail_result && matches!(event, SessionEvent::ToolResult { .. })),
+            "Injected journal failure"
+        );
+        self.inner.append(event, budget)
+    }
+
+    fn checkpoint(&mut self) -> Result<()> {
+        self.inner.checkpoint()
+    }
+}
+
+fn identity() -> SessionIdentity {
+    SessionIdentity {
+        session_id: "session-1".into(),
+        project_id: "project-1".into(),
+        task_id: Some("t-1".into()),
+        run_id: Some("r-1".into()),
+    }
+}
+
+fn call(id: &str, value: i64) -> ToolCall {
+    ToolCall {
+        provider_call_id: id.into(),
+        name: "edit".into(),
+        arguments: json!({"value":value}).to_string(),
+    }
+}
+
+fn response(text: &str, calls: Vec<ToolCall>) -> ProviderEvent {
+    ProviderEvent::Completed {
+        response: ModelResponse {
+            finish: if calls.is_empty() {
+                FinishReason::Stop
+            } else {
+                FinishReason::ToolCalls
+            },
+            text: text.into(),
+            calls,
+            continuation: Some(json!({"signed":"opaque"})),
+        },
+        usage: Some(Usage {
+            input_tokens: 10,
+            output_tokens: 5,
+            reported: true,
+        }),
+    }
+}
+
+fn scripted(turns: Vec<ProviderEvent>) -> ScriptedProvider {
+    ScriptedProvider {
+        turns: turns
+            .into_iter()
+            .map(|event| Ok(VecDeque::from([event])))
+            .collect(),
+        ..Default::default()
+    }
+}
+
+fn limits() -> Limits {
+    Limits {
+        tokens: 1_000_000,
+        ..Default::default()
+    }
+}
+
+fn setup(
+    provider: ScriptedProvider,
+    limits: Limits,
+) -> (
+    TempDir,
+    Engine<ScriptedProvider, FakeTools, FakeHost, FileJournal>,
+) {
+    let dir = TempDir::new().unwrap();
+    let journal = FileJournal::create(
+        &dir.path().canonicalize().unwrap(),
+        "session-1",
+        Quotas::default(),
+    )
+    .unwrap();
+
+    let engine = Engine::new(
+        identity(),
+        limits,
+        provider,
+        FakeTools::default(),
+        FakeHost::default(),
+        journal,
+    )
+    .unwrap();
+
+    (dir, engine)
+}
+async fn run<P: Provider, T: Tools, H: Host, J: Journal>(
+    engine: &mut Engine<P, T, H, J>,
+    cancellation: &Cancellation,
+) -> SessionEnd {
+    engine
+        .run(
+            SessionCommand::Start {
+                input: "Implement a fixture task".into(),
+            },
+            cancellation,
+        )
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn text_completion_records_usage_but_does_not_complete_a_ferrus_task() {
+    let (_dir, mut engine) = setup(scripted(vec![response("Done", vec![])]), limits());
+    let end = run(&mut engine, &Cancellation::default()).await;
+    assert_eq!(end.reason, EndReason::ModelFinished);
+    assert!(end.durable);
+    assert_eq!(end.budget.reported_input_tokens, 10);
+    assert_eq!(end.budget.reported_output_tokens, 5);
+    assert_eq!(end.budget.estimated_input_tokens, 0);
+    assert_eq!(end.budget.reserved_input_tokens, 0);
+    assert!(engine.tools.effects.lock().unwrap().is_empty());
+    assert!(matches!(
+        engine.host.records.last().unwrap().event,
+        SessionEvent::Ended {
+            reason: EndReason::ModelFinished
+        }
+    ));
+    assert!(
+        engine
+            .run(SessionCommand::Cancel, &Cancellation::default())
+            .await
+            .is_err()
+    );
+}
+
+#[tokio::test]
+async fn multiple_tools_keep_call_result_order_and_continuation_data() {
+    let (_dir, mut engine) = setup(
+        scripted(vec![
+            response("", vec![call("a", 1), call("b", 2)]),
+            response("Done", vec![]),
+        ]),
+        limits(),
+    );
+    let end = run(&mut engine, &Cancellation::default()).await;
+    assert_eq!(end.reason, EndReason::ModelFinished);
+    assert_eq!(*engine.tools.effects.lock().unwrap(), ["call-1", "call-2"]);
+    let order: Vec<_> = engine
+        .host
+        .records
+        .iter()
+        .filter_map(|record| match &record.event {
+            SessionEvent::ToolIntent { call_id, .. } => Some(format!("intent:{call_id}")),
+            SessionEvent::ToolResult { call_id, .. } => Some(format!("result:{call_id}")),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        order,
+        [
+            "intent:call-1",
+            "result:call-1",
+            "intent:call-2",
+            "result:call-2"
+        ]
+    );
+    assert!(
+        matches!(&engine.provider.requests[1].messages[1], Message::Assistant { response } if response.continuation == Some(json!({"signed":"opaque"})))
+    );
+    assert!(
+        matches!(&engine.provider.requests[1].messages[2], Message::Tool { provider_call_id,.. } if provider_call_id=="a")
+    );
+    assert!(engine.provider.requests[0].max_output_tokens > 0);
+}
+
+#[tokio::test]
+async fn malformed_unknown_and_schema_invalid_calls_never_execute() {
+    let mut malformed = call("a", 1);
+    malformed.arguments = "{\"value\":".into();
+    let mut unknown = call("b", 2);
+    unknown.name = "other".into();
+    let mut invalid = call("c", 3);
+    invalid.arguments = "{\"value\":\"wrong\"}".into();
+    let mut budget = limits();
+    budget.no_progress = 5;
+    let (_dir, mut engine) = setup(
+        scripted(vec![
+            response("", vec![malformed, unknown, invalid]),
+            response("Done", vec![]),
+        ]),
+        budget,
+    );
+    assert_eq!(
+        run(&mut engine, &Cancellation::default()).await.reason,
+        EndReason::ModelFinished
+    );
+    assert!(engine.tools.effects.lock().unwrap().is_empty());
+    let errors: Vec<_> = engine
+        .host
+        .records
+        .iter()
+        .filter_map(|r| match &r.event {
+            SessionEvent::ToolResult {
+                outcome: ToolOutcome::Failed(error),
+                ..
+            } => Some(error.clone()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        errors,
+        [
+            ToolError::InvalidArguments,
+            ToolError::UnknownTool,
+            ToolError::InvalidArguments
+        ]
+    );
+}
+
+#[tokio::test]
+async fn partial_arguments_and_abrupt_stream_end_never_execute() {
+    let provider = ScriptedProvider {
+        turns: VecDeque::from([Ok(VecDeque::from([
+            ProviderEvent::ArgumentsDelta("{\"value\":".into()),
+            ProviderEvent::TextDelta("working".into()),
+        ]))]),
+        ..Default::default()
+    };
+    let (_dir, mut engine) = setup(provider, limits());
+    assert_eq!(
+        run(&mut engine, &Cancellation::default()).await.reason,
+        EndReason::ProviderProtocol
+    );
+    assert!(engine.tools.effects.lock().unwrap().is_empty());
+    assert!(
+        engine
+            .host
+            .records
+            .iter()
+            .all(|r| !matches!(r.event, SessionEvent::ToolIntent { .. }))
+    );
+}
+
+#[tokio::test]
+async fn repeated_failures_and_identical_successes_stop_no_progress_loops() {
+    for fail in [false, true] {
+        let provider = scripted(
+            (0..8)
+                .map(|n| response("", vec![call(&n.to_string(), 1)]))
+                .collect(),
+        );
+        let (_dir, mut engine) = setup(provider, limits());
+        engine.tools.fail = fail;
+        let end = run(&mut engine, &Cancellation::default()).await;
+        assert_eq!(end.reason, EndReason::Limit(LimitKind::NoProgress));
+        assert_eq!(
+            engine.tools.effects.lock().unwrap().len(),
+            if fail { 3 } else { 4 }
+        );
+    }
+}
+
+#[tokio::test]
+async fn turn_tool_token_retry_and_context_limits_are_enforced() {
+    for kind in [
+        LimitKind::ModelTurns,
+        LimitKind::ToolCalls,
+        LimitKind::Tokens,
+        LimitKind::Retries,
+        LimitKind::ContextBytes,
+        LimitKind::ResponseBytes,
+        LimitKind::ToolOutputBytes,
+    ] {
+        let mut budget = limits();
+        let mut provider = scripted(vec![
+            response("", vec![call("a", 1), call("b", 2)]),
+            response("Done", vec![]),
+        ]);
+        match kind {
+            LimitKind::ModelTurns => budget.model_turns = 1,
+            LimitKind::ToolCalls => budget.tool_calls = 1,
+            LimitKind::Tokens => budget.tokens = 1,
+            LimitKind::Retries => {
+                budget.retries = 0;
+                provider.turns = VecDeque::from([Err(ProviderError { retryable: true })]);
+            }
+            LimitKind::ContextBytes => budget.context_bytes = 1,
+            LimitKind::ResponseBytes => budget.response_bytes = 1,
+            LimitKind::ToolOutputBytes => budget.tool_output_bytes = 32,
+            _ => unreachable!(),
+        }
+        let (_dir, mut engine) = setup(provider, budget);
+        engine.tools.huge = kind == LimitKind::ToolOutputBytes;
+        let end = run(&mut engine, &Cancellation::default()).await;
+        assert_eq!(end.reason, EndReason::Limit(kind.clone()), "{kind:?}");
+        if kind == LimitKind::ToolCalls {
+            assert_eq!(engine.tools.effects.lock().unwrap().len(), 1);
+        }
+    }
+}
+
+#[tokio::test]
+async fn retries_charge_estimates_and_successful_usage_stays_distinct() {
+    let mut provider = scripted(vec![response("Done", vec![])]);
+    provider
+        .turns
+        .push_front(Err(ProviderError { retryable: true }));
+    let (_dir, mut engine) = setup(provider, limits());
+    let end = run(&mut engine, &Cancellation::default()).await;
+    assert_eq!(end.reason, EndReason::ModelFinished);
+    assert_eq!(end.budget.retries, 1);
+    assert_eq!(end.budget.model_turns, 2);
+    assert!(end.budget.estimated_input_tokens > 0 && end.budget.estimated_output_tokens > 0);
+    assert_eq!(end.budget.reported_input_tokens, 10);
+    let state = Replay::from_records(&engine.host.records).unwrap();
+    assert_eq!(state.budget, end.budget);
+}
+
+#[tokio::test]
+async fn cancellation_before_authorization_never_starts_an_effect() {
+    let cancellation = Cancellation::default();
+    let (_dir, mut engine) = setup(scripted(vec![response("", vec![call("a", 1)])]), limits());
+    engine.host.cancel_on_intent = Some(cancellation.clone());
+    let end = run(&mut engine, &cancellation).await;
+    assert_eq!(end.reason, EndReason::Cancelled);
+    assert!(engine.tools.effects.lock().unwrap().is_empty());
+    assert!(engine.journal.state().unknown_effects.is_empty());
+}
+
+#[tokio::test]
+async fn cancellation_or_deadline_during_an_effect_records_unknown_outcome() {
+    for cancel in [false, true] {
+        let mut budget = limits();
+        budget.elapsed_ms = if cancel { 30_000 } else { 1_000 };
+        let (_dir, mut engine) = setup(scripted(vec![response("", vec![call("a", 1)])]), budget);
+        engine.tools.stall = true;
+        let cancellation = Cancellation::default();
+        let control = cancellation.clone();
+        let effects = engine.tools.effects.clone();
+        let interrupter = async move {
+            if cancel {
+                loop {
+                    if !effects.lock().unwrap().is_empty() {
+                        control.cancel();
+                        break;
+                    }
+                    tokio::task::yield_now().await;
+                }
+            }
+        };
+        let (end, ()) = tokio::join!(run(&mut engine, &cancellation), interrupter);
+        assert_eq!(
+            end.reason,
+            if cancel {
+                EndReason::Cancelled
+            } else {
+                EndReason::Limit(LimitKind::Elapsed)
+            }
+        );
+        assert_eq!(engine.journal.state().unknown_effects, ["call-1"]);
+        assert!(engine.journal.state().pending_effect.is_none());
+    }
+}
+
+#[tokio::test]
+async fn stalled_provider_is_cancellable_and_cannot_hide_elapsed_budget() {
+    let mut budget = limits();
+    budget.elapsed_ms = 20;
+    let provider = ScriptedProvider {
+        turns: VecDeque::from([Ok(VecDeque::new())]),
+        stall: true,
+        ..Default::default()
+    };
+    let (_dir, mut engine) = setup(provider, budget);
+    let end = run(&mut engine, &Cancellation::default()).await;
+    assert_eq!(end.reason, EndReason::Limit(LimitKind::Elapsed));
+    assert!(end.budget.elapsed_ms >= 20);
+    assert!(end.budget.estimated_input_tokens > 0);
+}
+
+#[tokio::test]
+async fn journal_failures_stop_unrecorded_effects_and_uncommitted_acknowledgments() {
+    for after_effect in [false, true] {
+        let dir = TempDir::new().unwrap();
+        let inner = FileJournal::create(
+            &dir.path().canonicalize().unwrap(),
+            "session-1",
+            Quotas::default(),
+        )
+        .unwrap();
+        let path = inner.directory().to_path_buf();
+        let journal = FailingJournal {
+            inner,
+            fail_intent: !after_effect,
+            fail_result: after_effect,
+        };
+        let mut engine = Engine::new(
+            identity(),
+            limits(),
+            scripted(vec![response("", vec![call("a", 1), call("b", 2)])]),
+            FakeTools::default(),
+            FakeHost::default(),
+            journal,
+        )
+        .unwrap();
+        let end = run(&mut engine, &Cancellation::default()).await;
+        assert_eq!(end.reason, EndReason::JournalFailed);
+        assert!(!end.durable);
+        assert_eq!(
+            engine.tools.effects.lock().unwrap().len(),
+            usize::from(after_effect)
+        );
+        assert!(
+            engine
+                .host
+                .records
+                .iter()
+                .all(|r| !matches!(r.event, SessionEvent::ToolResult { .. }))
+        );
+        drop(engine);
+        let (journal, records) = FileJournal::recover(&path, Quotas::default()).unwrap();
+        assert_eq!(
+            journal.state().pending_effect.as_deref(),
+            after_effect.then_some("call-1")
+        );
+        assert!(Replay::from_records(&records).unwrap().end.is_none());
+    }
+}
+
+#[tokio::test]
+async fn recorded_replay_is_deterministic_preserves_budgets_and_has_no_effect_ports() {
+    let (_dir, mut engine) = setup(
+        scripted(vec![
+            response("", vec![call("a", 1), call("b", 2)]),
+            response("Done", vec![]),
+        ]),
+        limits(),
+    );
+    run(&mut engine, &Cancellation::default()).await;
+    let records = engine.host.records.clone();
+    let effects = engine.tools.effects.clone();
+    let expected = effects.lock().unwrap().clone();
+    drop(engine);
+    let first = Replay::from_records(&records).unwrap();
+    let second = Replay::from_records(&records).unwrap();
+    assert_eq!(first.messages, second.messages);
+    assert_eq!(first.budget, second.budget);
+    assert_eq!(first.end, Some(EndReason::ModelFinished));
+    assert_eq!(*effects.lock().unwrap(), expected);
+    let mut undercharged = records.clone();
+    let completed = undercharged
+        .iter_mut()
+        .find(|record| matches!(record.event, SessionEvent::ModelCompleted { .. }))
+        .unwrap();
+    completed.budget.reported_input_tokens = 0;
+    assert!(Replay::from_records(&undercharged).is_err());
+    let mut reordered = records.clone();
+    let results: Vec<_> = reordered
+        .iter()
+        .enumerate()
+        .filter(|(_, r)| matches!(r.event, SessionEvent::ToolResult { .. }))
+        .map(|(i, _)| i)
+        .collect();
+    let event = reordered[results[0]].event.clone();
+    reordered[results[0]].event = reordered[results[1]].event.clone();
+    reordered[results[1]].event = event;
+    assert!(Replay::from_records(&reordered).is_err());
+}
+
+#[tokio::test]
+async fn truncated_or_duplicate_call_responses_never_execute() {
+    for truncated in [false, true] {
+        let mut event = response("Partial", vec![call("duplicate", 1), call("duplicate", 2)]);
+        if let ProviderEvent::Completed { response, .. } = &mut event {
+            if truncated {
+                response.finish = FinishReason::Length;
+            }
+        }
+        let (_dir, mut engine) = setup(scripted(vec![event]), limits());
+        let end = run(&mut engine, &Cancellation::default()).await;
+        assert_eq!(
+            end.reason,
+            if truncated {
+                EndReason::ProviderTruncated
+            } else {
+                EndReason::ProviderProtocol
+            }
+        );
+        assert!(engine.tools.effects.lock().unwrap().is_empty());
+    }
+}
+
+#[tokio::test]
+async fn host_denial_returns_feedback_and_absent_usage_is_estimated() {
+    let mut final_response = response("Done", vec![]);
+    if let ProviderEvent::Completed { usage, .. } = &mut final_response {
+        *usage = None;
+    }
+    let (_dir, mut engine) = setup(
+        scripted(vec![response("", vec![call("a", 1)]), final_response]),
+        limits(),
+    );
+    engine.host.deny = true;
+    let end = run(&mut engine, &Cancellation::default()).await;
+    assert_eq!(end.reason, EndReason::ModelFinished);
+    assert!(engine.tools.effects.lock().unwrap().is_empty());
+    assert!(end.budget.estimated_output_tokens > 0);
+    assert_eq!(end.budget.reported_output_tokens, 5);
+    assert!(engine.host.records.iter().any(|record| matches!(
+        record.event,
+        SessionEvent::ToolResult {
+            outcome: ToolOutcome::Failed(ToolError::Denied),
+            ..
+        }
+    )));
+}

--- a/src/nano/core_tests.rs
+++ b/src/nano/core_tests.rs
@@ -546,7 +546,10 @@ async fn journal_failures_stop_unrecorded_effects_and_uncommitted_acknowledgment
             journal.state().pending_effect.as_deref(),
             after_effect.then_some("call-1")
         );
-        assert!(Replay::from_records(&records).unwrap().end.is_none());
+        assert_eq!(
+            Replay::from_records(&records).unwrap().end,
+            Some(EndReason::Limit(LimitKind::Elapsed))
+        );
     }
 }
 

--- a/src/nano/core_tests.rs
+++ b/src/nano/core_tests.rs
@@ -449,7 +449,7 @@ async fn cancellation_before_authorization_never_starts_an_effect() {
     assert!(engine.journal.state().unknown_effects.is_empty());
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn cancellation_or_deadline_during_an_effect_records_unknown_outcome() {
     for cancel in [false, true] {
         let mut budget = limits();
@@ -484,8 +484,8 @@ async fn cancellation_or_deadline_during_an_effect_records_unknown_outcome() {
     }
 }
 
-#[tokio::test]
-async fn stalled_provider_is_cancellable_and_cannot_hide_elapsed_budget() {
+#[tokio::test(start_paused = true)]
+async fn stalled_provider_cannot_hide_elapsed_budget() {
     let mut budget = limits();
     budget.elapsed_ms = 20;
     let provider = ScriptedProvider {
@@ -497,6 +497,7 @@ async fn stalled_provider_is_cancellable_and_cannot_hide_elapsed_budget() {
     let end = run(&mut engine, &Cancellation::default()).await;
     assert_eq!(end.reason, EndReason::Limit(LimitKind::Elapsed));
     assert!(end.budget.elapsed_ms >= 20);
+    assert_eq!(engine.provider.requests.len(), 1);
     assert!(end.budget.estimated_input_tokens > 0);
 }
 

--- a/src/nano/engine.rs
+++ b/src/nano/engine.rs
@@ -1,0 +1,492 @@
+//! Sequential bounded inference/tool loop. Journal commits precede effects and notifications.
+
+use super::{
+    journal::{Journal, encode, valid_id},
+    provider::{FinishReason, Message, ModelRequest, Provider, ProviderEvent, Usage},
+    session::{
+        Budget, EndReason, LimitKind, Limits, SessionCommand, SessionEnd, SessionEvent,
+        SessionIdentity,
+    },
+    tools::{Cancellation, Host, ToolCall, ToolError, ToolOutcome, Tools, ValidatedCall},
+};
+use anyhow::{Result, ensure};
+use std::collections::HashSet;
+use tokio::time::{Duration, Instant};
+
+pub(crate) struct Engine<P, T, H, J> {
+    identity: SessionIdentity,
+    limits: Limits,
+    pub provider: P,
+    pub tools: T,
+    pub host: H,
+    pub journal: J,
+    budget: Budget,
+    messages: Vec<Message>,
+    previous_call: Option<(String, serde_json::Value)>,
+    started: Option<Instant>,
+}
+
+impl<P: Provider, T: Tools, H: Host, J: Journal> Engine<P, T, H, J> {
+    pub(crate) fn new(
+        identity: SessionIdentity,
+        limits: Limits,
+        provider: P,
+        tools: T,
+        host: H,
+        journal: J,
+    ) -> Result<Self> {
+        limits.validate()?;
+        ensure!(
+            valid_id(&identity.session_id)
+                && !identity.project_id.is_empty()
+                && identity.task_id.is_some() == identity.run_id.is_some(),
+            "Invalid session identity"
+        );
+
+        Ok(Self {
+            identity,
+            limits,
+            provider,
+            tools,
+            host,
+            journal,
+            budget: Budget::default(),
+            messages: Vec::new(),
+            previous_call: None,
+            started: None,
+        })
+    }
+
+    /// One attempt per engine. Live resume and interactive steering are separate adapters.
+    pub(crate) async fn run(
+        &mut self,
+        command: SessionCommand,
+        cancellation: &Cancellation,
+    ) -> Result<SessionEnd> {
+        ensure!(self.started.is_none(), "Session already started");
+
+        let start = Instant::now();
+        let deadline = start
+            .checked_add(Duration::from_millis(self.limits.elapsed_ms))
+            .ok_or_else(|| anyhow::anyhow!("Session deadline overflow"))?;
+
+        self.started = Some(start);
+        let input = match command {
+            SessionCommand::Start { input } => input,
+            SessionCommand::Cancel => {
+                cancellation.cancel();
+                String::new()
+            }
+        };
+
+        if input.len() > self.limits.context_bytes {
+            // An oversized input is never copied into the journal.
+            return Ok(SessionEnd {
+                reason: EndReason::Limit(LimitKind::ContextBytes),
+                budget: self.budget.clone(),
+                durable: false,
+            });
+        }
+
+        if !self.commit(SessionEvent::Started {
+            identity: self.identity.clone(),
+            limits: self.limits.clone(),
+            input: input.clone(),
+        }) {
+            return Ok(self.journal_failure());
+        }
+
+        self.messages.push(Message::User { text: input });
+
+        let reason = self.drive(cancellation, deadline).await;
+        if reason == EndReason::JournalFailed {
+            return Ok(self.journal_failure());
+        }
+
+        self.update_elapsed();
+        if !self.commit(SessionEvent::Ended {
+            reason: reason.clone(),
+        }) {
+            return Ok(self.journal_failure());
+        }
+
+        Ok(SessionEnd {
+            reason,
+            budget: self.budget.clone(),
+            durable: true,
+        })
+    }
+
+    async fn drive(&mut self, cancellation: &Cancellation, deadline: Instant) -> EndReason {
+        loop {
+            if let Some(reason) = self.stop(cancellation, deadline) {
+                return reason;
+            }
+            if self.budget.model_turns >= self.limits.model_turns {
+                return EndReason::Limit(LimitKind::ModelTurns);
+            }
+
+            let descriptors = self.tools.descriptors();
+            let mut names = HashSet::new();
+            if descriptors
+                .iter()
+                .any(|tool| tool.name.is_empty() || !names.insert(tool.name.clone()))
+            {
+                return EndReason::ProviderProtocol;
+            }
+
+            let context = match encode(&(&self.messages, &descriptors), self.limits.context_bytes) {
+                Ok(bytes) => bytes,
+                Err(_) => return EndReason::Limit(LimitKind::ContextBytes),
+            };
+
+            // One byte per token is a conservative local estimate, not billing usage.
+            let input_estimate = context.len() as u64;
+            let remaining = self.limits.tokens.saturating_sub(self.budget.tokens());
+            if input_estimate >= remaining {
+                return EndReason::Limit(LimitKind::Tokens);
+            }
+
+            let output_reservation =
+                (remaining - input_estimate).min(self.limits.response_bytes as u64);
+            self.budget.model_turns += 1;
+            self.budget.reserved_input_tokens = input_estimate;
+            self.budget.reserved_output_tokens = output_reservation;
+
+            if !self.commit(SessionEvent::ModelStarted {
+                turn: self.budget.model_turns,
+            }) {
+                return EndReason::JournalFailed;
+            }
+
+            let request = ModelRequest {
+                messages: self.messages.clone(),
+                tools: descriptors,
+                max_output_tokens: output_reservation,
+            };
+
+            let started = interrupt(self.provider.start(request), cancellation, deadline).await;
+            let mut stream_bytes = 0usize;
+            let response = match started {
+                Err(reason) => {
+                    if !self.record_model_failure(false) {
+                        return EndReason::JournalFailed;
+                    }
+                    return reason;
+                }
+                Ok(Err(error)) => Err(error),
+                Ok(Ok(())) => loop {
+                    match interrupt(self.provider.next_event(), cancellation, deadline).await {
+                        Err(reason) => {
+                            if !self.record_model_failure(false) {
+                                return EndReason::JournalFailed;
+                            }
+                            return reason;
+                        }
+                        Ok(Err(error)) => break Err(error),
+                        Ok(Ok(None)) => {
+                            if !self.record_model_failure(false) {
+                                return EndReason::JournalFailed;
+                            }
+                            return EndReason::ProviderProtocol;
+                        }
+                        Ok(Ok(Some(
+                            ProviderEvent::TextDelta(delta) | ProviderEvent::ArgumentsDelta(delta),
+                        ))) => {
+                            stream_bytes = stream_bytes.saturating_add(delta.len().max(1));
+                            if stream_bytes > self.limits.response_bytes {
+                                if !self.record_model_failure(false) {
+                                    return EndReason::JournalFailed;
+                                }
+                                return EndReason::Limit(LimitKind::ResponseBytes);
+                            }
+                            // Ready buffered fragments must not starve cancellation on this executor.
+                            tokio::task::yield_now().await;
+                        }
+                        Ok(Ok(Some(ProviderEvent::Completed { response, usage }))) => {
+                            break Ok((response, usage));
+                        }
+                    }
+                },
+            };
+
+            let (response, reported) = match response {
+                Ok(value) => value,
+                Err(error) => {
+                    let retry = error.retryable && self.budget.retries < self.limits.retries;
+                    if retry {
+                        self.budget.retries += 1;
+                    }
+                    if !self.record_model_failure(error.retryable) {
+                        return EndReason::JournalFailed;
+                    }
+                    if !error.retryable {
+                        return EndReason::ProviderFailed;
+                    }
+                    if !retry {
+                        return EndReason::Limit(LimitKind::Retries);
+                    }
+                    continue;
+                }
+            };
+
+            let bytes = match encode(&response, self.limits.response_bytes) {
+                Ok(value) => value,
+                Err(_) => {
+                    if !self.record_model_failure(false) {
+                        return EndReason::JournalFailed;
+                    }
+                    return EndReason::Limit(LimitKind::ResponseBytes);
+                }
+            };
+
+            let usage = reported.unwrap_or(Usage {
+                input_tokens: input_estimate,
+                output_tokens: stream_bytes.max(bytes.len()) as u64,
+                reported: false,
+            });
+
+            self.budget.reserved_input_tokens = 0;
+            self.budget.reserved_output_tokens = 0;
+            self.budget.charge(&usage);
+
+            if response.calls.is_empty() && response.text.trim().is_empty() {
+                self.budget.no_progress += 1;
+            }
+            if !self.commit(SessionEvent::ModelCompleted {
+                response: response.clone(),
+                usage,
+            }) {
+                return EndReason::JournalFailed;
+            }
+
+            if response.finish == FinishReason::Length {
+                return EndReason::ProviderTruncated;
+            }
+            if (response.finish == FinishReason::ToolCalls) == response.calls.is_empty() {
+                return EndReason::ProviderProtocol;
+            }
+
+            self.messages.push(Message::Assistant {
+                response: response.clone(),
+            });
+
+            if let Some(reason) = self.stop(cancellation, deadline) {
+                return reason;
+            }
+            if encode(&self.messages, self.limits.context_bytes).is_err() {
+                return EndReason::Limit(LimitKind::ContextBytes);
+            }
+
+            let mut ids = HashSet::new();
+            if response
+                .calls
+                .iter()
+                .any(|call| call.provider_call_id.is_empty() || !ids.insert(&call.provider_call_id))
+            {
+                return EndReason::ProviderProtocol;
+            }
+
+            if response.calls.is_empty() && !response.text.trim().is_empty() {
+                if self.journal.checkpoint().is_err() {
+                    return EndReason::JournalFailed;
+                }
+                return EndReason::ModelFinished;
+            }
+
+            for call in response.calls {
+                if let Some(reason) = self.stop(cancellation, deadline) {
+                    return reason;
+                }
+                if self.budget.tool_calls >= self.limits.tool_calls {
+                    return EndReason::Limit(LimitKind::ToolCalls);
+                }
+
+                self.budget.tool_calls += 1;
+
+                let call_id = format!("call-{}", self.budget.tool_calls);
+                let validated = self.validate(&call_id, &call, &names);
+
+                if !self.commit(SessionEvent::ToolIntent {
+                    call_id: call_id.clone(),
+                    call: call.clone(),
+                }) {
+                    return EndReason::JournalFailed;
+                }
+
+                let mut interrupted = None;
+                let mut outcome = match &validated {
+                    Err(error) => ToolOutcome::Failed(error.clone()),
+                    Ok(validated) => {
+                        match interrupt(self.host.authorize(validated), cancellation, deadline)
+                            .await
+                        {
+                            Err(reason) => {
+                                interrupted = Some(reason);
+                                ToolOutcome::Failed(ToolError::Interrupted)
+                            }
+                            Ok(Err(error)) => ToolOutcome::Failed(error),
+                            Ok(Ok(())) => match interrupt(
+                                self.tools.execute(validated, cancellation),
+                                cancellation,
+                                deadline,
+                            )
+                            .await
+                            {
+                                Ok(outcome) => outcome,
+                                Err(reason) => {
+                                    interrupted = Some(reason);
+                                    ToolOutcome::Unknown(ToolError::Interrupted)
+                                }
+                            },
+                        }
+                    }
+                };
+
+                if encode(&outcome, self.limits.tool_output_bytes).is_err() {
+                    outcome = ToolOutcome::Unknown(ToolError::OutputLimit);
+                    interrupted = Some(EndReason::Limit(LimitKind::ToolOutputBytes));
+                }
+
+                let fingerprint = validated
+                    .as_ref()
+                    .ok()
+                    .map(|call| (call.name.clone(), call.arguments.clone()));
+
+                if !matches!(outcome, ToolOutcome::Success(_))
+                    || (fingerprint.is_some() && fingerprint == self.previous_call)
+                {
+                    self.budget.no_progress += 1;
+                } else {
+                    self.budget.no_progress = 0;
+                }
+
+                self.previous_call = fingerprint;
+
+                if !self.commit(SessionEvent::ToolResult {
+                    call_id,
+                    outcome: outcome.clone(),
+                }) {
+                    return EndReason::JournalFailed;
+                }
+
+                self.messages.push(Message::Tool {
+                    provider_call_id: call.provider_call_id,
+                    outcome: outcome.clone(),
+                });
+
+                if let Some(reason) = interrupted {
+                    return reason;
+                }
+
+                if matches!(outcome, ToolOutcome::Unknown(_)) {
+                    return EndReason::EffectUnknown;
+                }
+
+                if encode(&self.messages, self.limits.context_bytes).is_err() {
+                    return EndReason::Limit(LimitKind::ContextBytes);
+                }
+            }
+
+            if self.journal.checkpoint().is_err() {
+                return EndReason::JournalFailed;
+            }
+        }
+    }
+
+    fn validate(
+        &self,
+        call_id: &str,
+        call: &ToolCall,
+        names: &HashSet<String>,
+    ) -> Result<ValidatedCall, ToolError> {
+        if !names.contains(&call.name) {
+            return Err(ToolError::UnknownTool);
+        }
+
+        let arguments: serde_json::Value =
+            serde_json::from_str(&call.arguments).map_err(|_| ToolError::InvalidArguments)?;
+
+        if !arguments.is_object() {
+            return Err(ToolError::InvalidArguments);
+        }
+
+        self.tools.validate(&call.name, &arguments)?;
+
+        Ok(ValidatedCall {
+            call_id: call_id.into(),
+            provider_call_id: call.provider_call_id.clone(),
+            name: call.name.clone(),
+            arguments,
+        })
+    }
+
+    fn record_model_failure(&mut self, retryable: bool) -> bool {
+        let usage = Usage {
+            input_tokens: self.budget.reserved_input_tokens,
+            output_tokens: self.budget.reserved_output_tokens,
+            reported: false,
+        };
+
+        self.budget.reserved_input_tokens = 0;
+        self.budget.reserved_output_tokens = 0;
+        self.budget.charge(&usage);
+
+        self.commit(SessionEvent::ModelFailed { retryable, usage })
+    }
+
+    fn stop(&self, cancellation: &Cancellation, deadline: Instant) -> Option<EndReason> {
+        if cancellation.is_cancelled() {
+            Some(EndReason::Cancelled)
+        } else if Instant::now() >= deadline {
+            Some(EndReason::Limit(LimitKind::Elapsed))
+        } else if self.budget.tokens() >= self.limits.tokens {
+            Some(EndReason::Limit(LimitKind::Tokens))
+        } else if self.budget.no_progress >= self.limits.no_progress {
+            Some(EndReason::Limit(LimitKind::NoProgress))
+        } else {
+            None
+        }
+    }
+
+    fn update_elapsed(&mut self) {
+        self.budget.elapsed_ms = self.started.map_or(0, |start| {
+            start.elapsed().as_millis().min(u64::MAX as u128) as u64
+        });
+    }
+
+    fn commit(&mut self, event: SessionEvent) -> bool {
+        if !matches!(event, SessionEvent::Started { .. }) {
+            self.update_elapsed();
+        }
+
+        match self.journal.append(event, &self.budget) {
+            Ok(record) => {
+                self.host.committed(&record);
+                true
+            }
+            Err(_) => false,
+        }
+    }
+
+    fn journal_failure(&self) -> SessionEnd {
+        SessionEnd {
+            reason: EndReason::JournalFailed,
+            budget: self.budget.clone(),
+            durable: false,
+        }
+    }
+}
+
+async fn interrupt<T>(
+    future: impl std::future::Future<Output = T>,
+    cancellation: &Cancellation,
+    deadline: Instant,
+) -> Result<T, EndReason> {
+    tokio::select! {
+        biased;
+        _ = cancellation.cancelled() => Err(EndReason::Cancelled),
+        _ = tokio::time::sleep_until(deadline) => Err(EndReason::Limit(LimitKind::Elapsed)),
+        output = future => Ok(output),
+    }
+}

--- a/src/nano/engine.rs
+++ b/src/nano/engine.rs
@@ -287,7 +287,7 @@ impl<P: Provider, T: Tools, H: Host, J: Journal> Engine<P, T, H, J> {
                 return EndReason::ProviderProtocol;
             }
 
-            if response.calls.is_empty() && !response.text.trim().is_empty() {
+            if response.is_final() {
                 if self.journal.checkpoint().is_err() {
                     return EndReason::JournalFailed;
                 }

--- a/src/nano/ferrus.rs
+++ b/src/nano/ferrus.rs
@@ -33,6 +33,7 @@ impl LaunchContext {
                 .filter(|value| !value.trim().is_empty())
                 .with_context(|| format!("Missing managed launch context: {key}"))
         };
+
         let baseline_tree = get(ENV_BASELINE_TREE);
         ensure!(
             baseline_tree
@@ -40,6 +41,7 @@ impl LaunchContext {
                 .is_none_or(|value| !value.trim().is_empty()),
             "Empty managed baseline tree"
         );
+
         Ok(Self {
             project_root: PathBuf::from(required(ENV_PROJECT_ROOT)?),
             workspace,
@@ -69,10 +71,12 @@ impl FerrusSession {
                 && !launch.run_id.trim().is_empty(),
             "Missing managed launch identity"
         );
+
         ensure!(
             launch.project_root.is_absolute() && launch.workspace.is_absolute(),
             "Managed launch paths must be absolute"
         );
+
         let project_root = tokio::fs::canonicalize(&launch.project_root).await?;
         let workspace = tokio::fs::canonicalize(&launch.workspace).await?;
         let registration = project::read_project_registration_at(&project_root).await?;
@@ -91,10 +95,12 @@ impl FerrusSession {
                 && !launch.task_id.contains(['/', '\\']),
             "Invalid managed task ID"
         );
+
         let baseline_path = registration
             .data_dir
             .join("worktrees/.baseline-trees")
             .join(format!("{}.txt", launch.task_id));
+
         let session = Self {
             scope: ExecutorSessionScope {
                 database_path: registration.database_path,
@@ -109,6 +115,7 @@ impl FerrusSession {
             baseline_tree: launch.baseline_tree,
             baseline_path,
         };
+
         session.status().await?;
         Ok(session)
     }
@@ -116,9 +123,11 @@ impl FerrusSession {
     pub(crate) fn project_id(&self) -> &str {
         &self.project_id
     }
+
     pub(crate) fn project_root(&self) -> &std::path::Path {
         &self.project_root
     }
+
     pub(crate) fn baseline_tree(&self) -> Option<&str> {
         self.baseline_tree.as_deref()
     }
@@ -147,6 +156,7 @@ impl FerrusSession {
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
             Err(error) => return Err(error.into()),
         };
+
         ensure!(
             recorded.as_ref().is_none_or(|value| !value.is_empty())
                 && recorded == self.baseline_tree,
@@ -159,6 +169,7 @@ impl FerrusSession {
                     && !tokio::fs::try_exists(self.project_root.join(".git")).await?),
             "Managed Git workspace requires a baseline tree"
         );
+
         Ok(())
     }
 }

--- a/src/nano/journal.rs
+++ b/src/nano/journal.rs
@@ -1,0 +1,444 @@
+//! Durable single-writer JSONL storage, bounded artifacts, and atomic prefix checkpoints.
+
+use super::{
+    private,
+    replay::{JOURNAL_VERSION, Replay},
+    session::{Budget, Record, SessionEvent},
+};
+use anyhow::{Context, Result, ensure};
+use fs2::FileExt;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::{
+    fs::{self, File},
+    io::{BufRead, BufReader, Read, Seek, SeekFrom, Write},
+    path::{Path, PathBuf},
+};
+
+#[derive(Debug, Clone)]
+pub(crate) struct Quotas {
+    pub record_bytes: usize,
+    pub journal_bytes: u64,
+    pub artifact_bytes: usize,
+    pub total_bytes: u64,
+    pub files: usize,
+}
+
+impl Default for Quotas {
+    fn default() -> Self {
+        Self {
+            record_bytes: 512 * 1024,
+            journal_bytes: 16 * 1024 * 1024,
+            artifact_bytes: 1024 * 1024,
+            total_bytes: 32 * 1024 * 1024,
+            files: 256,
+        }
+    }
+}
+
+pub(crate) trait Journal {
+    fn append(&mut self, event: SessionEvent, budget: &Budget) -> Result<Record>;
+
+    fn checkpoint(&mut self) -> Result<()>;
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct Checkpoint {
+    pub version: u32,
+    pub session_id: String,
+    pub sequence: u64,
+    pub budget: Budget,
+    pub prefix_sha256: String,
+}
+
+pub(crate) struct FileJournal {
+    directory: PathBuf,
+    _lock: File,
+    file: File,
+    quotas: Quotas,
+    state: Replay,
+    session_id: String,
+    journal_bytes: u64,
+    total_bytes: u64,
+    files: usize,
+    digest: Sha256,
+    poisoned: bool,
+}
+
+pub(crate) fn valid_id(id: &str) -> bool {
+    !id.is_empty()
+        && id.len() <= 96
+        && id
+            .bytes()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, b'-' | b'_'))
+}
+
+/// Bound serialization itself, not just the resulting allocation.
+pub(crate) fn encode<T: Serialize>(value: &T, limit: usize) -> Result<Vec<u8>> {
+    struct Bounded {
+        bytes: Vec<u8>,
+        limit: usize,
+    }
+
+    impl Write for Bounded {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            if bytes.len() > self.limit.saturating_sub(self.bytes.len()) {
+                return Err(std::io::Error::other(
+                    "Serialized output exceeds byte limit",
+                ));
+            }
+
+            self.bytes.extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    let mut output = Bounded {
+        bytes: Vec::new(),
+        limit,
+    };
+
+    serde_json::to_writer(&mut output, value)?;
+    Ok(output.bytes)
+}
+
+impl FileJournal {
+    pub(crate) fn create(project_data: &Path, session_id: &str, quotas: Quotas) -> Result<Self> {
+        ensure!(valid_id(session_id), "Invalid nano session ID");
+        ensure!(
+            project_data.is_absolute() && project_data.is_dir(),
+            "Registered project data must exist"
+        );
+        ensure!(
+            quotas.record_bytes > 0
+                && quotas.journal_bytes > 0
+                && quotas.total_bytes > 0
+                && quotas.artifact_bytes > 0
+                && quotas.files >= 2,
+            "Invalid journal quotas"
+        );
+
+        let root = project_data.canonicalize()?;
+        let nano = root.join("nano");
+        private::directory(&nano, false)?;
+
+        let sessions = nano.join("sessions");
+        private::directory(&sessions, false)?;
+
+        let directory = sessions.join(session_id);
+        private::directory(&directory, true)?;
+        private::directory(&directory.join("outputs"), true)?;
+        private::directory(&directory.join("checkpoints"), true)?;
+
+        let lock = private::file(&directory.join("writer.lock"), true)?;
+        lock.try_lock_exclusive()
+            .context("Nano journal already has a writer")?;
+
+        let file = private::file(&directory.join("events.jsonl"), true)?;
+        private::sync_directory(&directory)?;
+        private::sync_directory(&sessions)?;
+        private::sync_directory(&nano)?;
+        private::sync_directory(&root)?;
+
+        Ok(Self {
+            directory,
+            _lock: lock,
+            file,
+            quotas,
+            state: Replay::default(),
+            session_id: session_id.into(),
+            journal_bytes: 0,
+            total_bytes: 0,
+            files: 2,
+            digest: Sha256::new(),
+            poisoned: false,
+        })
+    }
+
+    /// Repair only an unterminated final line. Complete corrupt records fail closed.
+    /// Opening a journal never executes or resumes recorded effects.
+    pub(crate) fn recover(directory: &Path, quotas: Quotas) -> Result<(Self, Vec<Record>)> {
+        private::check(directory, true)?;
+        let session_id = directory
+            .file_name()
+            .and_then(|name| name.to_str())
+            .context("Invalid session directory")?
+            .to_string();
+
+        ensure!(valid_id(&session_id), "Invalid nano session ID");
+        let lock = private::file(&directory.join("writer.lock"), false)?;
+
+        lock.try_lock_exclusive()
+            .context("Nano journal already has a writer")?;
+
+        let (mut total_bytes, files) = measure(directory, &quotas)?;
+        let mut file = private::file(&directory.join("events.jsonl"), false)?;
+        let size = file.metadata()?.len();
+        ensure!(size <= quotas.journal_bytes, "Journal exceeds quota");
+
+        let max_line_bytes = quotas
+            .record_bytes
+            .checked_add(2)
+            .context("Record quota overflow")? as u64;
+
+        let mut reader = BufReader::new(file.try_clone()?);
+        let mut records = Vec::new();
+        let mut state = Replay::default();
+        let mut digest = Sha256::new();
+        let mut committed_bytes = 0;
+
+        loop {
+            let mut line = Vec::new();
+            // read_until alone could allocate the whole file for a corrupt line.
+            let count = reader
+                .by_ref()
+                .take(max_line_bytes)
+                .read_until(b'\n', &mut line)?;
+
+            if count == 0 {
+                break;
+            }
+
+            ensure!(
+                count <= quotas.record_bytes + 1,
+                "Journal record exceeds quota"
+            );
+
+            if line.last() != Some(&b'\n') {
+                break;
+            }
+
+            let record: Record = serde_json::from_slice(&line)?;
+            ensure!(
+                record.session_id == session_id,
+                "Session directory/record mismatch"
+            );
+
+            state.apply(&record)?;
+            digest.update(&line);
+            committed_bytes += count as u64;
+            records.push(record);
+        }
+
+        if committed_bytes < size {
+            file.set_len(committed_bytes)?;
+            file.sync_all()?;
+            total_bytes -= size - committed_bytes;
+        }
+
+        file.seek(SeekFrom::End(0))?;
+
+        Ok((
+            Self {
+                directory: directory.to_path_buf(),
+                _lock: lock,
+                file,
+                quotas,
+                state,
+                session_id,
+                journal_bytes: committed_bytes,
+                total_bytes,
+                files,
+                digest,
+                poisoned: false,
+            },
+            records,
+        ))
+    }
+
+    pub(crate) fn state(&self) -> &Replay {
+        &self.state
+    }
+
+    pub(crate) fn directory(&self) -> &Path {
+        &self.directory
+    }
+
+    pub(crate) fn artifact(&mut self, output_id: &str, bytes: &[u8]) -> Result<PathBuf> {
+        ensure!(valid_id(output_id), "Invalid output ID");
+        ensure!(
+            bytes.len() <= self.quotas.artifact_bytes,
+            "Artifact exceeds quota"
+        );
+
+        let path = self.directory.join("outputs").join(output_id);
+        self.atomic_file(&path, bytes)?;
+
+        Ok(path)
+    }
+
+    fn atomic_file(&mut self, path: &Path, bytes: &[u8]) -> Result<()> {
+        ensure!(!self.poisoned, "Journal writer is poisoned");
+        ensure!(
+            self.files < self.quotas.files
+                && bytes.len() as u64 <= self.quotas.total_bytes.saturating_sub(self.total_bytes),
+            "Session storage quota exhausted"
+        );
+        ensure!(
+            !path.try_exists()?,
+            "Immutable session artifact already exists"
+        );
+
+        let temporary = path.with_extension("tmp");
+        let result = (|| {
+            let mut file = private::file(&temporary, true)?;
+            file.write_all(bytes)?;
+            file.sync_all()?;
+            drop(file);
+            private::rename(&temporary, path)?;
+            private::sync_directory(path.parent().context("Missing artifact directory")?)?;
+            Ok(())
+        })();
+
+        if result.is_err() {
+            self.poisoned = true;
+        } else {
+            self.total_bytes += bytes.len() as u64;
+            self.files += 1;
+        }
+
+        result
+    }
+}
+
+impl Journal for FileJournal {
+    fn append(&mut self, event: SessionEvent, budget: &Budget) -> Result<Record> {
+        ensure!(!self.poisoned, "Journal writer is poisoned");
+        let record = Record {
+            version: JOURNAL_VERSION,
+            session_id: self.session_id.clone(),
+            sequence: self.state.sequence + 1,
+            budget: budget.clone(),
+            event,
+        };
+
+        let mut next = self.state.clone();
+        next.apply(&record)?;
+
+        let mut bytes = encode(&record, self.quotas.record_bytes)?;
+        bytes.push(b'\n');
+
+        ensure!(
+            bytes.len() as u64 <= self.quotas.journal_bytes.saturating_sub(self.journal_bytes)
+                && bytes.len() as u64 <= self.quotas.total_bytes.saturating_sub(self.total_bytes),
+            "Journal quota exhausted"
+        );
+
+        if let Err(error) = self
+            .file
+            .write_all(&bytes)
+            .and_then(|_| self.file.sync_all())
+        {
+            self.poisoned = true;
+            return Err(error.into());
+        }
+
+        self.digest.update(&bytes);
+        self.journal_bytes += bytes.len() as u64;
+        self.total_bytes += bytes.len() as u64;
+        self.state = next;
+
+        Ok(record)
+    }
+
+    fn checkpoint(&mut self) -> Result<()> {
+        ensure!(
+            self.state.checkpoint_ready(),
+            "Checkpoint would split a model/tool group"
+        );
+
+        let checkpoint = Checkpoint {
+            version: JOURNAL_VERSION,
+            session_id: self.session_id.clone(),
+            sequence: self.state.sequence,
+            budget: self.state.budget.clone(),
+            prefix_sha256: hex_digest(self.digest.clone()),
+        };
+
+        let bytes = encode(&checkpoint, self.quotas.record_bytes)?;
+        let path = self
+            .directory
+            .join("checkpoints")
+            .join(format!("{}.json", self.state.sequence));
+
+        self.atomic_file(&path, &bytes)
+    }
+}
+
+pub(crate) fn verify_checkpoint(checkpoint: &Checkpoint, records: &[Record]) -> Result<Replay> {
+    ensure!(
+        checkpoint.version == JOURNAL_VERSION,
+        "Unsupported checkpoint version"
+    );
+
+    let count = usize::try_from(checkpoint.sequence)?;
+    ensure!(count <= records.len(), "Checkpoint exceeds journal prefix");
+
+    let prefix = &records[..count];
+    let state = Replay::from_records(prefix)?;
+    ensure!(
+        state.checkpoint_ready()
+            && state.session_id == checkpoint.session_id
+            && state.budget == checkpoint.budget,
+        "Checkpoint does not match a complete journal group"
+    );
+
+    let mut digest = Sha256::new();
+    for record in prefix {
+        digest.update(serde_json::to_vec(record)?);
+        digest.update(b"\n");
+    }
+
+    ensure!(
+        hex_digest(digest) == checkpoint.prefix_sha256,
+        "Checkpoint digest mismatch"
+    );
+
+    Ok(state)
+}
+
+fn measure(directory: &Path, quotas: &Quotas) -> Result<(u64, usize)> {
+    let mut bytes = 0u64;
+    let mut files = 0;
+
+    for dir in [
+        directory.to_path_buf(),
+        directory.join("outputs"),
+        directory.join("checkpoints"),
+    ] {
+        private::check(&dir, true)?;
+        for entry in fs::read_dir(&dir)? {
+            let path = entry?.path();
+            if dir == directory
+                && matches!(
+                    path.file_name().and_then(|n| n.to_str()),
+                    Some("outputs" | "checkpoints")
+                )
+            {
+                continue;
+            }
+            private::check(&path, false)?;
+            files += 1;
+            bytes = bytes.saturating_add(fs::metadata(path)?.len());
+            ensure!(
+                files <= quotas.files && bytes <= quotas.total_bytes,
+                "Session storage exceeds quota"
+            );
+        }
+    }
+
+    Ok((bytes, files))
+}
+
+fn hex_digest(digest: Sha256) -> String {
+    digest
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}

--- a/src/nano/journal.rs
+++ b/src/nano/journal.rs
@@ -406,10 +406,16 @@ fn measure(directory: &Path, quotas: &Quotas) -> Result<(u64, usize)> {
     let mut bytes = 0u64;
     let mut files = 0;
 
-    for dir in [
-        directory.to_path_buf(),
-        directory.join("outputs"),
-        directory.join("checkpoints"),
+    for (dir, per_file_quota) in [
+        (directory.to_path_buf(), None),
+        (
+            directory.join("outputs"),
+            Some((quotas.artifact_bytes, "Artifact exceeds quota")),
+        ),
+        (
+            directory.join("checkpoints"),
+            Some((quotas.record_bytes, "Checkpoint exceeds quota")),
+        ),
     ] {
         private::check(&dir, true)?;
         for entry in fs::read_dir(&dir)? {
@@ -423,8 +429,15 @@ fn measure(directory: &Path, quotas: &Quotas) -> Result<(u64, usize)> {
                 continue;
             }
             private::check(&path, false)?;
+
+            let size = fs::metadata(path)?.len();
+            if let Some((limit, message)) = per_file_quota {
+                ensure!(size <= limit as u64, "{message}");
+            }
+
             files += 1;
-            bytes = bytes.saturating_add(fs::metadata(path)?.len());
+            bytes = bytes.saturating_add(size);
+
             ensure!(
                 files <= quotas.files && bytes <= quotas.total_bytes,
                 "Session storage exceeds quota"

--- a/src/nano/journal.rs
+++ b/src/nano/journal.rs
@@ -3,7 +3,7 @@
 use super::{
     private,
     replay::{JOURNAL_VERSION, Replay},
-    session::{Budget, Record, SessionEvent},
+    session::{Budget, EndReason, LimitKind, Record, SessionEvent},
 };
 use anyhow::{Context, Result, ensure};
 use fs2::FileExt;
@@ -161,6 +161,7 @@ impl FileJournal {
     }
 
     /// Repair only an unterminated final line. Complete corrupt records fail closed.
+    /// Charge the remaining elapsed budget and end any interrupted attempt durably.
     /// Opening a journal never executes or resumes recorded effects.
     pub(crate) fn recover(directory: &Path, quotas: Quotas) -> Result<(Self, Vec<Record>)> {
         private::check(directory, true)?;
@@ -233,22 +234,41 @@ impl FileJournal {
 
         file.seek(SeekFrom::End(0))?;
 
-        Ok((
-            Self {
-                directory: directory.to_path_buf(),
-                _lock: lock,
-                file,
-                quotas,
-                state,
-                session_id,
-                journal_bytes: committed_bytes,
-                total_bytes,
-                files,
-                digest,
-                poisoned: false,
-            },
-            records,
-        ))
+        let mut journal = Self {
+            directory: directory.to_path_buf(),
+            _lock: lock,
+            file,
+            quotas,
+            state,
+            session_id,
+            journal_bytes: committed_bytes,
+            total_bytes,
+            files,
+            digest,
+            poisoned: false,
+        };
+
+        if journal.state.end.is_none()
+            && let Some(Record {
+                event: SessionEvent::Started { limits, .. },
+                ..
+            }) = records.first()
+        {
+            // The process-local clock cannot account for an uncommitted wait.
+            // Exhaust the remaining allowance even at a complete checkpoint;
+            // keep pending effects and token reservations for reconciliation.
+            let mut budget = journal.state.budget.clone();
+            budget.elapsed_ms = budget.elapsed_ms.max(limits.elapsed_ms);
+
+            records.push(journal.append(
+                SessionEvent::Ended {
+                    reason: EndReason::Limit(LimitKind::Elapsed),
+                },
+                &budget,
+            )?);
+        }
+
+        Ok((journal, records))
     }
 
     pub(crate) fn state(&self) -> &Replay {

--- a/src/nano/journal_tests.rs
+++ b/src/nano/journal_tests.rs
@@ -1,0 +1,352 @@
+//! Storage recovery, integrity, quotas, private permissions, and checkpoint boundaries.
+
+use super::{
+    journal::*,
+    provider::{FinishReason, ModelResponse, Usage},
+    session::*,
+    tools::*,
+};
+use serde_json::json;
+use std::{
+    fs::{self, OpenOptions},
+    io::Write,
+};
+use tempfile::TempDir;
+
+fn create(quotas: Quotas) -> (TempDir, FileJournal) {
+    let dir = TempDir::new().unwrap();
+    let journal = FileJournal::create(&dir.path().canonicalize().unwrap(), "s-1", quotas).unwrap();
+    (dir, journal)
+}
+
+fn started(journal: &mut FileJournal) -> Record {
+    journal
+        .append(
+            SessionEvent::Started {
+                identity: SessionIdentity {
+                    session_id: "s-1".into(),
+                    project_id: "p-1".into(),
+                    task_id: None,
+                    run_id: None,
+                },
+                limits: Limits::default(),
+                input: "task".into(),
+            },
+            &Budget::default(),
+        )
+        .unwrap()
+}
+
+fn model_group(journal: &mut FileJournal) -> (Budget, Vec<ToolCall>) {
+    let mut budget = Budget {
+        model_turns: 1,
+        reserved_input_tokens: 20,
+        reserved_output_tokens: 30,
+        ..Default::default()
+    };
+
+    journal
+        .append(SessionEvent::ModelStarted { turn: 1 }, &budget)
+        .unwrap();
+
+    let calls = vec![
+        ToolCall {
+            provider_call_id: "a".into(),
+            name: "edit".into(),
+            arguments: "{}".into(),
+        },
+        ToolCall {
+            provider_call_id: "b".into(),
+            name: "edit".into(),
+            arguments: "{}".into(),
+        },
+    ];
+
+    budget.reserved_input_tokens = 0;
+    budget.reserved_output_tokens = 0;
+    budget.reported_input_tokens = 12;
+    budget.reported_output_tokens = 8;
+
+    journal
+        .append(
+            SessionEvent::ModelCompleted {
+                response: ModelResponse {
+                    finish: FinishReason::ToolCalls,
+                    text: String::new(),
+                    calls: calls.clone(),
+                    continuation: None,
+                },
+                usage: Usage {
+                    input_tokens: 12,
+                    output_tokens: 8,
+                    reported: true,
+                },
+            },
+            &budget,
+        )
+        .unwrap();
+    (budget, calls)
+}
+
+#[test]
+fn interrupted_tail_is_removed_but_complete_corruption_is_not_rewritten() {
+    let (_dir, mut journal) = create(Quotas::default());
+    let record = started(&mut journal);
+    let directory = journal.directory().to_path_buf();
+    let path = directory.join("events.jsonl");
+    let size = fs::metadata(&path).unwrap().len();
+    drop(journal);
+    OpenOptions::new()
+        .append(true)
+        .open(&path)
+        .unwrap()
+        .write_all(b"{\"version\":1")
+        .unwrap();
+    let (journal, records) = FileJournal::recover(&directory, Quotas::default()).unwrap();
+    assert_eq!(records, [record]);
+    assert_eq!(fs::metadata(&path).unwrap().len(), size);
+    drop(journal);
+    OpenOptions::new()
+        .append(true)
+        .open(&path)
+        .unwrap()
+        .write_all(b"corrupt\n")
+        .unwrap();
+    let size = fs::metadata(&path).unwrap().len();
+    assert!(FileJournal::recover(&directory, Quotas::default()).is_err());
+    assert_eq!(fs::metadata(&path).unwrap().len(), size);
+}
+
+#[test]
+fn duplicate_writer_and_duplicate_session_creation_are_rejected() {
+    let (dir, journal) = create(Quotas::default());
+    assert!(FileJournal::recover(journal.directory(), Quotas::default()).is_err());
+    assert!(
+        FileJournal::create(
+            &dir.path().canonicalize().unwrap(),
+            "s-1",
+            Quotas::default()
+        )
+        .is_err()
+    );
+    assert!(
+        FileJournal::create(
+            &dir.path().canonicalize().unwrap(),
+            "../escape",
+            Quotas::default()
+        )
+        .is_err()
+    );
+    let directory = journal.directory().to_path_buf();
+    drop(journal);
+    assert!(FileJournal::recover(&directory, Quotas::default()).is_ok());
+}
+
+#[test]
+fn checkpoints_require_whole_model_tool_groups_and_verified_prefixes() {
+    let (_dir, mut journal) = create(Quotas::default());
+    started(&mut journal);
+    let (mut budget, calls) = model_group(&mut journal);
+    assert!(journal.checkpoint().is_err());
+    for (index, call) in calls.into_iter().enumerate() {
+        budget.tool_calls += 1;
+        let call_id = format!("call-{}", budget.tool_calls);
+        journal
+            .append(
+                SessionEvent::ToolIntent {
+                    call_id: call_id.clone(),
+                    call,
+                },
+                &budget,
+            )
+            .unwrap();
+        assert!(journal.checkpoint().is_err());
+        journal
+            .append(
+                SessionEvent::ToolResult {
+                    call_id,
+                    outcome: ToolOutcome::Success(json!("ok")),
+                },
+                &budget,
+            )
+            .unwrap();
+        if index == 0 {
+            assert!(journal.checkpoint().is_err());
+        }
+    }
+    journal.checkpoint().unwrap();
+    let directory = journal.directory().to_path_buf();
+    let checkpoint_path = directory
+        .join("checkpoints")
+        .join(format!("{}.json", journal.state().sequence));
+    let mut checkpoint: Checkpoint =
+        serde_json::from_slice(&fs::read(&checkpoint_path).unwrap()).unwrap();
+    assert!(
+        fs::read_dir(directory.join("checkpoints"))
+            .unwrap()
+            .all(|entry| entry.unwrap().path().extension().unwrap() == "json")
+    );
+    drop(journal);
+    let (_, records) = FileJournal::recover(&directory, Quotas::default()).unwrap();
+    assert_eq!(
+        verify_checkpoint(&checkpoint, &records).unwrap().budget,
+        budget
+    );
+    checkpoint.budget.tool_calls += 1;
+    assert!(verify_checkpoint(&checkpoint, &records).is_err());
+}
+
+#[test]
+fn crash_during_model_request_preserves_reserved_usage_and_pending_tool_is_not_replayed() {
+    let (_dir, mut journal) = create(Quotas::default());
+    started(&mut journal);
+    let budget = Budget {
+        model_turns: 1,
+        reserved_input_tokens: 12,
+        reserved_output_tokens: 48,
+        ..Default::default()
+    };
+    journal
+        .append(SessionEvent::ModelStarted { turn: 1 }, &budget)
+        .unwrap();
+    let directory = journal.directory().to_path_buf();
+    drop(journal);
+    let (journal, _) = FileJournal::recover(&directory, Quotas::default()).unwrap();
+    assert_eq!(journal.state().budget.tokens(), 60);
+    assert!(!journal.state().checkpoint_ready());
+}
+
+#[test]
+fn bounded_artifacts_are_immutable_and_session_quotas_include_checkpoints() {
+    let quotas = Quotas {
+        artifact_bytes: 4,
+        files: 3,
+        ..Default::default()
+    };
+    let (_dir, mut journal) = create(quotas);
+    started(&mut journal);
+    assert!(journal.artifact("too-big", b"12345").is_err());
+    assert!(journal.artifact("../escape", b"1").is_err());
+    let path = journal.artifact("output-1", b"1234").unwrap();
+    assert_eq!(fs::read(&path).unwrap(), b"1234");
+    assert!(journal.artifact("output-1", b"0000").is_err());
+    assert_eq!(fs::read(&path).unwrap(), b"1234");
+    assert!(journal.checkpoint().is_err());
+    assert!(journal.artifact("output-2", b"1").is_err());
+}
+
+#[test]
+fn record_and_total_byte_quotas_fail_before_writing() {
+    for quotas in [
+        Quotas {
+            record_bytes: 10,
+            ..Default::default()
+        },
+        Quotas {
+            total_bytes: 10,
+            ..Default::default()
+        },
+        Quotas {
+            journal_bytes: 10,
+            ..Default::default()
+        },
+    ] {
+        let (_dir, mut journal) = create(quotas);
+        assert!(
+            journal
+                .append(
+                    SessionEvent::Started {
+                        identity: SessionIdentity {
+                            session_id: "s-1".into(),
+                            project_id: "p".into(),
+                            task_id: None,
+                            run_id: None
+                        },
+                        limits: Limits::default(),
+                        input: "task".into()
+                    },
+                    &Budget::default()
+                )
+                .is_err()
+        );
+        assert_eq!(
+            fs::metadata(journal.directory().join("events.jsonl"))
+                .unwrap()
+                .len(),
+            0
+        );
+    }
+    assert!(encode(&json!({"data":"x".repeat(10000)}), 10).is_err());
+}
+
+#[test]
+fn versions_sequences_and_mixed_session_ids_are_rejected() {
+    for corruption in ["version", "sequence", "session_id"] {
+        let (_dir, mut journal) = create(Quotas::default());
+        let mut record = started(&mut journal);
+        let directory = journal.directory().to_path_buf();
+        drop(journal);
+        match corruption {
+            "version" => record.version += 1,
+            "sequence" => record.sequence += 1,
+            _ => record.session_id = "other".into(),
+        }
+        let mut bytes = serde_json::to_vec(&record).unwrap();
+        bytes.push(b'\n');
+        fs::write(directory.join("events.jsonl"), &bytes).unwrap();
+        assert!(
+            FileJournal::recover(&directory, Quotas::default()).is_err(),
+            "{corruption}"
+        );
+    }
+}
+
+#[test]
+fn private_permissions_are_enforced_for_new_storage_and_recovery() {
+    let (_dir, mut journal) = create(Quotas::default());
+    started(&mut journal);
+    let output = journal.artifact("output-1", b"private").unwrap();
+    for path in [
+        journal.directory().join("events.jsonl"),
+        journal.directory().join("writer.lock"),
+        output,
+    ] {
+        super::private::check(&path, false).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                fs::metadata(path).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
+    }
+    super::private::check(journal.directory(), true).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let directory = journal.directory().to_path_buf();
+        drop(journal);
+        fs::set_permissions(
+            directory.join("events.jsonl"),
+            fs::Permissions::from_mode(0o644),
+        )
+        .unwrap();
+        assert!(FileJournal::recover(&directory, Quotas::default()).is_err());
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn symlinks_cannot_redirect_artifacts_or_recovery() {
+    use std::os::unix::fs::symlink;
+    let (dir, mut journal) = create(Quotas::default());
+    let outside = dir.path().join("outside");
+    fs::write(&outside, b"keep").unwrap();
+    symlink(&outside, journal.directory().join("outputs/redirect")).unwrap();
+    assert!(journal.artifact("redirect", b"replace").is_err());
+    let directory = journal.directory().to_path_buf();
+    drop(journal);
+    assert!(FileJournal::recover(&directory, Quotas::default()).is_err());
+    assert_eq!(fs::read(outside).unwrap(), b"keep");
+}

--- a/src/nano/journal_tests.rs
+++ b/src/nano/journal_tests.rs
@@ -236,6 +236,64 @@ fn bounded_artifacts_are_immutable_and_session_quotas_include_checkpoints() {
 }
 
 #[test]
+fn recovery_enforces_per_file_quotas_for_outputs_and_checkpoints() {
+    for checkpoint in [false, true] {
+        for lower_quota in [false, true] {
+            let mut quotas = Quotas {
+                artifact_bytes: 1024,
+                record_bytes: 2048,
+                ..Default::default()
+            };
+            let (_dir, mut journal) = create(quotas.clone());
+            started(&mut journal);
+            let directory = journal.directory().to_path_buf();
+            let (path, limit, error) = if checkpoint {
+                journal.checkpoint().unwrap();
+                (
+                    directory.join("checkpoints/1.json"),
+                    quotas.record_bytes,
+                    "Checkpoint exceeds quota",
+                )
+            } else {
+                (
+                    journal.artifact("output-1", b"private").unwrap(),
+                    quotas.artifact_bytes,
+                    "Artifact exceeds quota",
+                )
+            };
+            drop(journal);
+
+            // Whitespace padding keeps checkpoint JSON valid and makes its size
+            // larger than the journal record, isolating the checkpoint quota.
+            let mut bytes = fs::read(&path).unwrap();
+            bytes.resize(limit, b' ');
+            fs::write(&path, &bytes).unwrap();
+            drop(FileJournal::recover(&directory, quotas.clone()).unwrap());
+
+            if lower_quota {
+                if checkpoint {
+                    quotas.record_bytes -= 1;
+                } else {
+                    quotas.artifact_bytes -= 1;
+                }
+            } else {
+                bytes.push(b' ');
+                fs::write(&path, &bytes).unwrap();
+            }
+
+            let result = FileJournal::recover(&directory, quotas);
+            assert_eq!(
+                result.err().expect("Oversized file accepted").to_string(),
+                error
+            );
+            assert_eq!(fs::read(&path).unwrap(), bytes);
+            // A quota rejection must release the writer lock for a later reopen.
+            assert!(FileJournal::recover(&directory, Quotas::default()).is_ok());
+        }
+    }
+}
+
+#[test]
 fn record_and_total_byte_quotas_fail_before_writing() {
     for quotas in [
         Quotas {

--- a/src/nano/journal_tests.rs
+++ b/src/nano/journal_tests.rs
@@ -126,6 +126,49 @@ fn interrupted_tail_is_removed_but_complete_corruption_is_not_rewritten() {
 }
 
 #[test]
+fn overlong_complete_records_are_rejected_without_rewriting_the_journal() {
+    let quotas = Quotas {
+        record_bytes: 2048,
+        ..Default::default()
+    };
+    for extra_bytes in [0, 1, 2, 8192] {
+        let (_dir, mut journal) = create(quotas.clone());
+        let started = started(&mut journal);
+        let directory = journal.directory().to_path_buf();
+        let path = directory.join("events.jsonl");
+        let end = Record {
+            sequence: 2,
+            event: SessionEvent::Ended {
+                reason: EndReason::Cancelled,
+            },
+            ..started
+        };
+        drop(journal);
+
+        let mut line = serde_json::to_vec(&end).unwrap();
+        line.resize(quotas.record_bytes + extra_bytes, b' ');
+        line.push(b'\n');
+        OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap()
+            .write_all(&line)
+            .unwrap();
+        let original = fs::read(&path).unwrap();
+        let result = FileJournal::recover(&directory, quotas.clone());
+        if extra_bytes == 0 {
+            assert_eq!(result.unwrap().0.state().end, Some(EndReason::Cancelled));
+        } else {
+            assert_eq!(
+                result.err().expect("Overlong record accepted").to_string(),
+                "Journal record exceeds quota"
+            );
+        }
+        assert_eq!(fs::read(&path).unwrap(), original);
+    }
+}
+
+#[test]
 fn duplicate_writer_and_duplicate_session_creation_are_rejected() {
     let (dir, journal) = create(Quotas::default());
     assert!(FileJournal::recover(journal.directory(), Quotas::default()).is_err());

--- a/src/nano/journal_tests.rs
+++ b/src/nano/journal_tests.rs
@@ -92,6 +92,14 @@ fn model_group(journal: &mut FileJournal) -> (Budget, Vec<ToolCall>) {
 fn interrupted_tail_is_removed_but_complete_corruption_is_not_rewritten() {
     let (_dir, mut journal) = create(Quotas::default());
     let record = started(&mut journal);
+    let ended = journal
+        .append(
+            SessionEvent::Ended {
+                reason: EndReason::Cancelled,
+            },
+            &Budget::default(),
+        )
+        .unwrap();
     let directory = journal.directory().to_path_buf();
     let path = directory.join("events.jsonl");
     let size = fs::metadata(&path).unwrap().len();
@@ -103,7 +111,7 @@ fn interrupted_tail_is_removed_but_complete_corruption_is_not_rewritten() {
         .write_all(b"{\"version\":1")
         .unwrap();
     let (journal, records) = FileJournal::recover(&directory, Quotas::default()).unwrap();
-    assert_eq!(records, [record]);
+    assert_eq!(records, [record, ended]);
     assert_eq!(fs::metadata(&path).unwrap().len(), size);
     drop(journal);
     OpenOptions::new()
@@ -214,6 +222,135 @@ fn crash_during_model_request_preserves_reserved_usage_and_pending_tool_is_not_r
     let (journal, _) = FileJournal::recover(&directory, Quotas::default()).unwrap();
     assert_eq!(journal.state().budget.tokens(), 60);
     assert!(!journal.state().checkpoint_ready());
+}
+
+#[test]
+fn recovery_charges_unfinished_elapsed_budget_once_and_preserves_pending_work() {
+    for phase in [
+        "started",
+        "provider",
+        "overrun",
+        "tool",
+        "checkpoint",
+        "ended",
+    ] {
+        let (_dir, mut journal) = create(Quotas::default());
+        started(&mut journal);
+        let mut budget = Budget::default();
+        match phase {
+            "provider" | "overrun" => {
+                budget.model_turns = 1;
+                budget.reserved_input_tokens = 12;
+                budget.reserved_output_tokens = 48;
+                budget.elapsed_ms = if phase == "overrun" {
+                    Limits::default().elapsed_ms + 1
+                } else {
+                    10
+                };
+                journal
+                    .append(SessionEvent::ModelStarted { turn: 1 }, &budget)
+                    .unwrap();
+            }
+            "tool" => {
+                let (model_budget, calls) = model_group(&mut journal);
+                budget = model_budget;
+                budget.tool_calls = 1;
+                budget.elapsed_ms = 20;
+                journal
+                    .append(
+                        SessionEvent::ToolIntent {
+                            call_id: "call-1".into(),
+                            call: calls[0].clone(),
+                        },
+                        &budget,
+                    )
+                    .unwrap();
+            }
+            "checkpoint" => journal.checkpoint().unwrap(),
+            "ended" => {
+                budget.elapsed_ms = 30;
+                journal
+                    .append(
+                        SessionEvent::Ended {
+                            reason: EndReason::Cancelled,
+                        },
+                        &budget,
+                    )
+                    .unwrap();
+            }
+            _ => (),
+        }
+        let directory = journal.directory().to_path_buf();
+        let prefix = fs::read(directory.join("events.jsonl")).unwrap();
+        drop(journal);
+
+        let (mut journal, records) = FileJournal::recover(&directory, Quotas::default()).unwrap();
+        let reason = if phase == "ended" {
+            EndReason::Cancelled
+        } else {
+            budget.elapsed_ms = budget.elapsed_ms.max(Limits::default().elapsed_ms);
+            EndReason::Limit(LimitKind::Elapsed)
+        };
+        assert_eq!(journal.state().budget, budget, "{phase}");
+        assert_eq!(journal.state().end, Some(reason.clone()), "{phase}");
+        assert_eq!(
+            journal.state().pending_effect.as_deref(),
+            (phase == "tool").then_some("call-1")
+        );
+        assert_eq!(
+            super::replay::Replay::from_records(&records)
+                .unwrap()
+                .budget,
+            budget
+        );
+        assert!(
+            journal
+                .append(SessionEvent::ModelStarted { turn: 2 }, &budget)
+                .is_err()
+        );
+        let recovered = fs::read(directory.join("events.jsonl")).unwrap();
+        assert!(recovered.starts_with(&prefix));
+        drop(journal);
+        let (journal, repeated) = FileJournal::recover(&directory, Quotas::default()).unwrap();
+        assert_eq!(repeated, records);
+        assert_eq!(journal.state().end, Some(reason));
+        assert_eq!(fs::read(directory.join("events.jsonl")).unwrap(), recovered);
+    }
+}
+
+#[test]
+fn recovery_fails_if_the_elapsed_charge_cannot_be_persisted() {
+    let (_dir, mut journal) = create(Quotas::default());
+    started(&mut journal);
+    let directory = journal.directory().to_path_buf();
+    let path = directory.join("events.jsonl");
+    let prefix = fs::read(&path).unwrap();
+    drop(journal);
+
+    let quotas = Quotas {
+        journal_bytes: prefix.len() as u64,
+        ..Default::default()
+    };
+    assert!(FileJournal::recover(&directory, quotas).is_err());
+    assert_eq!(fs::read(&path).unwrap(), prefix);
+
+    // A torn recovery ending is retried from the same committed budget.
+    OpenOptions::new()
+        .append(true)
+        .open(&path)
+        .unwrap()
+        .write_all(b"{\"version\":1")
+        .unwrap();
+    let (journal, records) = FileJournal::recover(&directory, Quotas::default()).unwrap();
+    assert_eq!(records.len(), 2);
+    assert_eq!(
+        journal.state().budget.elapsed_ms,
+        Limits::default().elapsed_ms
+    );
+    assert_eq!(
+        journal.state().end,
+        Some(EndReason::Limit(LimitKind::Elapsed))
+    );
 }
 
 #[test]

--- a/src/nano/mod.rs
+++ b/src/nano/mod.rs
@@ -1,4 +1,15 @@
-//! Native coding-agent harness. The first slice binds a managed Executor session;
-//! engine, provider, and frontend composition are added independently.
+//! Native agent core and managed Ferrus adapter; frontend and provider wiring are separate.
 
+pub(crate) mod engine;
 pub(crate) mod ferrus;
+pub(crate) mod journal;
+mod private;
+pub(crate) mod provider;
+pub(crate) mod replay;
+pub(crate) mod session;
+pub(crate) mod tools;
+
+#[cfg(test)]
+mod core_tests;
+#[cfg(test)]
+mod journal_tests;

--- a/src/nano/private.rs
+++ b/src/nano/private.rs
@@ -1,0 +1,268 @@
+//! Private journal storage. Reject symlinks and inherited/broad permissions on reopen.
+
+use anyhow::{Result, ensure};
+use std::{
+    fs::{self, File},
+    path::Path,
+};
+
+pub(crate) fn check(path: &Path, directory: bool) -> Result<()> {
+    let metadata = fs::symlink_metadata(path)?;
+    ensure!(
+        if directory {
+            metadata.is_dir()
+        } else {
+            metadata.is_file()
+        },
+        "Unexpected session storage file type"
+    );
+
+    imp::check(path, &metadata)
+}
+
+pub(crate) fn directory(path: &Path, exclusive: bool) -> Result<()> {
+    match imp::directory(path) {
+        Ok(()) => (),
+        Err(error) if !exclusive && error.kind() == std::io::ErrorKind::AlreadyExists => (),
+        Err(error) => return Err(error.into()),
+    }
+
+    check(path, true)
+}
+
+pub(crate) fn file(path: &Path, create: bool) -> Result<File> {
+    if !create {
+        check(path, false)?;
+    }
+
+    let file = imp::file(path, create)?;
+    check(path, false)?;
+
+    Ok(file)
+}
+
+pub(crate) use imp::{rename, sync_directory};
+
+#[cfg(unix)]
+mod imp {
+    use super::*;
+    use std::{
+        fs::{DirBuilder, OpenOptions},
+        os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt, PermissionsExt},
+    };
+
+    pub(super) fn check(_path: &Path, metadata: &fs::Metadata) -> Result<()> {
+        // SAFETY: geteuid has no preconditions and returns the process identity.
+        ensure!(
+            metadata.uid() == unsafe { libc::geteuid() }
+                && metadata.permissions().mode() & 0o077 == 0,
+            "Session storage must be owner-only"
+        );
+
+        Ok(())
+    }
+
+    pub(super) fn directory(path: &Path) -> std::io::Result<()> {
+        DirBuilder::new().mode(0o700).create(path)
+    }
+
+    pub(super) fn file(path: &Path, create: bool) -> std::io::Result<File> {
+        OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create_new(create)
+            .mode(0o600)
+            .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
+            .open(path)
+    }
+
+    pub(crate) fn sync_directory(path: &Path) -> std::io::Result<()> {
+        File::open(path)?.sync_all()
+    }
+
+    pub(crate) fn rename(from: &Path, to: &Path) -> std::io::Result<()> {
+        fs::rename(from, to)
+    }
+}
+
+#[cfg(windows)]
+mod imp {
+    use super::*;
+    use std::{
+        os::windows::{ffi::OsStrExt, io::FromRawHandle},
+        ptr::{null, null_mut},
+    };
+
+    use windows_sys::Win32::{
+        Foundation::{GENERIC_READ, GENERIC_WRITE, INVALID_HANDLE_VALUE, LocalFree},
+        Security::{
+            Authorization::{
+                ConvertSecurityDescriptorToStringSecurityDescriptorW,
+                ConvertStringSecurityDescriptorToSecurityDescriptorW,
+            },
+            DACL_SECURITY_INFORMATION, GetFileSecurityW, PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES,
+        },
+        Storage::FileSystem::{
+            CREATE_NEW, CreateDirectoryW, CreateFileW, FILE_ATTRIBUTE_NORMAL,
+            FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_READ, FILE_SHARE_WRITE,
+            MOVEFILE_WRITE_THROUGH, MoveFileExW, OPEN_EXISTING,
+        },
+    };
+
+    struct Descriptor(PSECURITY_DESCRIPTOR);
+
+    impl Drop for Descriptor {
+        fn drop(&mut self) {
+            unsafe {
+                LocalFree(self.0);
+            }
+        }
+    }
+
+    fn wide(path: &Path) -> Vec<u16> {
+        path.as_os_str().encode_wide().chain(Some(0)).collect()
+    }
+
+    fn descriptor() -> std::io::Result<Descriptor> {
+        // Protected DACL: full access only for the object's owner, no inherited grants.
+        let text: Vec<u16> = "D:P(A;;FA;;;OW)\0".encode_utf16().collect();
+        let mut pointer = null_mut();
+
+        if unsafe {
+            ConvertStringSecurityDescriptorToSecurityDescriptorW(
+                text.as_ptr(),
+                1,
+                &mut pointer,
+                null_mut(),
+            )
+        } == 0
+        {
+            return Err(std::io::Error::last_os_error());
+        }
+
+        Ok(Descriptor(pointer))
+    }
+
+    fn text(descriptor: PSECURITY_DESCRIPTOR) -> std::io::Result<Vec<u16>> {
+        let mut pointer = null_mut();
+        let mut length = 0;
+        if unsafe {
+            ConvertSecurityDescriptorToStringSecurityDescriptorW(
+                descriptor,
+                1,
+                DACL_SECURITY_INFORMATION,
+                &mut pointer,
+                &mut length,
+            )
+        } == 0
+        {
+            return Err(std::io::Error::last_os_error());
+        }
+
+        let value = unsafe { std::slice::from_raw_parts(pointer, length as usize).to_vec() };
+        unsafe {
+            LocalFree(pointer.cast());
+        }
+
+        Ok(value)
+    }
+
+    pub(super) fn check(path: &Path, _: &fs::Metadata) -> Result<()> {
+        let path = wide(path);
+        let mut length = 0;
+
+        unsafe {
+            GetFileSecurityW(
+                path.as_ptr(),
+                DACL_SECURITY_INFORMATION,
+                null_mut(),
+                0,
+                &mut length,
+            );
+        }
+
+        ensure!(length > 0 && length <= 65536, "Cannot inspect session DACL");
+        let mut buffer = vec![0u32; (length as usize).div_ceil(4)];
+
+        ensure!(
+            unsafe {
+                GetFileSecurityW(
+                    path.as_ptr(),
+                    DACL_SECURITY_INFORMATION,
+                    buffer.as_mut_ptr().cast(),
+                    length,
+                    &mut length,
+                )
+            } != 0,
+            "Cannot read session DACL"
+        );
+
+        ensure!(
+            text(buffer.as_mut_ptr().cast())? == text(descriptor()?.0)?,
+            "Session storage must have a protected owner-only DACL"
+        );
+
+        Ok(())
+    }
+    pub(super) fn directory(path: &Path) -> std::io::Result<()> {
+        let descriptor = descriptor()?;
+        let attributes = SECURITY_ATTRIBUTES {
+            nLength: std::mem::size_of::<SECURITY_ATTRIBUTES>() as u32,
+            lpSecurityDescriptor: descriptor.0,
+            bInheritHandle: 0,
+        };
+
+        if unsafe { CreateDirectoryW(wide(path).as_ptr(), &attributes) } == 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+
+        Ok(())
+    }
+
+    pub(super) fn file(path: &Path, create: bool) -> std::io::Result<File> {
+        let descriptor = descriptor()?;
+        let attributes = SECURITY_ATTRIBUTES {
+            nLength: std::mem::size_of::<SECURITY_ATTRIBUTES>() as u32,
+            lpSecurityDescriptor: descriptor.0,
+            bInheritHandle: 0,
+        };
+
+        let handle = unsafe {
+            CreateFileW(
+                wide(path).as_ptr(),
+                GENERIC_READ | GENERIC_WRITE,
+                FILE_SHARE_READ | FILE_SHARE_WRITE,
+                if create { &attributes } else { null() },
+                if create { CREATE_NEW } else { OPEN_EXISTING },
+                FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT,
+                null_mut(),
+            )
+        };
+
+        if handle == INVALID_HANDLE_VALUE {
+            return Err(std::io::Error::last_os_error());
+        }
+
+        // SAFETY: CreateFileW returned a new owned handle; File closes it exactly once.
+        Ok(unsafe { File::from_raw_handle(handle) })
+    }
+
+    pub(crate) fn sync_directory(_: &Path) -> std::io::Result<()> {
+        Ok(())
+    }
+
+    pub(crate) fn rename(from: &Path, to: &Path) -> std::io::Result<()> {
+        if unsafe {
+            MoveFileExW(
+                wide(from).as_ptr(),
+                wide(to).as_ptr(),
+                MOVEFILE_WRITE_THROUGH,
+            )
+        } == 0
+        {
+            return Err(std::io::Error::last_os_error());
+        }
+
+        Ok(())
+    }
+}

--- a/src/nano/provider.rs
+++ b/src/nano/provider.rs
@@ -1,0 +1,77 @@
+//! Provider boundary. Adapters assemble complete responses; partial arguments are display-only.
+
+use super::tools::{ToolCall, ToolDescriptor, ToolOutcome};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct Usage {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+
+    /// False is a host estimate, never provider-reported billing data.
+    pub reported: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum FinishReason {
+    Stop,
+    ToolCalls,
+    Length,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ModelResponse {
+    pub finish: FinishReason,
+    pub text: String,
+    pub calls: Vec<ToolCall>,
+
+    /// Adapter-owned continuation data (including signed blocks), preserved without interpretation.
+    pub continuation: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "role", rename_all = "snake_case")]
+pub(crate) enum Message {
+    User {
+        text: String,
+    },
+    Assistant {
+        response: ModelResponse,
+    },
+    Tool {
+        provider_call_id: String,
+        outcome: ToolOutcome,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ModelRequest {
+    pub messages: Vec<Message>,
+    pub tools: Vec<ToolDescriptor>,
+    pub max_output_tokens: u64,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum ProviderEvent {
+    TextDelta(String),
+    ArgumentsDelta(String),
+    Completed {
+        response: ModelResponse,
+        usage: Option<Usage>,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ProviderError {
+    pub retryable: bool,
+}
+
+pub(crate) trait Provider {
+    /// Both start and next_event must be safe to drop on cancellation/deadline.
+    async fn start(&mut self, request: ModelRequest) -> Result<(), ProviderError>;
+
+    async fn next_event(&mut self) -> Result<Option<ProviderEvent>, ProviderError>;
+}

--- a/src/nano/provider.rs
+++ b/src/nano/provider.rs
@@ -32,6 +32,12 @@ pub(crate) struct ModelResponse {
     pub continuation: Option<serde_json::Value>,
 }
 
+impl ModelResponse {
+    pub(crate) fn is_final(&self) -> bool {
+        self.finish == FinishReason::Stop && self.calls.is_empty() && !self.text.trim().is_empty()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "role", rename_all = "snake_case")]
 pub(crate) enum Message {

--- a/src/nano/replay.rs
+++ b/src/nano/replay.rs
@@ -1,0 +1,204 @@
+//! Pure journal replay. It has no provider, tool, filesystem, or Ferrus effect ports.
+
+use super::{
+    provider::Message,
+    session::{Budget, EndReason, Record, SessionEvent},
+    tools::{ToolCall, ToolOutcome},
+};
+use anyhow::{Result, ensure};
+use std::collections::VecDeque;
+
+pub(crate) const JOURNAL_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct Replay {
+    pub sequence: u64,
+    pub session_id: String,
+    pub budget: Budget,
+    pub messages: Vec<Message>,
+    pub end: Option<EndReason>,
+    pub pending_effect: Option<String>,
+    pub unknown_effects: Vec<String>,
+    model_active: bool,
+    calls: VecDeque<ToolCall>,
+}
+
+impl Replay {
+    pub(crate) fn from_records(records: &[Record]) -> Result<Self> {
+        let mut state = Self::default();
+        for record in records {
+            state.apply(record)?;
+        }
+
+        Ok(state)
+    }
+
+    pub(crate) fn checkpoint_ready(&self) -> bool {
+        self.sequence > 0
+            && !self.model_active
+            && self.pending_effect.is_none()
+            && self.calls.is_empty()
+    }
+
+    pub(crate) fn apply(&mut self, record: &Record) -> Result<()> {
+        ensure!(
+            record.version == JOURNAL_VERSION,
+            "Unsupported nano journal version"
+        );
+
+        ensure!(
+            record.sequence == self.sequence + 1,
+            "Non-contiguous journal sequence"
+        );
+
+        ensure!(self.end.is_none(), "Event after session end");
+
+        if self.sequence == 0 {
+            ensure!(
+                matches!(&record.event, SessionEvent::Started { identity, .. } if identity.session_id == record.session_id),
+                "Journal must start with its session identity"
+            );
+            self.session_id = record.session_id.clone();
+        }
+
+        ensure!(
+            self.session_id == record.session_id,
+            "Journal session mismatch"
+        );
+
+        let before = &self.budget;
+        let after = &record.budget;
+
+        ensure!(
+            after.model_turns >= before.model_turns
+                && after.tool_calls >= before.tool_calls
+                && after.retries >= before.retries
+                && after.elapsed_ms >= before.elapsed_ms
+                && after.reported_input_tokens >= before.reported_input_tokens
+                && after.reported_output_tokens >= before.reported_output_tokens
+                && after.estimated_input_tokens >= before.estimated_input_tokens
+                && after.estimated_output_tokens >= before.estimated_output_tokens,
+            "Budget consumption regressed"
+        );
+
+        let mut expected = before.clone();
+        expected.elapsed_ms = after.elapsed_ms;
+        expected.no_progress = after.no_progress;
+
+        match &record.event {
+            SessionEvent::ModelStarted { .. } => {
+                ensure!(
+                    before.reserved_input_tokens == 0
+                        && before.reserved_output_tokens == 0
+                        && after.reserved_input_tokens > 0
+                        && after.reserved_output_tokens > 0,
+                    "Invalid provider usage reservation"
+                );
+                expected.model_turns += 1;
+                expected.reserved_input_tokens = after.reserved_input_tokens;
+                expected.reserved_output_tokens = after.reserved_output_tokens;
+            }
+            SessionEvent::ModelCompleted { usage, .. }
+            | SessionEvent::ModelFailed { usage, .. } => {
+                expected.reserved_input_tokens = 0;
+                expected.reserved_output_tokens = 0;
+                expected.charge(usage);
+                if let SessionEvent::ModelFailed { retryable, .. } = &record.event {
+                    ensure!(
+                        after.retries == before.retries
+                            || (*retryable && after.retries == before.retries + 1),
+                        "Invalid retry charge"
+                    );
+                    expected.retries = after.retries;
+                }
+            }
+            SessionEvent::ToolIntent { .. } => expected.tool_calls += 1,
+            _ => (),
+        }
+
+        ensure!(
+            &expected == after,
+            "Budget does not match recorded consumption"
+        );
+
+        match &record.event {
+            SessionEvent::Started { limits, input, .. } => {
+                ensure!(
+                    self.sequence == 0 && after == &Budget::default(),
+                    "Duplicate or charged session start"
+                );
+                limits.validate()?;
+                self.messages.push(Message::User {
+                    text: input.clone(),
+                });
+            }
+            SessionEvent::ModelStarted { turn } => {
+                ensure!(
+                    self.checkpoint_ready() && self.end.is_none(),
+                    "Model started inside an unfinished group"
+                );
+                ensure!(
+                    *turn == before.model_turns + 1 && after.model_turns == *turn,
+                    "Invalid model turn"
+                );
+                self.model_active = true;
+            }
+            SessionEvent::ModelCompleted { response, .. } => {
+                ensure!(
+                    self.model_active && self.calls.is_empty(),
+                    "Unexpected model response"
+                );
+                self.model_active = false;
+                self.calls = response.calls.clone().into();
+                self.messages.push(Message::Assistant {
+                    response: response.clone(),
+                });
+            }
+            SessionEvent::ModelFailed { .. } => {
+                ensure!(self.model_active, "Unexpected provider failure");
+                self.model_active = false;
+            }
+            SessionEvent::ToolIntent { call_id, call } => {
+                ensure!(
+                    self.pending_effect.is_none() && self.calls.front() == Some(call),
+                    "Tool intent out of model order"
+                );
+                ensure!(
+                    after.tool_calls == before.tool_calls + 1
+                        && *call_id == format!("call-{}", after.tool_calls),
+                    "Invalid tool call ID"
+                );
+                self.pending_effect = Some(call_id.clone());
+            }
+            SessionEvent::ToolResult { call_id, outcome } => {
+                ensure!(
+                    self.pending_effect.as_ref() == Some(call_id),
+                    "Tool result has no matching intent"
+                );
+                let call = self.calls.pop_front().expect("intent checked call queue");
+                self.messages.push(Message::Tool {
+                    provider_call_id: call.provider_call_id,
+                    outcome: outcome.clone(),
+                });
+                if matches!(outcome, ToolOutcome::Unknown(_)) {
+                    self.unknown_effects.push(call_id.clone());
+                }
+                self.pending_effect = None;
+            }
+            SessionEvent::Ended { reason } => {
+                if *reason == EndReason::ModelFinished {
+                    ensure!(
+                        self.checkpoint_ready(),
+                        "Model finish inside an unfinished group"
+                    );
+                }
+                self.end = Some(reason.clone());
+            }
+        }
+
+        self.budget = record.budget.clone();
+        self.sequence = record.sequence;
+
+        Ok(())
+    }
+}

--- a/src/nano/replay.rs
+++ b/src/nano/replay.rs
@@ -20,6 +20,7 @@ pub(crate) struct Replay {
     pub pending_effect: Option<String>,
     pub unknown_effects: Vec<String>,
     model_active: bool,
+    final_response_ready: bool,
     calls: VecDeque<ToolCall>,
 }
 
@@ -142,6 +143,7 @@ impl Replay {
                     "Invalid model turn"
                 );
                 self.model_active = true;
+                self.final_response_ready = false;
             }
             SessionEvent::ModelCompleted { response, .. } => {
                 ensure!(
@@ -149,6 +151,7 @@ impl Replay {
                     "Unexpected model response"
                 );
                 self.model_active = false;
+                self.final_response_ready = response.is_final();
                 self.calls = response.calls.clone().into();
                 self.messages.push(Message::Assistant {
                     response: response.clone(),
@@ -157,6 +160,7 @@ impl Replay {
             SessionEvent::ModelFailed { .. } => {
                 ensure!(self.model_active, "Unexpected provider failure");
                 self.model_active = false;
+                self.final_response_ready = false;
             }
             SessionEvent::ToolIntent { call_id, call } => {
                 ensure!(
@@ -190,6 +194,10 @@ impl Replay {
                     ensure!(
                         self.checkpoint_ready(),
                         "Model finish inside an unfinished group"
+                    );
+                    ensure!(
+                        self.final_response_ready,
+                        "Model finish requires a completed final response"
                     );
                 }
                 self.end = Some(reason.clone());

--- a/src/nano/session.rs
+++ b/src/nano/session.rs
@@ -1,0 +1,190 @@
+//! Transport-neutral session protocol and persisted resource accounting.
+
+use serde::{Deserialize, Serialize};
+
+use super::provider::{ModelResponse, Usage};
+use super::tools::{ToolCall, ToolOutcome};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct SessionIdentity {
+    pub session_id: String,
+    pub project_id: String,
+    pub task_id: Option<String>,
+    pub run_id: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum SessionCommand {
+    Start { input: String },
+    Cancel,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct Limits {
+    pub model_turns: u64,
+    pub tokens: u64,
+    pub tool_calls: u64,
+    pub retries: u64,
+    pub no_progress: u64,
+    pub elapsed_ms: u64,
+    pub context_bytes: usize,
+    pub response_bytes: usize,
+    pub tool_output_bytes: usize,
+}
+
+impl Default for Limits {
+    fn default() -> Self {
+        Self {
+            model_turns: 64,
+            tokens: 200_000,
+            tool_calls: 256,
+            retries: 3,
+            no_progress: 3,
+            elapsed_ms: 30 * 60 * 1000,
+            context_bytes: 256 * 1024,
+            response_bytes: 64 * 1024,
+            tool_output_bytes: 32 * 1024,
+        }
+    }
+}
+
+impl Limits {
+    pub(crate) fn validate(&self) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            self.model_turns > 0
+                && self.tokens > 0
+                && self.tool_calls > 0
+                && self.no_progress > 0
+                && self.elapsed_ms > 0
+                && self.context_bytes > 0
+                && self.response_bytes > 0
+                && self.tool_output_bytes > 0,
+            "Session limits must be positive (retries may be zero)"
+        );
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct Budget {
+    pub model_turns: u64,
+    pub tool_calls: u64,
+    pub retries: u64,
+    pub no_progress: u64,
+    pub elapsed_ms: u64,
+    pub reported_input_tokens: u64,
+    pub reported_output_tokens: u64,
+    pub estimated_input_tokens: u64,
+    pub estimated_output_tokens: u64,
+    pub reserved_input_tokens: u64,
+    pub reserved_output_tokens: u64,
+}
+
+impl Budget {
+    pub(crate) fn tokens(&self) -> u64 {
+        self.reported_input_tokens
+            .saturating_add(self.reported_output_tokens)
+            .saturating_add(self.estimated_input_tokens)
+            .saturating_add(self.estimated_output_tokens)
+            .saturating_add(self.reserved_input_tokens)
+            .saturating_add(self.reserved_output_tokens)
+    }
+
+    pub(crate) fn charge(&mut self, usage: &Usage) {
+        let (input, output) = if usage.reported {
+            (
+                &mut self.reported_input_tokens,
+                &mut self.reported_output_tokens,
+            )
+        } else {
+            (
+                &mut self.estimated_input_tokens,
+                &mut self.estimated_output_tokens,
+            )
+        };
+
+        *input = input.saturating_add(usage.input_tokens);
+        *output = output.saturating_add(usage.output_tokens);
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum LimitKind {
+    ModelTurns,
+    Tokens,
+    ToolCalls,
+    Retries,
+    NoProgress,
+    Elapsed,
+    ContextBytes,
+    ResponseBytes,
+    ToolOutputBytes,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "reason", content = "detail", rename_all = "snake_case")]
+pub(crate) enum EndReason {
+    ModelFinished,
+    Cancelled,
+    Limit(LimitKind),
+    ProviderFailed,
+    ProviderProtocol,
+    ProviderTruncated,
+    JournalFailed,
+    EffectUnknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub(crate) enum SessionEvent {
+    Started {
+        identity: SessionIdentity,
+        limits: Limits,
+        input: String,
+    },
+    ModelStarted {
+        turn: u64,
+    },
+    ModelCompleted {
+        response: ModelResponse,
+        usage: Usage,
+    },
+    ModelFailed {
+        retryable: bool,
+        usage: Usage,
+    },
+    ToolIntent {
+        call_id: String,
+        call: ToolCall,
+    },
+    ToolResult {
+        call_id: String,
+        outcome: ToolOutcome,
+    },
+    Ended {
+        reason: EndReason,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct Record {
+    pub version: u32,
+    pub session_id: String,
+    pub sequence: u64,
+    pub budget: Budget,
+    pub event: SessionEvent,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SessionEnd {
+    pub reason: EndReason,
+    pub budget: Budget,
+    /// False means the final state could not be durably recorded. Never acknowledge it as committed.
+    pub durable: bool,
+}

--- a/src/nano/tools.rs
+++ b/src/nano/tools.rs
@@ -1,0 +1,93 @@
+//! Coding-tool and host boundaries. No runtime identity comes from model arguments.
+
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tokio::sync::watch;
+
+use super::session::Record;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ToolCall {
+    pub provider_call_id: String,
+    pub name: String,
+    pub arguments: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ToolDescriptor {
+    pub name: String,
+    pub description: String,
+    pub input_schema: serde_json::Value,
+}
+
+#[derive(Debug)]
+pub(crate) struct ValidatedCall {
+    pub call_id: String,
+    pub provider_call_id: String,
+    pub name: String,
+    pub arguments: serde_json::Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ToolError {
+    UnknownTool,
+    InvalidArguments,
+    Denied,
+    Failed,
+    Interrupted,
+    OutputLimit,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status", content = "content", rename_all = "snake_case")]
+pub(crate) enum ToolOutcome {
+    Success(serde_json::Value),
+    Failed(ToolError),
+    /// The effect may have happened. Never automatically re-execute this call.
+    Unknown(ToolError),
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct Cancellation(Arc<watch::Sender<bool>>);
+
+impl Default for Cancellation {
+    fn default() -> Self {
+        Self(Arc::new(watch::channel(false).0))
+    }
+}
+
+impl Cancellation {
+    pub(crate) fn cancel(&self) {
+        self.0.send_replace(true);
+    }
+
+    pub(crate) fn is_cancelled(&self) -> bool {
+        *self.0.borrow()
+    }
+
+    pub(crate) async fn cancelled(&self) {
+        let mut receiver = self.0.subscribe();
+        let _ = receiver.wait_for(|cancelled| *cancelled).await;
+    }
+}
+
+pub(crate) trait Tools {
+    fn descriptors(&self) -> Vec<ToolDescriptor>;
+
+    /// The adapter owns schema validation; execution receives only the validated object.
+    fn validate(&self, name: &str, arguments: &serde_json::Value) -> Result<(), ToolError>;
+
+    /// Implementations must clean up owned processes on drop and reconcile effects whose
+    /// completion cannot be observed. Cancellation/deadline may drop this future.
+    async fn execute(&mut self, call: &ValidatedCall, cancellation: &Cancellation) -> ToolOutcome;
+}
+
+pub(crate) trait Host {
+    /// Revalidate session authority immediately before each effect.
+    async fn authorize(&mut self, call: &ValidatedCall) -> Result<(), ToolError>;
+
+    /// Called only after a record is durable. UI delivery does not own session state.
+    fn committed(&mut self, record: &Record);
+}


### PR DESCRIPTION
## Summary

Add the Nano session engine and durable journal, establishing the execution core for the native Ferrus harness.

- Run sequential model/tool turns through provider, tool, host, and journal interfaces, with cancellation and limits on tokens, calls, retries, elapsed time, and payload sizes.
- Reserve usage before provider requests, validate tool calls, reauthorize effects, and persist intent and results before reporting progress.
- Add a private, quota-bounded JSONL journal with a single-writer lock, atomic checkpoints, and replay that reconstructs session state without executing effects.
- Document session and recovery contracts, update the Nano roadmap, and bump the version to `0.5.0-alpha.1`.

Closes #74.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Enhancement
- [ ] Performance
- [x] Documentation
- [ ] Refactor
- [ ] Security
- [ ] Breaking change

## Workflow impact (if applicable)

- [x] No impact
- [ ] Minor change (does not alter lifecycle semantics)
- [ ] Changes behavior of an existing step
- [ ] Introduces new state/transition

Session state is separate from the Ferrus task/run lifecycle. Model completion does not complete a task. Live providers, coding tools, CLI/HQ integration, and automatic effect resume remain follow-up work.

## Checklist

- [x] I added/updated tests where it makes sense
- [x] I updated docs/examples if needed
- [x] This change is backwards-compatible (or clearly marked as breaking)
- [x] I ran formatting/lints locally (if applicable)

## Notes for reviewers

Focus on durable intent/result ordering, conservative usage accounting, and recovery validation. Cancellation during a tool call leaves an unknown outcome; replay must never retry that effect automatically. Checkpoints cover complete model/tool groups, and recovery only truncates an unterminated final journal record.

Session artifacts remain separate from orchestration and graph/memory databases. Storage checks enforce owner-only access on Unix and Windows; quotas apply per session.

Local validation: `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test` passed (930 tests). Regression coverage includes limits, cancellation, journal failures, permissions, checkpoints, and replay.
