### PR TITLE
Add streaming Chat Completions provider for Nano

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,6 +45,15 @@ jobs:
       - name: Test build without update notifications
         run: cargo test --locked --no-default-features
 
+      - name: Check native inference provider without update notifications
+        run: cargo clippy --locked --no-default-features --features nano-openai -- -D warnings
+
+      - name: Test native inference provider
+        run: cargo test --locked --features nano-openai
+
+      - name: Test native inference provider without update notifications
+        run: cargo test --locked --no-default-features --features nano-openai nano::
+
   smoke:
     strategy:
       fail-fast: false

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,7 +52,8 @@ jobs:
         run: cargo test --locked --features nano-openai
 
       - name: Test native inference provider without update notifications
-        run: cargo test --locked --no-default-features --features nano-openai nano::
+        run: |
+          cargo test --locked --no-default-features --features nano-openai nano::
 
   smoke:
     strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1172,9 +1172,9 @@ dependencies = [
 
 [[package]]
 name = "neva"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01dc6efd7d547724860ba419a19d5e6ade81204f7f997cf4a721cb91c4e20417"
+checksum = "0e187be89fe33a59f52bcd8a94f9a395d3ec8e7f9281d02a892e63034b0225b9"
 dependencies = [
  "base64 0.23.1",
  "bytes",
@@ -1197,9 +1197,9 @@ dependencies = [
 
 [[package]]
 name = "neva_macros"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f8104e43d9f71bd3e1af203cbaec42d7d8cf9da40b8fb0ff01bfaeb8cf112fb"
+checksum = "a9f23561b473fb9151331ed1d40fc9480cf2dd4070c1fc428fa95d00a20c06bb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,6 +175,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
 name = "chacha20"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,6 +189,7 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
+ "rand_core",
 ]
 
 [[package]]
@@ -487,6 +500,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,6 +580,7 @@ dependencies = [
  "futures-util",
  "libc",
  "neva",
+ "reqwest",
  "ring",
  "rusqlite",
  "semver",
@@ -595,6 +620,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "fs2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -602,6 +636,15 @@ checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -641,8 +684,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -652,11 +697,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "rand_core",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -729,6 +776,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -741,6 +811,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -768,10 +897,114 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
+
+[[package]]
+name = "icu_properties"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
+
+[[package]]
+name = "icu_provider"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -793,6 +1026,12 @@ checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
  "hybrid-array",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791930b43c0d5973160d90a8f3894509f2b273430f5c5c73b668636d0287c5c0"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -872,6 +1111,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
+
+[[package]]
 name = "litrs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -891,6 +1136,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -1060,6 +1311,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1079,6 +1339,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.2",
+ "lru-slab",
+ "rand",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1094,10 +1410,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1169,6 +1505,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1206,6 +1580,12 @@ dependencies = [
  "smallvec",
  "sqlite-wasm-rs",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -1250,6 +1630,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -1269,6 +1650,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -1381,6 +1768,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1456,6 +1855,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "sqlite-wasm-rs"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1466,6 +1875,12 @@ dependencies = [
  "rsqlite-vfs",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "streaming-iterator"
@@ -1505,6 +1920,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1550,6 +1985,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1558,6 +2003,21 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf0ded5c4e56918d8f8a339e1bb67d038d3bc6d144ac407904015ba2e4cde9b"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -1570,6 +2030,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -1583,6 +2044,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c85f2c3ef0b1cd58b36682f4b17aaa995f0e5db534d85692b4903abce21f67"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -1649,6 +2120,51 @@ name = "toml_writer"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -1742,6 +2258,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1810,10 +2332,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
 name = "utf8-zero"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -1865,6 +2405,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1899,6 +2448,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1965,6 +2524,26 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2252,6 +2831,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2272,10 +2880,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ update-check = ["dep:semver", "dep:ureq"]
 nano-openai = ["dep:reqwest"]
 
 [dependencies]
-neva = { version = "0.5.6", features = ["server", "di", "legacy-spec"] }
+neva = { version = "0.5.7", features = ["server", "di", "legacy-spec"] }
 tokio = { version = "1.52.3", features = ["fs", "io-util", "macros", "process", "rt-multi-thread", "sync", "time"] }
 clap = { version = "4.6.1", features = ["derive"] }
 serde = { version = "1.0.229", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ path = "src/main.rs"
 [features]
 default = ["update-check"]
 update-check = ["dep:semver", "dep:ureq"]
+nano-openai = ["dep:reqwest"]
 
 [dependencies]
 neva = { version = "0.5.6", features = ["server", "di", "legacy-spec"] }
@@ -47,6 +48,7 @@ dirs = "6.0.0"
 futures-util = { version = "0.3.32", default-features = false, features = ["std"] }
 semver = { version = "1.0.28", optional = true }
 ureq = { version = "3.3.0", default-features = false, features = ["rustls"], optional = true }
+reqwest = { version = "0.12.28", default-features = false, features = ["rustls-tls"], optional = true }
 rusqlite = { version = "0.40.1", features = ["bundled", "hooks"] }
 ring = "0.17.14"
 sha2 = "0.11.0"

--- a/docs/ferrus-nano-architecture.md
+++ b/docs/ferrus-nano-architecture.md
@@ -1,12 +1,12 @@
 # Ferrus Nano: Native Agent Harness
 
-Status: accepted implementation plan, updated 2026-09-07. The #73 managed-session binding and
-#74 bounded engine/journal are implemented; live providers, launcher, and later slices remain planned. No measured
-performance claim.
+Status: accepted implementation plan, updated 2026-09-08. The #73 managed-session binding,
+#74 bounded engine/journal, and #75 opt-in Chat Completions adapter are implemented. Live model
+validation, launcher, and later slices remain planned. No measured performance claim.
 
 Working product name: `ferrus-nano`. Ferrus backend name: `nano`.
 
-Related documents: [session engine and journal](ferrus-nano-sessions.md), [roadmap](milestones.md), [repository graph](repository-graph-architecture.md),
+Related documents: [session engine and journal](ferrus-nano-sessions.md), [first provider](ferrus-nano-provider.md), [roadmap](milestones.md), [repository graph](repository-graph-architecture.md),
 [project memory](project-memory-architecture.md).
 
 ## 1. Decision
@@ -62,7 +62,7 @@ Audit base: Ferrus commit `4f52783d6f5efa64ea1a2adf48b55c8b27c565be`.
 | Agent adapters | `ExecutorAgent` and `SupervisorAgent`, model overrides, stdin prompts | Executor-only/headless-only capability declarations; native registration |
 | UI | Crossterm HQ, `UiMessage`, transcript and question handling | A session-event adapter and, later, a conversation view |
 | MCP | neva 0.5.6 with `server`, `di`, `legacy-spec` | Add client features for external tools, preserve protocol compatibility |
-| Agent engine | Sequential bounded core, provider/tool/host interfaces, durable journal, pure replay, and scripted tests | Live provider adapter, managed tool wiring, compaction, and live resume |
+| Agent engine | Sequential bounded core, provider/tool/host interfaces, durable journal, pure replay, and scripted tests | Live model validation, managed tool wiring, compaction, and live resume |
 | Instructions | Ferrus role prompts, project guidance, and embedded skill templates | A bounded native instruction loader with explicit precedence and provenance |
 | Coding tools | Graph source readers, check runner and process primitives | General bounded reads/search, patch editing, command sessions |
 
@@ -208,10 +208,11 @@ usage, context limits, and provider-specific continuation data. Keep provider wi
 adapters; preserve opaque signed/reasoning blocks where the provider requires them. Do not invent
 a common format that silently loses tool-call IDs or continuation requirements.
 
-Choose one real provider for the first end-to-end slice, plus a scripted provider for tests. The
-first production provider is still open. A second adapter is a later compatibility check, not a
-prerequisite for the engine. An OpenAI-compatible endpoint is a candidate adapter, not a guarantee
-that local servers implement identical tool calling, streaming, usage, or context limits.
+The first adapter targets LM Studio through OpenAI-compatible Chat Completions streaming,
+with optional Bearer authentication. See [provider configuration and verification](ferrus-nano-provider.md).
+A scripted provider remains available for engine tests. A second adapter is a later compatibility
+check; compatible endpoints still require explicit validation of tool calling, streaming, usage,
+and context limits with the selected model.
 
 Load credentials through host configuration or environment references. Keep credentials out of
 project files, command arguments, transcript events, tool children, and MCP child environments.
@@ -657,8 +658,7 @@ Read on 2026-09-06. These are sources for design ideas, not dependencies or copi
 
 ## 16. Decisions still open
 
-- First production provider/model and its credential configuration. The engine contract can be
-  designed now; select and test the wire adapter before claiming N1 complete.
+- Validate the first loaded model against the opt-in LM Studio smoke test before claiming N1 complete.
 - Concrete token/time/output defaults, calibrated with the task suite rather than guessed savings.
 - Which platform gets the first enforced command sandbox after the trusted-local MVP.
 - Whether standalone first ships a shared terminal UI or a headless executable before that UI.

--- a/docs/ferrus-nano-provider.md
+++ b/docs/ferrus-nano-provider.md
@@ -12,8 +12,8 @@ Ferrus configuration, HQ, MCP, graph, and memory paths do not load these setting
 resolve credentials, or initialize the client. No model is selected automatically.
 
 Keep the settings file outside the project, for example in your private Ferrus
-configuration directory. The loader requires an existing owner-only file (0600 on
-Unix; protected owner-only DACL on Windows). Example:
+configuration directory. The loader opens inputs read-only and requires an existing
+owner-only file (0400 or 0600 on Unix; protected owner-only DACL on Windows). Example:
 
 ```toml
 base_url = "http://127.0.0.1:1234/v1"

--- a/docs/ferrus-nano-provider.md
+++ b/docs/ferrus-nano-provider.md
@@ -1,0 +1,105 @@
+# Nano Chat Completions Provider
+
+The first inference adapter targets **LM Studio's OpenAI-compatible
+`POST /v1/chat/completions` streaming API**. It is opt-in through the `nano-openai`
+Cargo feature. This implements #75; a Nano CLI and HQ launcher remain #80 work.
+An OpenAI-compatible label alone does not establish endpoint or model compatibility.
+
+## Host configuration
+
+The caller explicitly loads `nano::config::Config` and constructs `OpenAi`. Ordinary
+Ferrus configuration, HQ, MCP, graph, and memory paths do not load these settings,
+resolve credentials, or initialize the client. No model is selected automatically.
+
+Keep the settings file outside the project, for example in your private Ferrus
+configuration directory. The loader requires an existing owner-only file (0600 on
+Unix; protected owner-only DACL on Windows). Example:
+
+```toml
+base_url = "http://127.0.0.1:1234/v1"
+model = "your-loaded-tool-capable-model"
+context_tokens = 32768
+max_output_tokens = 4096
+temperature = 0.0
+request_timeout_ms = 120000
+include_usage = true
+
+# Optional: omit entirely when LM Studio authentication is disabled.
+# This file contains only the token, not a shell assignment or JSON object.
+# api_key_file = "/absolute/private/host/path/lm-studio-token"
+```
+
+The key file must also be owner-only, at most 4096 bytes, and contain a nonempty
+single token. It is read directly into a sensitive Authorization header. With no
+key file, requests omit Authorization entirely; no dummy key is necessary.
+The adapter neither reads API keys from environment variables nor exports them to
+tool/MCP child environments. It never stores key contents or credential paths in
+session records. Unknown settings, including inline `api_key`, fail explicitly.
+
+HTTP is permitted only on loopback; other hosts require HTTPS. The base URL must
+use `/v1` and cannot contain userinfo, a query, or a fragment. Redirects, automatic
+HTTP retries, and environment proxy discovery are disabled. Authentication and
+unsupported endpoint errors do not trigger protocol fallback.
+
+LM Studio normally allows unauthenticated requests; its authentication option uses
+Bearer tokens. See [LM Studio authentication](https://lmstudio.ai/docs/developer/core/authentication).
+
+## Protocol and budgets
+
+- Text-only Chat Completions messages, JSON function schemas, one choice, `max_tokens`,
+  and optional `stream_options.include_usage` are supported. A tool-capable loaded
+  model is required. Responses API, audio, images, deprecated function calls,
+  refusal/content-filter completion, and unknown delta features fail explicitly.
+- SSE framing supports LF/CRLF, split UTF-8, split function names/arguments, multiple
+  indexed calls, comments, and a separate trailing usage event. Calls become executable
+  only after a finish reason **and `[DONE]`**. EOF before that is a failed attempt.
+- `reasoning_content` and `reasoning` string deltas are preserved as opaque continuation
+  data and projected back unchanged. Other signed/reasoning formats are unsupported;
+  the adapter does not silently discard them.
+- Default limits are 4 MiB wire bytes per attempt, 256 KiB per SSE event, 64 tool calls,
+  and 120 seconds per HTTP request. The request timeout covers headers and body;
+  connection establishment is capped at the smaller of 10 seconds and that timeout.
+  The engine's independent byte, time, turn, token, and tool budgets still apply.
+- Context admission conservatively counts serialized request bytes as tokens and
+  reserves output space. Configure `context_tokens` to match the loaded model's
+  actual context. Known server context-overflow codes end with `Limit(ContextTokens)`;
+  automatic compaction is later work. Set `include_usage = false` explicitly if the
+  chosen server does not support streamed usage; absent usage is estimated by the engine.
+- 429, transient 5xx/transport errors, timeout, and incomplete streams use the engine's
+  existing retry budget. Backoff starts at 500 ms and is capped at 30 seconds, including
+  numeric `Retry-After`. Waiting is cancellable and consumes the same elapsed allowance.
+  Failed requests consume their reserved input/output budget as estimates; completed
+  provider usage remains separate. No adapter-local retries can duplicate effects.
+- Started records contain the validated model, API identity, base URL, and effective
+  provider settings. Model failure records contain only typed error codes. Existing
+  version-1 journals without these optional fields remain readable.
+
+Sources: [LM Studio Chat Completions](https://lmstudio.ai/docs/developer/openai-compat/chat-completions),
+[LM Studio tool use](https://lmstudio.ai/docs/developer/openai-compat/tools), and
+[Chat Completions streaming schema](https://developers.openai.com/api/reference/resources/chat/subresources/completions/streaming-events).
+
+## Verification
+
+Deterministic fixtures and loopback HTTP tests require no model, credentials, or paid
+inference. They exercise anonymous/Bearer requests, ordered calls and continuation,
+partial streams, usage, retry accounting, context admission, timeout, and cancellation.
+
+```sh
+cargo test --locked --features nano-openai nano::
+cargo clippy --locked --features nano-openai -- -D warnings
+cargo test --locked --no-default-features --features nano-openai nano::
+```
+
+For the live smoke test, start LM Studio on `127.0.0.1:1234`, load a model supporting
+tool calls, and prepare the private host settings file with its exact model ID:
+
+```sh
+FERRUS_NANO_SMOKE_CONFIG=/absolute/private/host/path/nano.toml \
+  cargo test --locked --features nano-openai live_lm_studio_tool_session -- --ignored --nocapture
+```
+
+The test runs a bounded session with a pure `lookup` tool, requires a successful tool
+call before final completion, and reports the configured model and reported/estimated
+usage. The temporary journal is removed after the test. CI never runs this test.
+Live compatibility has not yet been verified; run it against the configured model
+before enabling that endpoint for managed execution.

--- a/docs/ferrus-nano-sessions.md
+++ b/docs/ferrus-nano-sessions.md
@@ -1,7 +1,8 @@
 # Nano Session Engine and Journal
 
-Status: implemented foundation for #74. There is no live provider, CLI command, HQ launcher,
-or automatic effect resume in this slice. See the [architecture and PR index](ferrus-nano-architecture.md).
+Status: implemented foundation for #74. #75 adds an opt-in
+[Chat Completions provider](ferrus-nano-provider.md). CLI commands, HQ launch, and automatic
+effect resume remain later work. See the [architecture and PR index](ferrus-nano-architecture.md).
 
 ## Boundaries
 

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -25,7 +25,7 @@ Last reviewed against the repository: 2026-09-07.
 | Spec closure and project memory | Local baseline implemented | Outcome archival, curated memory indexing, revision-pinned queries, and evidence-backed repository links exist. Raw runtime bodies are excluded from default ingestion. |
 | Repository graph and indexed context | Local baseline implemented | Optional SQLite sidecar, incremental extraction, bounded CLI/MCP retrieval, task overlays, and frozen review views. Rust/Cargo and generic file structure are supported. |
 | Distributed context data plane | Prototype implemented | Opt-in contracts and local prototype adapters for authorized jobs, encrypted storage, publication, queries, and maintenance. No deployed remote service is implied. |
-| Ferrus nano-agent | Foundation implemented; runtime planned | #73 adds native binding and claim/status/heartbeat; #74 adds the bounded engine and durable journal. Live provider, HQ launch, interactive UI, and standalone delivery remain later slices. |
+| Ferrus nano-agent | Foundation implemented; runtime planned | #73 adds native binding and claim/status/heartbeat; #74 adds the bounded engine/journal; #75 adds opt-in LM Studio Chat Completions. Live model validation, HQ launch, interactive UI, and standalone delivery remain pending. |
 
 ## Milestone 1: Windows Support
 
@@ -167,7 +167,8 @@ Implemented foundation:
 - host-owned project/agent/task/run/workspace/baseline binding from launch data and registered runtime state;
 - native typed claim, status, and heartbeat, with exact run validation at transaction boundaries;
 - sequential provider/tool/host boundaries, persisted budgets, cancellation, a private single-writer journal, and pure recorded replay;
-- regression coverage for bindings, lease ownership, MCP parity, engine limits, effect ordering, and journal recovery.
+- an opt-in Chat Completions adapter targeting LM Studio, with private credential-file references, bounded streaming, and shared retry accounting;
+- regression coverage for bindings, lease ownership, MCP parity, engine limits, effect ordering, journal recovery, and offline provider protocols. The live provider smoke test remains opt-in.
 
 Delivery is tracked in [Ferrus nano-agents](https://github.com/ferrus-dev/ferrus/milestone/6).
 The [architecture and complete PR index](ferrus-nano-architecture.md#planned-prs-and-github-issues)
@@ -175,7 +176,7 @@ contains one issue per planned PR, dependencies, and acceptance criteria:
 
 | Stage | Issues | Remaining scope |
 | --- | --- | --- |
-| N1: headless Executor | #75-#80 | First live streaming provider, coding tools, command sessions, native context, lifecycle operations, and HQ launch/events |
+| N1: headless Executor | #75-#80 | Live model validation, coding tools, command sessions, native context, lifecycle operations, and HQ launch/events |
 | N2: context efficiency | #81-#82 | Working-set invalidation, budgets, and compaction |
 | N3: reliability and extensions | #83-#85 | External MCP via neva, resume/reconciliation, comparative evaluation, and headless release gates |
 | N4/N5: interactive and standalone | #86-#88 | HQ interaction, standalone host/binary, and shared UI |

--- a/src/nano/config.rs
+++ b/src/nano/config.rs
@@ -166,7 +166,7 @@ impl Config {
 }
 
 fn read_private(path: &Path, limit: usize) -> Result<Vec<u8>> {
-    let file = private::file(path, false)
+    let file = private::read_only_file(path)
         .map_err(|_| anyhow::anyhow!("Nano host file must exist and be owner-only"))?;
 
     let mut bytes = Vec::new();

--- a/src/nano/config.rs
+++ b/src/nano/config.rs
@@ -1,0 +1,179 @@
+//! Explicit, host-local provider configuration. No global client or credential environment.
+
+use super::{private, provider::ProviderSettings};
+use anyhow::{Context, Result, ensure};
+use reqwest::{Url, header::HeaderValue};
+use serde::Deserialize;
+use std::{
+    io::Read,
+    path::{Path, PathBuf},
+};
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct Config {
+    pub base_url: String,
+    pub model: String,
+    pub api_key_file: Option<PathBuf>,
+    #[serde(default = "default_context")]
+    pub context_tokens: u64,
+    #[serde(default = "default_output")]
+    pub max_output_tokens: u64,
+    #[serde(default)]
+    pub temperature: f64,
+    #[serde(default = "default_timeout")]
+    pub request_timeout_ms: u64,
+    #[serde(default = "default_wire")]
+    pub wire_bytes: usize,
+    #[serde(default = "default_event")]
+    pub event_bytes: usize,
+    #[serde(default = "default_calls")]
+    pub max_tool_calls: usize,
+    #[serde(default = "default_usage")]
+    pub include_usage: bool,
+}
+
+fn default_context() -> u64 {
+    32_768
+}
+fn default_output() -> u64 {
+    4096
+}
+fn default_timeout() -> u64 {
+    120_000
+}
+fn default_wire() -> usize {
+    4 * 1024 * 1024
+}
+fn default_event() -> usize {
+    256 * 1024
+}
+fn default_calls() -> usize {
+    64
+}
+fn default_usage() -> bool {
+    true
+}
+
+impl Config {
+    /// The future launcher calls this explicitly; normal Ferrus config never reads it.
+    pub(crate) fn load(path: &Path) -> Result<Self> {
+        let bytes = read_private(path, 16 * 1024)?;
+        let text = std::str::from_utf8(&bytes).context("Nano settings must be UTF-8")?;
+        // TOML diagnostics may quote unknown secret-bearing fields: do not return them.
+        toml::from_str(text).map_err(|_| anyhow::anyhow!("Invalid nano provider settings"))
+    }
+
+    pub(crate) fn validate(&self) -> Result<(Url, ProviderSettings)> {
+        let mut base =
+            Url::parse(&self.base_url).map_err(|_| anyhow::anyhow!("Invalid provider URL"))?;
+
+        ensure!(
+            base.username().is_empty()
+                && base.password().is_none()
+                && base.query().is_none()
+                && base.fragment().is_none()
+                && base.host_str().is_some(),
+            "Provider URL must not contain credentials, query, or fragment"
+        );
+
+        let local = matches!(base.host_str(), Some("localhost" | "127.0.0.1" | "[::1]"));
+        ensure!(
+            base.scheme() == "https" || (base.scheme() == "http" && local),
+            "Provider requires HTTPS or loopback HTTP"
+        );
+
+        ensure!(
+            base.path().trim_end_matches('/') == "/v1",
+            "This adapter requires a /v1 base URL"
+        );
+
+        ensure!(
+            !self.model.trim().is_empty()
+                && self.model.len() <= 256
+                && !self.model.chars().any(char::is_control),
+            "Invalid model identifier"
+        );
+
+        ensure!(
+            self.max_output_tokens > 0
+                && self.max_output_tokens < self.context_tokens
+                && self.context_tokens <= 16_777_216,
+            "Invalid provider context/output limits"
+        );
+
+        ensure!(
+            self.temperature.is_finite() && (0.0..=2.0).contains(&self.temperature),
+            "Invalid temperature"
+        );
+
+        ensure!(
+            (1..=3_600_000).contains(&self.request_timeout_ms)
+                && (1024..=64 * 1024 * 1024).contains(&self.wire_bytes)
+                && (256..=1024 * 1024).contains(&self.event_bytes)
+                && self.event_bytes <= self.wire_bytes
+                && (1..=256).contains(&self.max_tool_calls),
+            "Invalid provider transport limits"
+        );
+
+        base.set_path("/v1");
+
+        let settings = ProviderSettings {
+            api: "openai_chat_completions_v1".into(),
+            base_url: base.to_string(),
+            model: self.model.clone(),
+            context_tokens: self.context_tokens,
+            max_output_tokens: self.max_output_tokens,
+            temperature: self.temperature,
+            request_timeout_ms: self.request_timeout_ms,
+            wire_bytes: self.wire_bytes,
+            event_bytes: self.event_bytes,
+            max_tool_calls: self.max_tool_calls,
+            include_usage: self.include_usage,
+        };
+
+        base.set_path("/v1/chat/completions");
+
+        Ok((base, settings))
+    }
+
+    pub(crate) fn authorization(&self) -> Result<Option<HeaderValue>> {
+        let Some(path) = &self.api_key_file else {
+            return Ok(None);
+        };
+
+        ensure!(
+            path.is_absolute(),
+            "Credential file must be an absolute host-local path"
+        );
+
+        let bytes = read_private(path, 4096)?;
+        let key = std::str::from_utf8(&bytes)
+            .map_err(|_| anyhow::anyhow!("Invalid provider credential"))?
+            .trim();
+
+        ensure!(
+            !key.is_empty() && key.bytes().all(|b| b.is_ascii_graphic()),
+            "Invalid provider credential"
+        );
+
+        let mut header = HeaderValue::from_str(&format!("Bearer {key}"))
+            .map_err(|_| anyhow::anyhow!("Invalid provider credential"))?;
+
+        header.set_sensitive(true);
+        Ok(Some(header))
+    }
+}
+
+fn read_private(path: &Path, limit: usize) -> Result<Vec<u8>> {
+    let file = private::file(path, false)
+        .map_err(|_| anyhow::anyhow!("Nano host file must exist and be owner-only"))?;
+
+    let mut bytes = Vec::new();
+    file.take(limit as u64 + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|_| anyhow::anyhow!("Cannot read nano host file"))?;
+
+    ensure!(bytes.len() <= limit, "Nano host file exceeds size limit");
+    Ok(bytes)
+}

--- a/src/nano/core_tests.rs
+++ b/src/nano/core_tests.rs
@@ -31,7 +31,7 @@ impl Provider for ScriptedProvider {
         self.active = self
             .turns
             .pop_front()
-            .unwrap_or(Err(ProviderError { retryable: false }))?;
+            .unwrap_or(Err(ProviderError::new(ProviderErrorKind::Transport, false)))?;
         Ok(())
     }
 
@@ -404,7 +404,8 @@ async fn turn_tool_token_retry_and_context_limits_are_enforced() {
             LimitKind::Tokens => budget.tokens = 1,
             LimitKind::Retries => {
                 budget.retries = 0;
-                provider.turns = VecDeque::from([Err(ProviderError { retryable: true })]);
+                provider.turns =
+                    VecDeque::from([Err(ProviderError::new(ProviderErrorKind::Transport, true))]);
             }
             LimitKind::ContextBytes => budget.context_bytes = 1,
             LimitKind::ResponseBytes => budget.response_bytes = 1,
@@ -426,7 +427,7 @@ async fn retries_charge_estimates_and_successful_usage_stays_distinct() {
     let mut provider = scripted(vec![response("Done", vec![])]);
     provider
         .turns
-        .push_front(Err(ProviderError { retryable: true }));
+        .push_front(Err(ProviderError::new(ProviderErrorKind::Transport, true)));
     let (_dir, mut engine) = setup(provider, limits());
     let end = run(&mut engine, &Cancellation::default()).await;
     assert_eq!(end.reason, EndReason::ModelFinished);
@@ -645,6 +646,7 @@ async fn replay_requires_a_final_response_from_the_latest_model_attempt() {
                 };
                 next.budget.charge(&usage);
                 next.event = SessionEvent::ModelFailed {
+                    error: None,
                     retryable: false,
                     usage,
                 };
@@ -659,6 +661,7 @@ async fn replay_requires_a_final_response_from_the_latest_model_attempt() {
                 match case {
                     "failed" => {
                         record.event = SessionEvent::ModelFailed {
+                            error: None,
                             retryable: false,
                             usage: usage.clone(),
                         }

--- a/src/nano/engine.rs
+++ b/src/nano/engine.rs
@@ -2,7 +2,9 @@
 
 use super::{
     journal::{Journal, encode, valid_id},
-    provider::{FinishReason, Message, ModelRequest, Provider, ProviderEvent, Usage},
+    provider::{
+        FinishReason, Message, ModelRequest, Provider, ProviderErrorKind, ProviderEvent, Usage,
+    },
     session::{
         Budget, EndReason, LimitKind, Limits, SessionCommand, SessionEnd, SessionEvent,
         SessionIdentity,
@@ -92,6 +94,7 @@ impl<P: Provider, T: Tools, H: Host, J: Journal> Engine<P, T, H, J> {
             identity: self.identity.clone(),
             limits: self.limits.clone(),
             input: input.clone(),
+            provider: self.provider.settings().map(Box::new),
         }) {
             return Ok(self.journal_failure());
         }
@@ -99,6 +102,7 @@ impl<P: Provider, T: Tools, H: Host, J: Journal> Engine<P, T, H, J> {
         self.messages.push(Message::User { text: input });
 
         let reason = self.drive(cancellation, deadline).await;
+        self.provider.cancel();
         if reason == EndReason::JournalFailed {
             return Ok(self.journal_failure());
         }
@@ -217,14 +221,37 @@ impl<P: Provider, T: Tools, H: Host, J: Journal> Engine<P, T, H, J> {
                     if retry {
                         self.budget.retries += 1;
                     }
-                    if !self.record_model_failure(error.retryable) {
+                    if !self.record_failure(error.retryable, Some(error.kind.clone())) {
                         return EndReason::JournalFailed;
                     }
                     if !error.retryable {
-                        return EndReason::ProviderFailed;
+                        return match error.kind {
+                            ProviderErrorKind::ContextOverflow => {
+                                EndReason::Limit(LimitKind::ContextTokens)
+                            }
+                            ProviderErrorKind::ResponseLimit => {
+                                EndReason::Limit(LimitKind::ResponseBytes)
+                            }
+                            ProviderErrorKind::Protocol | ProviderErrorKind::Unsupported => {
+                                EndReason::ProviderProtocol
+                            }
+                            _ => EndReason::ProviderFailed,
+                        };
                     }
                     if !retry {
                         return EndReason::Limit(LimitKind::Retries);
+                    }
+                    let backoff = (250u64.saturating_mul(1 << self.budget.retries.min(6)))
+                        .max(error.retry_after_ms)
+                        .min(30_000);
+                    if let Err(reason) = interrupt(
+                        tokio::time::sleep(Duration::from_millis(backoff)),
+                        cancellation,
+                        deadline,
+                    )
+                    .await
+                    {
+                        return reason;
                     }
                     continue;
                 }
@@ -422,6 +449,10 @@ impl<P: Provider, T: Tools, H: Host, J: Journal> Engine<P, T, H, J> {
     }
 
     fn record_model_failure(&mut self, retryable: bool) -> bool {
+        self.record_failure(retryable, None)
+    }
+
+    fn record_failure(&mut self, retryable: bool, error: Option<ProviderErrorKind>) -> bool {
         let usage = Usage {
             input_tokens: self.budget.reserved_input_tokens,
             output_tokens: self.budget.reserved_output_tokens,
@@ -432,7 +463,11 @@ impl<P: Provider, T: Tools, H: Host, J: Journal> Engine<P, T, H, J> {
         self.budget.reserved_output_tokens = 0;
         self.budget.charge(&usage);
 
-        self.commit(SessionEvent::ModelFailed { retryable, usage })
+        self.commit(SessionEvent::ModelFailed {
+            retryable,
+            usage,
+            error,
+        })
     }
 
     fn stop(&self, cancellation: &Cancellation, deadline: Instant) -> Option<EndReason> {

--- a/src/nano/engine.rs
+++ b/src/nano/engine.rs
@@ -151,8 +151,14 @@ impl<P: Provider, T: Tools, H: Host, J: Journal> Engine<P, T, H, J> {
                 return EndReason::Limit(LimitKind::Tokens);
             }
 
-            let output_reservation =
-                (remaining - input_estimate).min(self.limits.response_bytes as u64);
+            let output_reservation = (remaining - input_estimate)
+                .min(self.limits.response_bytes as u64)
+                .min(
+                    self.provider
+                        .settings()
+                        .map_or(u64::MAX, |settings| settings.max_output_tokens),
+                );
+
             self.budget.model_turns += 1;
             self.budget.reserved_input_tokens = input_estimate;
             self.budget.reserved_output_tokens = output_reservation;

--- a/src/nano/journal_tests.rs
+++ b/src/nano/journal_tests.rs
@@ -23,6 +23,7 @@ fn started(journal: &mut FileJournal) -> Record {
     journal
         .append(
             SessionEvent::Started {
+                provider: None,
                 identity: SessionIdentity {
                     session_id: "s-1".into(),
                     project_id: "p-1".into(),
@@ -494,6 +495,7 @@ fn record_and_total_byte_quotas_fail_before_writing() {
             journal
                 .append(
                     SessionEvent::Started {
+                        provider: None,
                         identity: SessionIdentity {
                             session_id: "s-1".into(),
                             project_id: "p".into(),

--- a/src/nano/mod.rs
+++ b/src/nano/mod.rs
@@ -1,10 +1,14 @@
 //! Native agent core and managed Ferrus adapter; frontend and provider wiring are separate.
 
+#[cfg(feature = "nano-openai")]
+pub(crate) mod config;
 pub(crate) mod engine;
 pub(crate) mod ferrus;
 pub(crate) mod journal;
 mod private;
 pub(crate) mod provider;
+#[cfg(feature = "nano-openai")]
+pub(crate) mod providers;
 pub(crate) mod replay;
 pub(crate) mod session;
 pub(crate) mod tools;

--- a/src/nano/private.rs
+++ b/src/nano/private.rs
@@ -126,7 +126,8 @@ mod imp {
                 ConvertStringSecurityDescriptorToSecurityDescriptorW, GetSecurityInfo,
                 SE_FILE_OBJECT,
             },
-            DACL_SECURITY_INFORMATION, GetFileSecurityW, PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES,
+            DACL_SECURITY_INFORMATION, GetFileSecurityW, OWNER_SECURITY_INFORMATION,
+            PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES,
         },
         Storage::FileSystem::{
             CREATE_NEW, CreateDirectoryW, CreateFileW, FILE_ATTRIBUTE_NORMAL,
@@ -174,13 +175,20 @@ mod imp {
     }
 
     fn text(descriptor: PSECURITY_DESCRIPTOR) -> std::io::Result<Vec<u16>> {
+        security_text(descriptor, DACL_SECURITY_INFORMATION)
+    }
+
+    fn security_text(
+        descriptor: PSECURITY_DESCRIPTOR,
+        information: u32,
+    ) -> std::io::Result<Vec<u16>> {
         let mut pointer = null_mut();
         let mut length = 0;
         if unsafe {
             ConvertSecurityDescriptorToStringSecurityDescriptorW(
                 descriptor,
                 1,
-                DACL_SECURITY_INFORMATION,
+                information,
                 &mut pointer,
                 &mut length,
             )
@@ -254,13 +262,18 @@ mod imp {
             metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT == 0,
             "Host input cannot be a reparse point"
         );
+        let descriptor = input_descriptor(file)?;
+        check_input_dacl(descriptor.0)
+    }
+
+    fn input_descriptor(file: &File) -> Result<Descriptor> {
         let mut pointer = null_mut();
         // Inspect the opened handle so a path replacement cannot substitute another DACL.
         let result = unsafe {
             GetSecurityInfo(
                 file.as_raw_handle(),
                 SE_FILE_OBJECT,
-                DACL_SECURITY_INFORMATION,
+                OWNER_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION,
                 null_mut(),
                 null_mut(),
                 null_mut(),
@@ -271,11 +284,30 @@ mod imp {
         if result != 0 {
             return Err(std::io::Error::from_raw_os_error(result as i32).into());
         }
-        let descriptor = Descriptor(pointer);
-        let actual = text(descriptor.0)?;
-        for expected in ["D:P(A;;FA;;;OW)", "D:P(A;;FR;;;OW)", "D:P(A;;GR;;;OW)"] {
-            if actual == text(descriptor_from_text(expected)?.0)? {
-                return Ok(());
+        Ok(Descriptor(pointer))
+    }
+
+    fn input_owner(descriptor: PSECURITY_DESCRIPTOR) -> Result<String> {
+        let owner = String::from_utf16(&security_text(descriptor, OWNER_SECURITY_INFORMATION)?)?;
+        let owner = owner
+            .trim_end_matches('\0')
+            .strip_prefix("O:")
+            .filter(|owner| !owner.is_empty())
+            .ok_or_else(|| anyhow::anyhow!("Host input owner is missing"))?;
+        Ok(owner.to_owned())
+    }
+
+    fn check_input_dacl(descriptor: PSECURITY_DESCRIPTOR) -> Result<()> {
+        let owner = input_owner(descriptor)?;
+        let actual = text(descriptor)?;
+        // Compare canonical DACLs, accepting a single explicit grant to either Owner
+        // Rights or the owning account. Extra or inherited grants still fail closed.
+        for trustee in ["OW", owner.as_str()] {
+            for rights in ["FA", "FR", "GR"] {
+                let expected = descriptor_from_text(&format!("D:P(A;;{rights};;;{trustee})"))?;
+                if actual == text(expected.0)? {
+                    return Ok(());
+                }
             }
         }
         anyhow::bail!("Host input must have a protected owner-only DACL")
@@ -326,5 +358,63 @@ mod imp {
         }
 
         Ok(())
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use std::io::{Read, Write};
+        use windows_sys::Win32::Security::{PROTECTED_DACL_SECURITY_INFORMATION, SetFileSecurityW};
+
+        const OWNER: &str = "S-1-5-21-100-200-300-1001";
+
+        #[test]
+        fn input_dacl_accepts_owner_account_and_owner_rights_only() {
+            for trustee in ["OW", OWNER] {
+                for rights in ["FA", "FR", "GR"] {
+                    let descriptor =
+                        descriptor_from_text(&format!("O:{OWNER}D:P(A;;{rights};;;{trustee})"))
+                            .unwrap();
+                    check_input_dacl(descriptor.0).unwrap();
+                }
+            }
+            for dacl in [
+                "D:P(A;;FR;;;WD)".to_owned(),
+                "D:P(A;;FR;;;S-1-5-21-100-200-300-1002)".to_owned(),
+                format!("D:P(A;;FR;;;{OWNER})(A;;FR;;;WD)"),
+                format!("D:(A;;FR;;;{OWNER})"),
+                format!("D:P(A;ID;FR;;;{OWNER})"),
+            ] {
+                let descriptor = descriptor_from_text(&format!("O:{OWNER}{dacl}")).unwrap();
+                assert!(check_input_dacl(descriptor.0).is_err(), "{dacl}");
+            }
+        }
+
+        #[test]
+        fn provisioned_owner_read_grant_opens_without_write_access() {
+            let directory = tempfile::TempDir::new().unwrap();
+            let path = directory.path().join("credential");
+            let mut file = super::super::file(&path, true).unwrap();
+            file.write_all(b"fixture-token").unwrap();
+            let owner = input_owner(input_descriptor(&file).unwrap().0).unwrap();
+            drop(file);
+            let descriptor = descriptor_from_text(&format!("D:P(A;;FR;;;{owner})")).unwrap();
+            // Equivalent to removing inherited grants and granting the owner Read via icacls.
+            assert_ne!(
+                unsafe {
+                    SetFileSecurityW(
+                        wide(&path).as_ptr(),
+                        DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
+                        descriptor.0,
+                    )
+                },
+                0
+            );
+            let mut input = super::super::read_only_file(&path).unwrap();
+            let mut bytes = Vec::new();
+            input.read_to_end(&mut bytes).unwrap();
+            assert_eq!(bytes, b"fixture-token");
+            assert!(input.write_all(b"overwrite").is_err());
+        }
     }
 }

--- a/src/nano/private.rs
+++ b/src/nano/private.rs
@@ -35,9 +35,22 @@ pub(crate) fn file(path: &Path, create: bool) -> Result<File> {
         check(path, false)?;
     }
 
-    let file = imp::file(path, create)?;
+    let file = imp::file(path, create, true)?;
     check(path, false)?;
 
+    Ok(file)
+}
+
+/// Open a host input without write access, then validate the opened object before reading.
+pub(crate) fn read_only_file(path: &Path) -> Result<File> {
+    ensure!(
+        fs::symlink_metadata(path)?.is_file(),
+        "Unexpected host input file type"
+    );
+    let file = imp::file(path, false, false)?;
+    let metadata = file.metadata()?;
+    ensure!(metadata.is_file(), "Unexpected host input file type");
+    imp::check_input(&file, &metadata)?;
     Ok(file)
 }
 
@@ -52,6 +65,10 @@ mod imp {
     };
 
     pub(super) fn check(_path: &Path, metadata: &fs::Metadata) -> Result<()> {
+        check_owner(metadata)
+    }
+
+    fn check_owner(metadata: &fs::Metadata) -> Result<()> {
         // SAFETY: geteuid has no preconditions and returns the process identity.
         ensure!(
             metadata.uid() == unsafe { libc::geteuid() }
@@ -66,10 +83,14 @@ mod imp {
         DirBuilder::new().mode(0o700).create(path)
     }
 
-    pub(super) fn file(path: &Path, create: bool) -> std::io::Result<File> {
+    pub(super) fn check_input(_file: &File, metadata: &fs::Metadata) -> Result<()> {
+        check_owner(metadata)
+    }
+
+    pub(super) fn file(path: &Path, create: bool, writable: bool) -> std::io::Result<File> {
         OpenOptions::new()
             .read(true)
-            .write(true)
+            .write(writable)
             .create_new(create)
             .mode(0o600)
             .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
@@ -89,7 +110,11 @@ mod imp {
 mod imp {
     use super::*;
     use std::{
-        os::windows::{ffi::OsStrExt, io::FromRawHandle},
+        os::windows::{
+            ffi::OsStrExt,
+            fs::MetadataExt,
+            io::{AsRawHandle, FromRawHandle},
+        },
         ptr::{null, null_mut},
     };
 
@@ -98,14 +123,15 @@ mod imp {
         Security::{
             Authorization::{
                 ConvertSecurityDescriptorToStringSecurityDescriptorW,
-                ConvertStringSecurityDescriptorToSecurityDescriptorW,
+                ConvertStringSecurityDescriptorToSecurityDescriptorW, GetSecurityInfo,
+                SE_FILE_OBJECT,
             },
             DACL_SECURITY_INFORMATION, GetFileSecurityW, PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES,
         },
         Storage::FileSystem::{
             CREATE_NEW, CreateDirectoryW, CreateFileW, FILE_ATTRIBUTE_NORMAL,
-            FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_READ, FILE_SHARE_WRITE,
-            MOVEFILE_WRITE_THROUGH, MoveFileExW, OPEN_EXISTING,
+            FILE_ATTRIBUTE_REPARSE_POINT, FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_READ,
+            FILE_SHARE_WRITE, MOVEFILE_WRITE_THROUGH, MoveFileExW, OPEN_EXISTING,
         },
     };
 
@@ -125,7 +151,11 @@ mod imp {
 
     fn descriptor() -> std::io::Result<Descriptor> {
         // Protected DACL: full access only for the object's owner, no inherited grants.
-        let text: Vec<u16> = "D:P(A;;FA;;;OW)\0".encode_utf16().collect();
+        descriptor_from_text("D:P(A;;FA;;;OW)")
+    }
+
+    fn descriptor_from_text(sddl: &str) -> std::io::Result<Descriptor> {
+        let text: Vec<u16> = sddl.encode_utf16().chain(Some(0)).collect();
         let mut pointer = null_mut();
 
         if unsafe {
@@ -219,7 +249,39 @@ mod imp {
         Ok(())
     }
 
-    pub(super) fn file(path: &Path, create: bool) -> std::io::Result<File> {
+    pub(super) fn check_input(file: &File, metadata: &fs::Metadata) -> Result<()> {
+        ensure!(
+            metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT == 0,
+            "Host input cannot be a reparse point"
+        );
+        let mut pointer = null_mut();
+        // Inspect the opened handle so a path replacement cannot substitute another DACL.
+        let result = unsafe {
+            GetSecurityInfo(
+                file.as_raw_handle(),
+                SE_FILE_OBJECT,
+                DACL_SECURITY_INFORMATION,
+                null_mut(),
+                null_mut(),
+                null_mut(),
+                null_mut(),
+                &mut pointer,
+            )
+        };
+        if result != 0 {
+            return Err(std::io::Error::from_raw_os_error(result as i32).into());
+        }
+        let descriptor = Descriptor(pointer);
+        let actual = text(descriptor.0)?;
+        for expected in ["D:P(A;;FA;;;OW)", "D:P(A;;FR;;;OW)", "D:P(A;;GR;;;OW)"] {
+            if actual == text(descriptor_from_text(expected)?.0)? {
+                return Ok(());
+            }
+        }
+        anyhow::bail!("Host input must have a protected owner-only DACL")
+    }
+
+    pub(super) fn file(path: &Path, create: bool, writable: bool) -> std::io::Result<File> {
         let descriptor = descriptor()?;
         let attributes = SECURITY_ATTRIBUTES {
             nLength: std::mem::size_of::<SECURITY_ATTRIBUTES>() as u32,
@@ -230,7 +292,7 @@ mod imp {
         let handle = unsafe {
             CreateFileW(
                 wide(path).as_ptr(),
-                GENERIC_READ | GENERIC_WRITE,
+                GENERIC_READ | if writable { GENERIC_WRITE } else { 0 },
                 FILE_SHARE_READ | FILE_SHARE_WRITE,
                 if create { &attributes } else { null() },
                 if create { CREATE_NEW } else { OPEN_EXISTING },

--- a/src/nano/provider.rs
+++ b/src/nano/provider.rs
@@ -119,6 +119,7 @@ pub(crate) struct ProviderSettings {
 }
 
 pub(crate) trait Provider {
+    /// When present, the output cap also bounds the engine's per-attempt reservation.
     fn settings(&self) -> Option<ProviderSettings> {
         None
     }

--- a/src/nano/provider.rs
+++ b/src/nano/provider.rs
@@ -73,9 +73,59 @@ pub(crate) enum ProviderEvent {
 #[derive(Debug, Clone)]
 pub(crate) struct ProviderError {
     pub retryable: bool,
+    pub kind: ProviderErrorKind,
+    pub retry_after_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ProviderErrorKind {
+    Transport,
+    Timeout,
+    RateLimited,
+    Authentication,
+    ContextOverflow,
+    TruncatedStream,
+    Protocol,
+    Unsupported,
+    ResponseLimit,
+}
+
+impl ProviderError {
+    pub(crate) fn new(kind: ProviderErrorKind, retryable: bool) -> Self {
+        Self {
+            kind,
+            retryable,
+            retry_after_ms: 0,
+        }
+    }
+}
+
+/// Only validated, non-secret effective settings may enter the journal.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ProviderSettings {
+    pub api: String,
+    pub base_url: String,
+    pub model: String,
+    pub context_tokens: u64,
+    pub max_output_tokens: u64,
+    pub temperature: f64,
+    pub request_timeout_ms: u64,
+    pub wire_bytes: usize,
+    pub event_bytes: usize,
+    pub max_tool_calls: usize,
+    pub include_usage: bool,
 }
 
 pub(crate) trait Provider {
+    fn settings(&self) -> Option<ProviderSettings> {
+        None
+    }
+
+    /// Close any retained stream, including cancellation between buffered events.
+    fn cancel(&mut self) {}
+
     /// Both start and next_event must be safe to drop on cancellation/deadline.
     async fn start(&mut self, request: ModelRequest) -> Result<(), ProviderError>;
 

--- a/src/nano/providers/fixtures/final.sse
+++ b/src/nano/providers/fixtures/final.sse
@@ -1,0 +1,8 @@
+data: {"id":"turn-2","model":"fixture-model","choices":[{"index":0,"delta":{"role":"assistant","content":"42"},"finish_reason":null}]}
+
+data: {"id":"turn-2","model":"fixture-model","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
+
+data: {"id":"turn-2","model":"fixture-model","choices":[],"usage":{"prompt_tokens":24,"completion_tokens":3,"total_tokens":27}}
+
+data: [DONE]
+

--- a/src/nano/providers/fixtures/tools.sse
+++ b/src/nano/providers/fixtures/tools.sse
@@ -1,0 +1,14 @@
+: recorded Chat Completions protocol fixture
+
+data: {"id":"turn-1","model":"fixture-model","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"opaque reasoning"},"finish_reason":null}]}
+
+data: {"id":"turn-1","model":"fixture-model","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call-a","type":"function","function":{"name":"look","arguments":"{\"value\":"}},{"index":1,"id":"call-b","type":"function","function":{"name":"lookup","arguments":"{\"value\":"}}]},"finish_reason":null}]}
+
+data: {"id":"turn-1","model":"fixture-model","choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"function":{"arguments":"2}"}},{"index":0,"function":{"name":"up","arguments":"1}"}}]},"finish_reason":null}]}
+
+data: {"id":"turn-1","model":"fixture-model","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}
+
+data: {"id":"turn-1","model":"fixture-model","choices":[],"usage":{"prompt_tokens":12,"completion_tokens":8,"total_tokens":20}}
+
+data: [DONE]
+

--- a/src/nano/providers/mod.rs
+++ b/src/nano/providers/mod.rs
@@ -1,0 +1,6 @@
+//! Opt-in inference transports. The first target is LM Studio Chat Completions.
+
+pub(crate) mod openai;
+mod sse;
+#[cfg(test)]
+mod tests;

--- a/src/nano/providers/openai.rs
+++ b/src/nano/providers/openai.rs
@@ -99,10 +99,6 @@ impl OpenAi {
         }
 
         if !request.tools.is_empty() {
-            if request.tools.len() > self.settings.max_tool_calls {
-                return Err(error(ProviderErrorKind::ResponseLimit));
-            }
-
             body["tools"] = Value::Array(request.tools.into_iter().map(|tool| json!({
                 "type":"function", "function":{"name":tool.name,"description":tool.description,"parameters":tool.input_schema}
             })).collect());

--- a/src/nano/providers/openai.rs
+++ b/src/nano/providers/openai.rs
@@ -1,0 +1,253 @@
+//! LM Studio /v1/chat/completions transport with optional Bearer authentication.
+
+use super::sse::{Decoder, error};
+use crate::nano::{config::Config, journal::encode, provider::*};
+use anyhow::Result;
+use reqwest::{
+    Client, Response, Url,
+    header::{AUTHORIZATION, CONTENT_TYPE, HeaderValue},
+};
+use serde_json::{Value, json};
+use std::time::Duration;
+
+struct Active {
+    response: Response,
+    decoder: Decoder,
+}
+
+pub(crate) struct OpenAi {
+    client: Client,
+    endpoint: Url,
+    authorization: Option<HeaderValue>,
+    settings: ProviderSettings,
+    active: Option<Active>,
+}
+
+impl OpenAi {
+    pub(crate) fn new(config: Config) -> Result<Self> {
+        let (endpoint, settings) = config.validate()?;
+        let authorization = config.authorization()?;
+        let timeout = Duration::from_millis(settings.request_timeout_ms);
+        let client = Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .retry(reqwest::retry::never())
+            .no_proxy()
+            .connect_timeout(timeout.min(Duration::from_secs(10)))
+            .read_timeout(timeout)
+            .timeout(timeout)
+            .build()
+            .map_err(|_| anyhow::anyhow!("Cannot initialize nano HTTP client"))?;
+
+        Ok(Self {
+            client,
+            endpoint,
+            authorization,
+            settings,
+            active: None,
+        })
+    }
+
+    pub(super) fn body(&self, request: ModelRequest) -> Result<Vec<u8>, ProviderError> {
+        let output = request
+            .max_output_tokens
+            .min(self.settings.max_output_tokens);
+
+        if output == 0 {
+            return Err(error(ProviderErrorKind::ContextOverflow));
+        }
+
+        // Bound the input before constructing the provider-specific projection.
+        encode(
+            &(&request.messages, &request.tools),
+            self.settings.context_tokens as usize,
+        )
+        .map_err(|_| error(ProviderErrorKind::ContextOverflow))?;
+
+        let mut messages = Vec::new();
+        for message in request.messages {
+            messages.push(match message {
+                Message::User { text } => json!({"role":"user", "content":text}),
+                Message::Tool { provider_call_id, outcome } => json!({
+                    "role":"tool", "tool_call_id":provider_call_id,
+                    "content":serde_json::to_string(&outcome).map_err(|_| error(ProviderErrorKind::Protocol))?,
+                }),
+                Message::Assistant { response } => {
+                    let mut value = json!({"role":"assistant", "content":response.text});
+                    if !response.calls.is_empty() {
+                        value["tool_calls"] = Value::Array(response.calls.into_iter().map(|call| json!({
+                            "id":call.provider_call_id,"type":"function", "function":{"name":call.name,"arguments":call.arguments}
+                        })).collect());
+                    }
+                    if let Some(continuation) = response.continuation {
+                        for (key, data) in continuation.as_object().ok_or_else(|| error(ProviderErrorKind::Unsupported))? {
+                            if !matches!(key.as_str(), "reasoning" | "reasoning_content") || !data.is_string() {
+                                return Err(error(ProviderErrorKind::Unsupported));
+                            }
+                            value[key] = data.clone();
+                        }
+                    }
+                    value
+                }
+            });
+        }
+
+        let mut body = json!({"model":self.settings.model, "messages":messages, "stream":true,
+            "temperature":self.settings.temperature, "max_tokens":output, "n":1});
+
+        if self.settings.include_usage {
+            body["stream_options"] = json!({"include_usage":true});
+        }
+
+        if !request.tools.is_empty() {
+            if request.tools.len() > self.settings.max_tool_calls {
+                return Err(error(ProviderErrorKind::ResponseLimit));
+            }
+
+            body["tools"] = Value::Array(request.tools.into_iter().map(|tool| json!({
+                "type":"function", "function":{"name":tool.name,"description":tool.description,"parameters":tool.input_schema}
+            })).collect());
+
+            body["tool_choice"] = json!("auto");
+        }
+
+        // One serialized byte per token is a conservative admission estimate.
+        // The server's context-overflow response remains authoritative.
+        encode(
+            &body,
+            self.settings.context_tokens.saturating_sub(output) as usize,
+        )
+        .map_err(|_| error(ProviderErrorKind::ContextOverflow))
+    }
+}
+
+impl Provider for OpenAi {
+    fn cancel(&mut self) {
+        self.active = None;
+    }
+
+    fn settings(&self) -> Option<ProviderSettings> {
+        Some(self.settings.clone())
+    }
+
+    async fn start(&mut self, request: ModelRequest) -> Result<(), ProviderError> {
+        self.active = None;
+
+        let body = self.body(request)?;
+        let mut request = self
+            .client
+            .post(self.endpoint.clone())
+            .header(CONTENT_TYPE, "application/json")
+            .body(body);
+
+        if let Some(header) = &self.authorization {
+            request = request.header(AUTHORIZATION, header.clone());
+        }
+
+        let mut response = request.send().await.map_err(transport_error)?;
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let retry_after_ms = response
+                .headers()
+                .get("retry-after")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|v| v.parse::<u64>().ok())
+                .unwrap_or(0)
+                .saturating_mul(1000)
+                .min(30_000);
+
+            if status != 400 && status != 413 && status != 422 {
+                let mut failure = error(match status {
+                    401 | 403 => ProviderErrorKind::Authentication,
+                    429 => ProviderErrorKind::RateLimited,
+                    408 | 504 => ProviderErrorKind::Timeout,
+                    500 | 502 | 503 => ProviderErrorKind::Transport,
+                    _ => ProviderErrorKind::Unsupported,
+                });
+
+                failure.retry_after_ms = retry_after_ms;
+
+                return Err(failure);
+            }
+
+            let mut body = Vec::new();
+            while let Some(chunk) = response.chunk().await.map_err(transport_error)? {
+                if chunk.len() > self.settings.event_bytes.saturating_sub(body.len()) {
+                    return Err(error(ProviderErrorKind::ResponseLimit));
+                }
+
+                body.extend_from_slice(&chunk);
+            }
+
+            let code = serde_json::from_slice::<Value>(&body)
+                .ok()
+                .and_then(|v| v.get("error")?.get("code")?.as_str().map(str::to_owned));
+
+            let kind = if matches!(
+                code.as_deref(),
+                Some("context_length_exceeded" | "context_window_exceeded")
+            ) {
+                ProviderErrorKind::ContextOverflow
+            } else {
+                ProviderErrorKind::Unsupported
+            };
+
+            let mut failure = error(kind);
+            failure.retry_after_ms = retry_after_ms;
+
+            return Err(failure);
+        }
+        if !response
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .is_some_and(|v| {
+                v.split(';')
+                    .next()
+                    .is_some_and(|mime| mime.trim().eq_ignore_ascii_case("text/event-stream"))
+            })
+        {
+            return Err(error(ProviderErrorKind::Unsupported));
+        }
+
+        self.active = Some(Active {
+            response,
+            decoder: Decoder::new(self.settings.clone()),
+        });
+
+        Ok(())
+    }
+
+    async fn next_event(&mut self) -> Result<Option<ProviderEvent>, ProviderError> {
+        // Own the response inside the future so cancelling a read closes the stream.
+        let Some(mut active) = self.active.take() else {
+            return Ok(None);
+        };
+
+        loop {
+            if let Some(event) = active.decoder.next() {
+                if !matches!(event, ProviderEvent::Completed { .. }) {
+                    self.active = Some(active);
+                }
+                return Ok(Some(event));
+            }
+
+            let chunk = active
+                .response
+                .chunk()
+                .await
+                .map_err(transport_error)?
+                .ok_or_else(|| error(ProviderErrorKind::TruncatedStream))?;
+
+            active.decoder.push(&chunk)?;
+        }
+    }
+}
+
+fn transport_error(failure: reqwest::Error) -> ProviderError {
+    // Never journal raw URLs, headers, or server error bodies.
+    error(if failure.is_timeout() {
+        ProviderErrorKind::Timeout
+    } else {
+        ProviderErrorKind::Transport
+    })
+}

--- a/src/nano/providers/sse.rs
+++ b/src/nano/providers/sse.rs
@@ -1,0 +1,328 @@
+//! Bounded SSE framing and Chat Completions assembly. Only [DONE] releases calls.
+
+use crate::nano::{provider::*, tools::ToolCall};
+use serde_json::{Value, json};
+use std::collections::{BTreeMap, HashSet, VecDeque};
+
+pub(super) fn error(kind: ProviderErrorKind) -> ProviderError {
+    let retryable = matches!(
+        kind,
+        ProviderErrorKind::TruncatedStream
+            | ProviderErrorKind::Timeout
+            | ProviderErrorKind::Transport
+            | ProviderErrorKind::RateLimited
+    );
+    ProviderError::new(kind, retryable)
+}
+
+#[derive(Default)]
+struct Call {
+    id: String,
+    name: String,
+    arguments: String,
+}
+
+pub(super) struct Decoder {
+    settings: ProviderSettings,
+    bytes: usize,
+    line: Vec<u8>,
+    data: Vec<u8>,
+    events: VecDeque<ProviderEvent>,
+    text: String,
+    reasoning: BTreeMap<String, String>,
+    calls: BTreeMap<usize, Call>,
+    finish: Option<FinishReason>,
+    usage: Option<Usage>,
+    id: Option<String>,
+    model: Option<String>,
+    done: bool,
+}
+
+impl Decoder {
+    pub(super) fn new(settings: ProviderSettings) -> Self {
+        Self {
+            settings,
+            bytes: 0,
+            line: Vec::new(),
+            data: Vec::new(),
+            events: VecDeque::new(),
+            text: String::new(),
+            reasoning: BTreeMap::new(),
+            calls: BTreeMap::new(),
+            finish: None,
+            usage: None,
+            id: None,
+            model: None,
+            done: false,
+        }
+    }
+
+    pub(super) fn next(&mut self) -> Option<ProviderEvent> {
+        self.events.pop_front()
+    }
+
+    pub(super) fn push(&mut self, bytes: &[u8]) -> Result<(), ProviderError> {
+        self.bytes = self.bytes.saturating_add(bytes.len());
+        if self.bytes > self.settings.wire_bytes {
+            return Err(error(ProviderErrorKind::ResponseLimit));
+        }
+
+        for &byte in bytes {
+            if byte == b'\n' {
+                if self.line.last() == Some(&b'\r') {
+                    self.line.pop();
+                }
+
+                let line = std::mem::take(&mut self.line);
+                if line.is_empty() {
+                    if !self.data.is_empty() {
+                        let data = std::mem::take(&mut self.data);
+                        let text = std::str::from_utf8(&data)
+                            .map_err(|_| error(ProviderErrorKind::Protocol))?;
+                        self.event(text.trim())?;
+                    }
+                } else if line.starts_with(b"data:") {
+                    let value = line[5..].strip_prefix(b" ").unwrap_or(&line[5..]);
+                    if !self.data.is_empty() {
+                        self.data.push(b'\n');
+                    }
+                    self.data.extend_from_slice(value);
+                } else if !(line.starts_with(b":")
+                    || line.starts_with(b"id:")
+                    || line.starts_with(b"retry:")
+                    || line == b"event: message")
+                {
+                    return Err(error(ProviderErrorKind::Unsupported));
+                }
+            } else {
+                self.line.push(byte);
+            }
+
+            if self.line.len().saturating_add(self.data.len()) > self.settings.event_bytes {
+                return Err(error(ProviderErrorKind::ResponseLimit));
+            }
+        }
+        Ok(())
+    }
+
+    fn event(&mut self, data: &str) -> Result<(), ProviderError> {
+        if self.done {
+            return Err(error(ProviderErrorKind::Protocol));
+        }
+
+        if data == "[DONE]" {
+            let finish = self
+                .finish
+                .clone()
+                .ok_or_else(|| error(ProviderErrorKind::TruncatedStream))?;
+
+            let mut ids = HashSet::new();
+            let mut calls = Vec::new();
+
+            for (expected, (index, call)) in self.calls.iter().enumerate() {
+                if *index != expected
+                    || call.id.is_empty()
+                    || call.name.is_empty()
+                    || !ids.insert(&call.id)
+                {
+                    return Err(error(ProviderErrorKind::Protocol));
+                }
+
+                calls.push(ToolCall {
+                    provider_call_id: call.id.clone(),
+                    name: call.name.clone(),
+                    arguments: call.arguments.clone(),
+                });
+            }
+
+            if finish != FinishReason::Length
+                && (finish == FinishReason::ToolCalls) == calls.is_empty()
+            {
+                return Err(error(ProviderErrorKind::Protocol));
+            }
+
+            let continuation = (!self.reasoning.is_empty()).then(|| json!(self.reasoning));
+            self.events.push_back(ProviderEvent::Completed {
+                response: ModelResponse {
+                    finish,
+                    text: std::mem::take(&mut self.text),
+                    calls,
+                    continuation,
+                },
+                usage: self.usage.clone(),
+            });
+
+            self.done = true;
+
+            return Ok(());
+        }
+
+        let value: Value =
+            serde_json::from_str(data).map_err(|_| error(ProviderErrorKind::Protocol))?;
+
+        if value.get("error").is_some() {
+            return Err(error(ProviderErrorKind::Protocol));
+        }
+
+        if let Some(id) = value.get("id").and_then(Value::as_str) {
+            if self.id.as_deref().is_some_and(|old| old != id) {
+                return Err(error(ProviderErrorKind::Protocol));
+            }
+            self.id = Some(id.into());
+        }
+
+        if let Some(model) = value.get("model").and_then(Value::as_str) {
+            if self.model.as_deref().is_some_and(|old| old != model) {
+                return Err(error(ProviderErrorKind::Protocol));
+            }
+            self.model = Some(model.into());
+        }
+
+        if let Some(usage) = value.get("usage").filter(|v| !v.is_null()) {
+            if self.usage.is_some() {
+                return Err(error(ProviderErrorKind::Protocol));
+            }
+
+            self.usage = Some(Usage {
+                input_tokens: usage
+                    .get("prompt_tokens")
+                    .and_then(Value::as_u64)
+                    .ok_or_else(|| error(ProviderErrorKind::Protocol))?,
+                output_tokens: usage
+                    .get("completion_tokens")
+                    .and_then(Value::as_u64)
+                    .ok_or_else(|| error(ProviderErrorKind::Protocol))?,
+                reported: true,
+            });
+        }
+
+        let choices = value
+            .get("choices")
+            .and_then(Value::as_array)
+            .ok_or_else(|| error(ProviderErrorKind::Protocol))?;
+
+        if choices.is_empty() {
+            if self.finish.is_none() || self.usage.is_none() {
+                return Err(error(ProviderErrorKind::Protocol));
+            }
+            return Ok(());
+        }
+
+        if choices.len() != 1
+            || choices[0].get("index").and_then(Value::as_u64) != Some(0)
+            || self.finish.is_some()
+        {
+            return Err(error(ProviderErrorKind::Unsupported));
+        }
+
+        let choice = &choices[0];
+        let delta = choice
+            .get("delta")
+            .and_then(Value::as_object)
+            .ok_or_else(|| error(ProviderErrorKind::Protocol))?;
+
+        for (key, value) in delta {
+            if value.is_null() {
+                continue;
+            }
+
+            match key.as_str() {
+                "role" if value.as_str() == Some("assistant") => (),
+                "content" => {
+                    let text = value
+                        .as_str()
+                        .ok_or_else(|| error(ProviderErrorKind::Unsupported))?;
+
+                    self.text.push_str(text);
+                    self.events.push_back(ProviderEvent::TextDelta(text.into()));
+                }
+                "reasoning_content" | "reasoning" => {
+                    let text = value
+                        .as_str()
+                        .ok_or_else(|| error(ProviderErrorKind::Unsupported))?;
+
+                    self.reasoning
+                        .entry(key.clone())
+                        .or_default()
+                        .push_str(text);
+                }
+                "tool_calls" => {
+                    for call in value
+                        .as_array()
+                        .ok_or_else(|| error(ProviderErrorKind::Protocol))?
+                    {
+                        let fields = call
+                            .as_object()
+                            .ok_or_else(|| error(ProviderErrorKind::Protocol))?;
+
+                        if fields.keys().any(|key| {
+                            !matches!(key.as_str(), "index" | "id" | "type" | "function")
+                        }) {
+                            return Err(error(ProviderErrorKind::Unsupported));
+                        }
+
+                        let index = call
+                            .get("index")
+                            .and_then(Value::as_u64)
+                            .ok_or_else(|| error(ProviderErrorKind::Protocol))?;
+
+                        if index >= self.settings.max_tool_calls as u64 {
+                            return Err(error(ProviderErrorKind::ResponseLimit));
+                        }
+
+                        if call.get("type").is_some_and(|v| v != "function") {
+                            return Err(error(ProviderErrorKind::Unsupported));
+                        }
+
+                        let entry = self.calls.entry(index as usize).or_default();
+                        if let Some(id) = call.get("id").filter(|v| !v.is_null()) {
+                            let id = id
+                                .as_str()
+                                .ok_or_else(|| error(ProviderErrorKind::Protocol))?;
+
+                            if !entry.id.is_empty() {
+                                return Err(error(ProviderErrorKind::Protocol));
+                            }
+
+                            entry.id = id.into();
+                        }
+
+                        if let Some(function) = call.get("function") {
+                            let function = function
+                                .as_object()
+                                .ok_or_else(|| error(ProviderErrorKind::Protocol))?;
+
+                            for (field, value) in function {
+                                let text = value
+                                    .as_str()
+                                    .ok_or_else(|| error(ProviderErrorKind::Protocol))?;
+
+                                match field.as_str() {
+                                    "name" => entry.name.push_str(text),
+                                    "arguments" => {
+                                        entry.arguments.push_str(text);
+                                        self.events
+                                            .push_back(ProviderEvent::ArgumentsDelta(text.into()));
+                                    }
+                                    _ => return Err(error(ProviderErrorKind::Unsupported)),
+                                }
+                            }
+                        }
+                    }
+                }
+                _ => return Err(error(ProviderErrorKind::Unsupported)),
+            }
+        }
+
+        if let Some(reason) = choice.get("finish_reason").filter(|v| !v.is_null()) {
+            self.finish = Some(match reason.as_str() {
+                Some("stop") => FinishReason::Stop,
+                Some("tool_calls") => FinishReason::ToolCalls,
+                Some("length") => FinishReason::Length,
+                _ => return Err(error(ProviderErrorKind::Unsupported)),
+            });
+        }
+
+        Ok(())
+    }
+}

--- a/src/nano/providers/tests.rs
+++ b/src/nano/providers/tests.rs
@@ -51,8 +51,9 @@ fn decode(wire: &str, stride: usize) -> Result<Vec<ProviderEvent>, ProviderError
 
 #[test]
 fn split_frames_calls_usage_and_reasoning_are_preserved() {
+    let lf = TOOLS.replace("\r\n", "\n");
     for stride in [1, 3, 8192] {
-        for wire in [TOOLS.to_owned(), TOOLS.replace('\n', "\r\n")] {
+        for wire in [lf.clone(), lf.replace('\n', "\r\n")] {
             let events = decode(&wire, stride).unwrap();
             let ProviderEvent::Completed { response, usage } = events.last().unwrap() else {
                 panic!("Missing completion")
@@ -505,37 +506,40 @@ async fn authenticated_and_anonymous_sessions_record_settings_and_usage_without_
 
 #[tokio::test]
 async fn retries_and_truncated_streams_share_budget_without_duplicate_effects() {
-    let partial = TOOLS.replace("data: [DONE]\n\n", "");
-    let (url, server) = server(vec![
-        Reply::failure(429, "rate_limit"),
-        Reply::stream(&partial),
-        Reply::stream(TOOLS),
-        Reply::stream(FINAL),
-    ])
-    .await;
-    let directory = TempDir::new().unwrap();
-    let mut engine = engine(OpenAi::new(config(&url)).unwrap(), &directory);
-    let end = engine
-        .run(
-            SessionCommand::Start {
-                input: "Use lookup".into(),
-            },
-            &Cancellation::default(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(end.reason, EndReason::ModelFinished);
-    assert_eq!(engine.tools.calls, 2);
-    assert_eq!(end.budget.retries, 2);
-    assert_eq!(end.budget.model_turns, 4);
-    assert!(end.budget.estimated_input_tokens > 0 && end.budget.estimated_output_tokens > 0);
-    assert!(end.budget.elapsed_ms >= 1500);
-    assert!(
-        !serde_json::to_string(&engine.host.records)
-            .unwrap()
-            .contains("secret-server-detail")
-    );
-    assert_eq!(server.await.unwrap().len(), 4);
+    let lf = TOOLS.replace("\r\n", "\n");
+    for wire in [lf.clone(), lf.replace('\n', "\r\n")] {
+        let partial = &wire[..wire.find("data: [DONE]").unwrap()];
+        let (url, server) = server(vec![
+            Reply::failure(429, "rate_limit"),
+            Reply::stream(partial),
+            Reply::stream(&wire),
+            Reply::stream(FINAL),
+        ])
+        .await;
+        let directory = TempDir::new().unwrap();
+        let mut engine = engine(OpenAi::new(config(&url)).unwrap(), &directory);
+        let end = engine
+            .run(
+                SessionCommand::Start {
+                    input: "Use lookup".into(),
+                },
+                &Cancellation::default(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(end.reason, EndReason::ModelFinished);
+        assert_eq!(engine.tools.calls, 2);
+        assert_eq!(end.budget.retries, 2);
+        assert_eq!(end.budget.model_turns, 4);
+        assert!(end.budget.estimated_input_tokens > 0 && end.budget.estimated_output_tokens > 0);
+        assert!(end.budget.elapsed_ms >= 1500);
+        assert!(
+            !serde_json::to_string(&engine.host.records)
+                .unwrap()
+                .contains("secret-server-detail")
+        );
+        assert_eq!(server.await.unwrap().len(), 4);
+    }
 }
 
 #[tokio::test]

--- a/src/nano/providers/tests.rs
+++ b/src/nano/providers/tests.rs
@@ -146,6 +146,67 @@ fn partial_streams_never_release_completed_calls_and_unsupported_features_fail()
 }
 
 #[test]
+fn provider_inputs_open_read_only_and_reject_unsafe_paths() {
+    let directory = TempDir::new().unwrap();
+    let key = directory.path().join("key");
+    private::file(&key, true)
+        .unwrap()
+        .write_all(b"fixture-token")
+        .unwrap();
+    let settings = directory.path().join("nano.toml");
+    let mut cfg = config("http://127.0.0.1:1234/v1");
+    cfg.api_key_file = Some(key.clone());
+    private::file(&settings, true)
+        .unwrap()
+        .write_all(b"base_url = 'http://127.0.0.1:1234/v1'\nmodel = 'fixture-model'\n")
+        .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        for path in [&key, &settings] {
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o400)).unwrap();
+        }
+    }
+    #[cfg(windows)]
+    for path in [&key, &settings] {
+        let mut permissions = std::fs::metadata(path).unwrap().permissions();
+        permissions.set_readonly(true);
+        std::fs::set_permissions(path, permissions).unwrap();
+    }
+    assert_eq!(Config::load(&settings).unwrap().model, "fixture-model");
+    assert_eq!(
+        cfg.authorization().unwrap().unwrap(),
+        "Bearer fixture-token"
+    );
+    assert!(
+        private::read_only_file(&key)
+            .unwrap()
+            .write_all(b"overwrite")
+            .is_err()
+    );
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{PermissionsExt, symlink};
+        let link = directory.path().join("link");
+        symlink(&key, &link).unwrap();
+        cfg.api_key_file = Some(link.clone());
+        assert!(cfg.authorization().is_err());
+        assert!(Config::load(&link).is_err());
+        cfg.api_key_file = Some(key.clone());
+        std::fs::set_permissions(&key, std::fs::Permissions::from_mode(0o444)).unwrap();
+        assert!(cfg.authorization().is_err());
+    }
+    assert!(Config::load(directory.path()).is_err());
+    assert_eq!(std::fs::read(&key).unwrap(), b"fixture-token");
+    #[cfg(windows)]
+    for path in [&key, &settings] {
+        let mut permissions = std::fs::metadata(path).unwrap().permissions();
+        permissions.set_readonly(false);
+        std::fs::set_permissions(path, permissions).unwrap();
+    }
+}
+
+#[test]
 fn host_configuration_rejects_inline_secrets_and_private_file_errors_without_echoing_them() {
     let directory = TempDir::new().unwrap();
     let path = directory.path().join("nano.toml");

--- a/src/nano/providers/tests.rs
+++ b/src/nano/providers/tests.rs
@@ -265,6 +265,34 @@ async fn context_overflow_ends_the_session_without_retrying_or_executing_tools()
 }
 
 #[test]
+fn advertised_tools_are_bounded_by_context_not_generated_call_count() {
+    for max_tool_calls in [1, 64] {
+        let mut cfg = config("http://127.0.0.1:1234/v1");
+        cfg.max_tool_calls = max_tool_calls;
+        let context_tokens = cfg.context_tokens;
+        let provider = OpenAi::new(cfg).unwrap();
+        let mut request = request();
+        request.tools = (0..=max_tool_calls)
+            .map(|index| ToolDescriptor {
+                name: format!("lookup_{index}"),
+                ..request.tools[0].clone()
+            })
+            .collect();
+        let body: Value = serde_json::from_slice(&provider.body(request.clone()).unwrap()).unwrap();
+        assert_eq!(body["tools"].as_array().unwrap().len(), max_tool_calls + 1);
+        for (tool, advertised) in request.tools.iter().zip(body["tools"].as_array().unwrap()) {
+            assert_eq!(advertised["function"]["name"], tool.name);
+            assert_eq!(advertised["function"]["parameters"], tool.input_schema);
+        }
+        request.tools[0].description = "x".repeat(context_tokens as usize);
+        assert_eq!(
+            provider.body(request).unwrap_err().kind,
+            ProviderErrorKind::ContextOverflow
+        );
+    }
+}
+
+#[test]
 fn configuration_and_transport_bounds_fail_explicitly() {
     for url in [
         "http://example.com/v1",
@@ -283,6 +311,12 @@ fn configuration_and_transport_bounds_fail_explicitly() {
         ProviderErrorKind::ContextOverflow
     );
     let mut settings = config("http://127.0.0.1:1234/v1").validate().unwrap().1;
+    settings.max_tool_calls = 1;
+    let mut decoder = Decoder::new(settings.clone());
+    assert_eq!(
+        decoder.push(TOOLS.as_bytes()).unwrap_err().kind,
+        ProviderErrorKind::ResponseLimit
+    );
     settings.event_bytes = 256;
     let mut decoder = Decoder::new(settings.clone());
     assert_eq!(

--- a/src/nano/providers/tests.rs
+++ b/src/nano/providers/tests.rs
@@ -1,0 +1,581 @@
+//! Offline wire fixtures and loopback HTTP tests; live inference is explicitly ignored.
+
+use super::{openai::OpenAi, sse::Decoder};
+use crate::nano::{
+    config::Config,
+    engine::Engine,
+    journal::{FileJournal, Quotas},
+    private,
+    provider::*,
+    session::*,
+    tools::*,
+};
+use serde_json::{Value, json};
+use std::{io::Write, time::Duration};
+use tempfile::TempDir;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpListener,
+};
+
+const TOOLS: &str = include_str!("fixtures/tools.sse");
+const FINAL: &str = include_str!("fixtures/final.sse");
+
+fn config(url: &str) -> Config {
+    toml::from_str(&format!("base_url = {url:?}\nmodel = 'fixture-model'\n")).unwrap()
+}
+
+fn request() -> ModelRequest {
+    ModelRequest {
+        messages: vec![Message::User {
+            text: "Use lookup, then report its result".into(),
+        }],
+        tools: Lookup::default().descriptors(),
+        max_output_tokens: 4096,
+    }
+}
+
+fn decode(wire: &str, stride: usize) -> Result<Vec<ProviderEvent>, ProviderError> {
+    let mut decoder = Decoder::new(config("http://127.0.0.1:1234/v1").validate().unwrap().1);
+    let mut events = Vec::new();
+
+    for bytes in wire.as_bytes().chunks(stride) {
+        decoder.push(bytes)?;
+        while let Some(event) = decoder.next() {
+            events.push(event);
+        }
+    }
+
+    Ok(events)
+}
+
+#[test]
+fn split_frames_calls_usage_and_reasoning_are_preserved() {
+    for stride in [1, 3, 8192] {
+        for wire in [TOOLS.to_owned(), TOOLS.replace('\n', "\r\n")] {
+            let events = decode(&wire, stride).unwrap();
+            let ProviderEvent::Completed { response, usage } = events.last().unwrap() else {
+                panic!("Missing completion")
+            };
+            assert_eq!(response.finish, FinishReason::ToolCalls);
+            assert_eq!(
+                response
+                    .calls
+                    .iter()
+                    .map(|c| (&*c.provider_call_id, &*c.name, &*c.arguments))
+                    .collect::<Vec<_>>(),
+                [
+                    ("call-a", "lookup", "{\"value\":1}"),
+                    ("call-b", "lookup", "{\"value\":2}")
+                ]
+            );
+            assert_eq!(usage.as_ref().unwrap().input_tokens, 12);
+            assert_eq!(usage.as_ref().unwrap().output_tokens, 8);
+            assert!(usage.as_ref().unwrap().reported);
+            assert_eq!(
+                response.continuation,
+                Some(json!({"reasoning_content":"opaque reasoning"}))
+            );
+            let provider = OpenAi::new(config("http://127.0.0.1:1234/v1")).unwrap();
+            let body: Value = serde_json::from_slice(
+                &provider
+                    .body(ModelRequest {
+                        messages: vec![
+                            Message::Assistant {
+                                response: response.clone(),
+                            },
+                            Message::Tool {
+                                provider_call_id: "call-a".into(),
+                                outcome: ToolOutcome::Success(json!(42)),
+                            },
+                        ],
+                        ..request()
+                    })
+                    .unwrap(),
+            )
+            .unwrap();
+            assert_eq!(body["messages"][0]["reasoning_content"], "opaque reasoning");
+            assert_eq!(body["messages"][0]["tool_calls"][0]["id"], "call-a");
+            assert_eq!(body["messages"][1]["tool_call_id"], "call-a");
+        }
+    }
+    let unicode = FINAL.replace("42", "caf\u{e9}");
+    assert!(
+        matches!(decode(&unicode, 1).unwrap().last(), Some(ProviderEvent::Completed { response, .. }) if response.text == "caf\u{e9}")
+    );
+}
+
+#[test]
+fn partial_streams_never_release_completed_calls_and_unsupported_features_fail() {
+    for cut in [
+        TOOLS.find("finish_reason\":\"tool_calls").unwrap(),
+        TOOLS.find("data: [DONE]").unwrap(),
+    ] {
+        assert!(
+            decode(&TOOLS[..cut], 7)
+                .unwrap()
+                .iter()
+                .all(|e| !matches!(e, ProviderEvent::Completed { .. }))
+        );
+    }
+    for wire in [
+        FINAL.replace("\"stop\"", "\"content_filter\""),
+        FINAL.replace("\"content\":\"42\"", "\"audio\":{}"),
+        FINAL.replace("\"index\":0", "\"index\":1"),
+        TOOLS.replace("call-b", "call-a"),
+        TOOLS.replace("\"index\":1", "\"index\":99999"),
+        "data: [DONE]\n\n".into(),
+        "data: {broken}\n\n".into(),
+    ] {
+        assert!(decode(&wire, 1).is_err(), "Malformed fixture accepted");
+    }
+    let events = decode(&FINAL.replace("\"stop\"", "\"length\""), 7).unwrap();
+    assert!(
+        matches!(events.last(), Some(ProviderEvent::Completed { response, .. }) if response.finish == FinishReason::Length)
+    );
+    let no_usage = FINAL
+        .lines()
+        .filter(|l| !l.contains("\"usage\""))
+        .collect::<Vec<_>>()
+        .join("\n")
+        + "\n";
+    assert!(matches!(
+        decode(&no_usage, 1).unwrap().last(),
+        Some(ProviderEvent::Completed { usage: None, .. })
+    ));
+}
+
+#[test]
+fn host_configuration_rejects_inline_secrets_and_private_file_errors_without_echoing_them() {
+    let directory = TempDir::new().unwrap();
+    let path = directory.path().join("nano.toml");
+    private::file(&path, true).unwrap().write_all(b"base_url = 'http://127.0.0.1:1234/v1'\nmodel = 'fixture-model'\napi_key = 'inline-secret'\n").unwrap();
+    let error = Config::load(&path).unwrap_err();
+    assert!(!format!("{error:?}").contains("inline-secret"));
+    std::fs::write(
+        &path,
+        "base_url = 'http://127.0.0.1:1234/v1'\nmodel = 'fixture-model'\n",
+    )
+    .unwrap();
+    assert!(
+        Config::load(&path)
+            .unwrap()
+            .authorization()
+            .unwrap()
+            .is_none()
+    );
+    let key = directory.path().join("key");
+    private::file(&key, true)
+        .unwrap()
+        .write_all(b"bad\nsecret")
+        .unwrap();
+    let mut cfg = config("http://127.0.0.1:1234/v1");
+    cfg.api_key_file = Some(key);
+    assert!(!format!("{:?}", cfg.authorization().unwrap_err()).contains("secret"));
+}
+
+#[tokio::test]
+async fn context_overflow_ends_the_session_without_retrying_or_executing_tools() {
+    let (url, server) = server(vec![Reply::failure(400, "context_length_exceeded")]).await;
+    let directory = TempDir::new().unwrap();
+    let mut engine = engine(OpenAi::new(config(&url)).unwrap(), &directory);
+    let end = engine
+        .run(
+            SessionCommand::Start {
+                input: "Use lookup".into(),
+            },
+            &Cancellation::default(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(end.reason, EndReason::Limit(LimitKind::ContextTokens));
+    assert_eq!(end.budget.model_turns, 1);
+    assert_eq!(end.budget.retries, 0);
+    assert_eq!(engine.tools.calls, 0);
+    assert!(engine.host.records.iter().any(|r| matches!(
+        r.event,
+        SessionEvent::ModelFailed {
+            error: Some(ProviderErrorKind::ContextOverflow),
+            ..
+        }
+    )));
+    server.await.unwrap();
+}
+
+#[test]
+fn configuration_and_transport_bounds_fail_explicitly() {
+    for url in [
+        "http://example.com/v1",
+        "http://secret@127.0.0.1/v1",
+        "http://127.0.0.1/v1?key=secret",
+        "http://127.0.0.1/api/v1",
+    ] {
+        assert!(config(url).validate().is_err());
+    }
+    let mut cfg = config("http://127.0.0.1:1234/v1");
+    cfg.context_tokens = 100;
+    cfg.max_output_tokens = 99;
+    let provider = OpenAi::new(cfg).unwrap();
+    assert_eq!(
+        provider.body(request()).unwrap_err().kind,
+        ProviderErrorKind::ContextOverflow
+    );
+    let mut settings = config("http://127.0.0.1:1234/v1").validate().unwrap().1;
+    settings.event_bytes = 256;
+    let mut decoder = Decoder::new(settings.clone());
+    assert_eq!(
+        decoder.push(&vec![b'x'; 257]).unwrap_err().kind,
+        ProviderErrorKind::ResponseLimit
+    );
+    settings.wire_bytes = 1024;
+    let mut decoder = Decoder::new(settings);
+    assert_eq!(
+        decoder.push(&vec![b'\n'; 1025]).unwrap_err().kind,
+        ProviderErrorKind::ResponseLimit
+    );
+}
+
+struct Reply {
+    status: u16,
+    body: String,
+    headers: &'static str,
+    stall: bool,
+}
+impl Reply {
+    fn stream(body: &str) -> Self {
+        Self {
+            status: 200,
+            body: body.into(),
+            headers: "Content-Type: text/event-stream\r\n",
+            stall: false,
+        }
+    }
+    fn failure(status: u16, code: &str) -> Self {
+        Self {
+            status,
+            body: json!({"error":{"code":code,"message":"secret-server-detail"}}).to_string(),
+            headers: "Retry-After: 1\r\n",
+            stall: false,
+        }
+    }
+}
+
+async fn server(replies: Vec<Reply>) -> (String, tokio::task::JoinHandle<Vec<(String, Value)>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = format!("http://{}/v1", listener.local_addr().unwrap());
+    let task = tokio::spawn(async move {
+        let mut requests = Vec::new();
+        for reply in replies {
+            let (mut socket, _) = tokio::time::timeout(Duration::from_secs(10), listener.accept())
+                .await
+                .unwrap()
+                .unwrap();
+            let mut bytes = Vec::new();
+            let (headers, body) = loop {
+                let mut buf = [0; 4096];
+                let count = socket.read(&mut buf).await.unwrap();
+                assert!(count > 0);
+                bytes.extend_from_slice(&buf[..count]);
+                assert!(bytes.len() < 1024 * 1024);
+                if let Some(end) = bytes.windows(4).position(|v| v == b"\r\n\r\n") {
+                    let headers = String::from_utf8(bytes[..end].to_vec()).unwrap();
+                    let length: usize = headers
+                        .lines()
+                        .find_map(|l| {
+                            l.to_ascii_lowercase()
+                                .strip_prefix("content-length: ")
+                                .map(str::to_owned)
+                        })
+                        .unwrap()
+                        .parse()
+                        .unwrap();
+                    if bytes.len() >= end + 4 + length {
+                        break (
+                            headers,
+                            serde_json::from_slice(&bytes[end + 4..end + 4 + length]).unwrap(),
+                        );
+                    }
+                }
+            };
+            requests.push((headers, body));
+            let head = format!(
+                "HTTP/1.1 {} Fixture\r\n{}Content-Length: {}\r\nConnection: close\r\n\r\n",
+                reply.status,
+                reply.headers,
+                if reply.stall { 99999 } else { reply.body.len() }
+            );
+            socket.write_all(head.as_bytes()).await.unwrap();
+            if reply.stall {
+                socket.write_all(reply.body.as_bytes()).await.unwrap();
+                let mut buf = [0; 1];
+                let closed = tokio::time::timeout(Duration::from_secs(5), socket.read(&mut buf))
+                    .await
+                    .unwrap();
+                assert!(
+                    matches!(closed, Ok(0) | Err(_)),
+                    "Cancelled stream remained open"
+                );
+            } else {
+                for chunk in reply.body.as_bytes().chunks(7) {
+                    if socket.write_all(chunk).await.is_err() {
+                        break;
+                    }
+                }
+            }
+        }
+        requests
+    });
+    (url, task)
+}
+
+#[derive(Default)]
+struct Lookup {
+    calls: usize,
+}
+impl Tools for Lookup {
+    fn descriptors(&self) -> Vec<ToolDescriptor> {
+        vec![ToolDescriptor {
+            name: "lookup".into(),
+            description: "Return the answer to the smoke test. Call this tool before answering."
+                .into(),
+            input_schema: json!({"type":"object","properties":{"value":{"type":"integer"}},"required":["value"],"additionalProperties":false}),
+        }]
+    }
+    fn validate(&self, _: &str, arguments: &Value) -> Result<(), ToolError> {
+        if arguments
+            .as_object()
+            .is_some_and(|o| o.len() == 1 && o.get("value").is_some_and(Value::is_i64))
+        {
+            Ok(())
+        } else {
+            Err(ToolError::InvalidArguments)
+        }
+    }
+    async fn execute(&mut self, _: &ValidatedCall, _: &Cancellation) -> ToolOutcome {
+        self.calls += 1;
+        ToolOutcome::Success(json!({"answer":42}))
+    }
+}
+#[derive(Default)]
+struct TestHost {
+    records: Vec<Record>,
+}
+impl Host for TestHost {
+    async fn authorize(&mut self, _: &ValidatedCall) -> Result<(), ToolError> {
+        Ok(())
+    }
+    fn committed(&mut self, record: &Record) {
+        self.records.push(record.clone());
+    }
+}
+
+fn engine(provider: OpenAi, directory: &TempDir) -> Engine<OpenAi, Lookup, TestHost, FileJournal> {
+    Engine::new(
+        SessionIdentity {
+            session_id: "smoke-1".into(),
+            project_id: "fixture".into(),
+            task_id: None,
+            run_id: None,
+        },
+        Limits {
+            tokens: 1_000_000,
+            model_turns: 6,
+            ..Default::default()
+        },
+        provider,
+        Lookup::default(),
+        TestHost::default(),
+        FileJournal::create(
+            &directory.path().canonicalize().unwrap(),
+            "smoke-1",
+            Quotas::default(),
+        )
+        .unwrap(),
+    )
+    .unwrap()
+}
+
+#[tokio::test]
+async fn authenticated_and_anonymous_sessions_record_settings_and_usage_without_secrets() {
+    for authenticate in [false, true] {
+        let (url, server) = server(vec![Reply::stream(TOOLS), Reply::stream(FINAL)]).await;
+        let directory = TempDir::new().unwrap();
+        let mut cfg = config(&url);
+        if authenticate {
+            let path = directory.path().join("credential");
+            private::file(&path, true)
+                .unwrap()
+                .write_all(b"fixture-private-token")
+                .unwrap();
+            cfg.api_key_file = Some(path);
+        }
+        let mut engine = engine(OpenAi::new(cfg).unwrap(), &directory);
+        let end = engine
+            .run(
+                SessionCommand::Start {
+                    input: "Use lookup with value 1, then report the answer.".into(),
+                },
+                &Cancellation::default(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(end.reason, EndReason::ModelFinished);
+        assert_eq!(engine.tools.calls, 2);
+        assert_eq!(end.budget.reported_input_tokens, 36);
+        assert_eq!(end.budget.reported_output_tokens, 11);
+        let records = serde_json::to_string(&engine.host.records).unwrap();
+        assert!(
+            records.contains("fixture-model") && records.contains("openai_chat_completions_v1")
+        );
+        assert!(!records.contains("fixture-private-token") && !records.contains("api_key_file"));
+        for (headers, body) in server.await.unwrap() {
+            assert_eq!(
+                headers
+                    .to_ascii_lowercase()
+                    .contains("authorization: bearer fixture-private-token"),
+                authenticate
+            );
+            assert!(headers.starts_with("POST /v1/chat/completions "));
+            assert_eq!(body["stream"], true);
+            assert_eq!(body["max_tokens"], 4096);
+        }
+    }
+}
+
+#[tokio::test]
+async fn retries_and_truncated_streams_share_budget_without_duplicate_effects() {
+    let partial = TOOLS.replace("data: [DONE]\n\n", "");
+    let (url, server) = server(vec![
+        Reply::failure(429, "rate_limit"),
+        Reply::stream(&partial),
+        Reply::stream(TOOLS),
+        Reply::stream(FINAL),
+    ])
+    .await;
+    let directory = TempDir::new().unwrap();
+    let mut engine = engine(OpenAi::new(config(&url)).unwrap(), &directory);
+    let end = engine
+        .run(
+            SessionCommand::Start {
+                input: "Use lookup".into(),
+            },
+            &Cancellation::default(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(end.reason, EndReason::ModelFinished);
+    assert_eq!(engine.tools.calls, 2);
+    assert_eq!(end.budget.retries, 2);
+    assert_eq!(end.budget.model_turns, 4);
+    assert!(end.budget.estimated_input_tokens > 0 && end.budget.estimated_output_tokens > 0);
+    assert!(end.budget.elapsed_ms >= 1500);
+    assert!(
+        !serde_json::to_string(&engine.host.records)
+            .unwrap()
+            .contains("secret-server-detail")
+    );
+    assert_eq!(server.await.unwrap().len(), 4);
+}
+
+#[tokio::test]
+async fn status_errors_and_context_overflow_are_typed_and_not_retried() {
+    for (status, code, kind) in [
+        (401, "invalid_api_key", ProviderErrorKind::Authentication),
+        (
+            400,
+            "context_length_exceeded",
+            ProviderErrorKind::ContextOverflow,
+        ),
+        (400, "unsupported", ProviderErrorKind::Unsupported),
+    ] {
+        let (url, server) = server(vec![Reply::failure(status, code)]).await;
+        let mut provider = OpenAi::new(config(&url)).unwrap();
+        let error = provider.start(request()).await.unwrap_err();
+        assert_eq!(error.kind, kind);
+        assert!(!error.retryable);
+        assert!(!format!("{error:?}").contains("secret-server-detail"));
+        server.await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn authentication_failure_does_not_wait_for_a_stalled_error_body() {
+    let mut reply = Reply::failure(401, "invalid_api_key");
+    reply.body.clear();
+    reply.stall = true;
+    let (url, server) = server(vec![reply]).await;
+    let mut provider = OpenAi::new(config(&url)).unwrap();
+    let error = provider.start(request()).await.unwrap_err();
+    assert_eq!(error.kind, ProviderErrorKind::Authentication);
+    assert!(!error.retryable);
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn cancellation_between_buffered_events_closes_the_stream() {
+    let mut reply = Reply::stream(
+        "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"partial\"},\"finish_reason\":null}]}\n\n",
+    );
+    reply.stall = true;
+    let (url, server) = server(vec![reply]).await;
+    let mut provider = OpenAi::new(config(&url)).unwrap();
+    provider.start(request()).await.unwrap();
+    assert!(matches!(
+        provider.next_event().await.unwrap(),
+        Some(ProviderEvent::TextDelta(_))
+    ));
+    provider.cancel();
+    assert!(provider.next_event().await.unwrap().is_none());
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn stalled_stream_timeout_and_cancellation_close_the_connection() {
+    for cancel in [false, true] {
+        let mut reply = Reply::stream("");
+        reply.stall = true;
+        let (url, server) = server(vec![reply]).await;
+        let mut cfg = config(&url);
+        cfg.request_timeout_ms = if cancel { 10_000 } else { 1000 };
+        let mut provider = OpenAi::new(cfg).unwrap();
+        provider.start(request()).await.unwrap();
+        if cancel {
+            assert!(
+                tokio::time::timeout(Duration::from_millis(10), provider.next_event())
+                    .await
+                    .is_err()
+            );
+        } else {
+            assert_eq!(
+                provider.next_event().await.unwrap_err().kind,
+                ProviderErrorKind::Timeout
+            );
+        }
+        assert!(provider.next_event().await.unwrap().is_none());
+        server.await.unwrap();
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires an explicitly configured LM Studio server and loaded tool-capable model"]
+async fn live_lm_studio_tool_session() {
+    let path = std::env::var_os("FERRUS_NANO_SMOKE_CONFIG")
+        .expect("Set FERRUS_NANO_SMOKE_CONFIG to the private host settings file");
+    let cfg = Config::load(std::path::Path::new(&path)).unwrap();
+    let model = cfg.model.clone();
+    let directory = TempDir::new().unwrap();
+    let mut engine = engine(OpenAi::new(cfg).unwrap(), &directory);
+    let end = engine.run(SessionCommand::Start { input:"Call the lookup tool with value 1. Then report the answer field from its result. Do not answer before calling the tool.".into() }, &Cancellation::default()).await.unwrap();
+    assert_eq!(end.reason, EndReason::ModelFinished);
+    assert!(engine.tools.calls > 0);
+    assert!(engine.host.records.iter().any(|record| matches!(&record.event,
+        SessionEvent::ModelCompleted { response, .. } if response.is_final() && response.text.contains("42"))));
+    println!(
+        "model={model} tool_calls={} reported_input={} reported_output={} estimated_input={} estimated_output={}",
+        engine.tools.calls,
+        end.budget.reported_input_tokens,
+        end.budget.reported_output_tokens,
+        end.budget.estimated_input_tokens,
+        end.budget.estimated_output_tokens
+    );
+}

--- a/src/nano/providers/tests.rs
+++ b/src/nano/providers/tests.rs
@@ -466,6 +466,22 @@ impl Host for TestHost {
 }
 
 fn engine(provider: OpenAi, directory: &TempDir) -> Engine<OpenAi, Lookup, TestHost, FileJournal> {
+    engine_with_limits(
+        provider,
+        directory,
+        Limits {
+            tokens: 1_000_000,
+            model_turns: 6,
+            ..Default::default()
+        },
+    )
+}
+
+fn engine_with_limits(
+    provider: OpenAi,
+    directory: &TempDir,
+    limits: Limits,
+) -> Engine<OpenAi, Lookup, TestHost, FileJournal> {
     Engine::new(
         SessionIdentity {
             session_id: "smoke-1".into(),
@@ -473,11 +489,7 @@ fn engine(provider: OpenAi, directory: &TempDir) -> Engine<OpenAi, Lookup, TestH
             task_id: None,
             run_id: None,
         },
-        Limits {
-            tokens: 1_000_000,
-            model_turns: 6,
-            ..Default::default()
-        },
+        limits,
         provider,
         Lookup::default(),
         TestHost::default(),
@@ -573,6 +585,54 @@ async fn retries_and_truncated_streams_share_budget_without_duplicate_effects() 
                 .contains("secret-server-detail")
         );
         assert_eq!(server.await.unwrap().len(), 4);
+    }
+}
+
+#[tokio::test]
+async fn transient_failures_charge_only_the_effective_output_cap() {
+    let partial = &FINAL[..FINAL.find("data: [DONE]").unwrap()];
+    let (url, server) = server(vec![
+        Reply::failure(429, "rate_limit"),
+        Reply::failure(503, "unavailable"),
+        Reply::stream(partial),
+        Reply::stream(FINAL),
+    ])
+    .await;
+    let directory = TempDir::new().unwrap();
+    let cfg = config(&url);
+    let output_cap = cfg.max_output_tokens;
+    let mut engine = engine_with_limits(OpenAi::new(cfg).unwrap(), &directory, Limits::default());
+    let end = engine
+        .run(
+            SessionCommand::Start {
+                input: "x".repeat(8192),
+            },
+            &Cancellation::default(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(end.reason, EndReason::ModelFinished);
+    assert_eq!(end.budget.retries, 3);
+    assert_eq!(end.budget.model_turns, 4);
+    assert_eq!(end.budget.estimated_output_tokens, 3 * output_cap);
+    for record in &engine.host.records {
+        match &record.event {
+            SessionEvent::ModelStarted { .. } => {
+                assert_eq!(record.budget.reserved_output_tokens, output_cap);
+            }
+            SessionEvent::ModelFailed { usage, .. } => {
+                assert_eq!(usage.output_tokens, output_cap);
+                assert!(!usage.reported);
+            }
+            _ => (),
+        }
+    }
+    let replay = crate::nano::replay::Replay::from_records(&engine.host.records).unwrap();
+    assert_eq!(replay.budget, end.budget);
+    let requests = server.await.unwrap();
+    assert_eq!(requests.len(), 4);
+    for (_, body) in requests {
+        assert_eq!(body["max_tokens"], output_cap);
     }
 }
 

--- a/src/nano/session.rs
+++ b/src/nano/session.rs
@@ -2,7 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::provider::{ModelResponse, Usage};
+use super::provider::{ModelResponse, ProviderErrorKind, ProviderSettings, Usage};
 use super::tools::{ToolCall, ToolOutcome};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -122,6 +122,7 @@ pub(crate) enum LimitKind {
     NoProgress,
     Elapsed,
     ContextBytes,
+    ContextTokens,
     ResponseBytes,
     ToolOutputBytes,
 }
@@ -139,13 +140,15 @@ pub(crate) enum EndReason {
     EffectUnknown,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "event", rename_all = "snake_case")]
 pub(crate) enum SessionEvent {
     Started {
         identity: SessionIdentity,
         limits: Limits,
         input: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        provider: Option<Box<ProviderSettings>>,
     },
     ModelStarted {
         turn: u64,
@@ -157,6 +160,8 @@ pub(crate) enum SessionEvent {
     ModelFailed {
         retryable: bool,
         usage: Usage,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        error: Option<ProviderErrorKind>,
     },
     ToolIntent {
         call_id: String,
@@ -171,7 +176,7 @@ pub(crate) enum SessionEvent {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct Record {
     pub version: u32,


### PR DESCRIPTION
## Summary

Add Nano's first streaming inference adapter, targeting LM Studio's OpenAI-compatible Chat Completions API behind the optional `nano-openai` feature.

- Support an explicit endpoint/model and anonymous requests or Bearer authentication from a private credential file.
- Assemble bounded SSE responses, split tool arguments, call IDs, usage, and supported reasoning continuation. Release completed calls only after a finish reason and `[DONE]`.
- Charge transient retries and backoff to the existing session budget; record non-secret provider settings and typed failures. Close retained streams on cancellation and session exit.
- Add protocol fixtures, loopback HTTP tests, feature coverage in CI, and host configuration documentation.

Closes #75.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Enhancement
- [ ] Performance
- [x] Documentation
- [ ] Refactor
- [ ] Security
- [ ] Breaking change

## Workflow impact (if applicable)

- [x] No impact
- [ ] Minor change (does not alter lifecycle semantics)
- [ ] Changes behavior of an existing step
- [ ] Introduces new state/transition

Ferrus task/run lifecycle and external-agent configuration are unchanged. Provider loading is explicit; ordinary Ferrus paths initialize no inference client. Nano CLI and HQ launch remain follow-up work.

## Checklist

- [x] I added/updated tests where it makes sense
- [x] I updated docs/examples if needed
- [x] This change is backwards-compatible (or clearly marked as breaking)
- [x] I ran formatting/lints locally (if applicable)

## Notes for reviewers

Focus on the completion gate for tool calls, cancellation between buffered events, and retry/usage accounting. Credentials and raw server errors stay out of journal records. New journal fields are optional, preserving existing version-1 records.

Local validation passed: `cargo fmt --check`, Clippy with `-D warnings` for default and provider feature combinations, full tests with and without the provider (946 tests with `nano-openai`), and 49 Nano tests with default features disabled.

The live LM Studio smoke test is opt-in and was not run because the server was offline. Compatibility with a loaded model remains unverified; other OpenAI-compatible endpoints and unsupported protocol features are not implicitly supported.
