### PR TITLE
feat(nano): add bounded native workspace tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,6 +597,7 @@ dependencies = [
  "tracing-subscriber",
  "tree-sitter",
  "tree-sitter-rust",
+ "unicode-normalization",
  "ureq",
  "windows-sys 0.61.2",
 ]
@@ -2274,6 +2275,15 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ errno = "0.3.14"
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61.2", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_Diagnostics_ToolHelp", "Win32_System_IO", "Win32_System_JobObjects", "Win32_System_Threading"] }
+windows-sys = { version = "0.61.2", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_SystemServices", "Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_Diagnostics_ToolHelp", "Win32_System_IO", "Win32_System_JobObjects", "Win32_System_Threading"] }
 
 [dev-dependencies]
 criterion = { version = "0.8.2", default-features = false, features = ["cargo_bench_support"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ tree-sitter-rust = "=0.24.2"
 [target.'cfg(unix)'.dependencies]
 errno = "0.3.14"
 libc = "0.2"
+unicode-normalization = "0.1.25"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61.2", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_SystemServices", "Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_Diagnostics_ToolHelp", "Win32_System_IO", "Win32_System_JobObjects", "Win32_System_Threading"] }

--- a/docs/ferrus-nano-architecture.md
+++ b/docs/ferrus-nano-architecture.md
@@ -247,6 +247,7 @@ tool catalog. They remain available to the runtime without spending inference tu
 File tools confine paths to authorized roots, handle symlinks safely, preserve unrelated edits,
 and check the expected content before writing. Validate all patch hunks before applying a patch;
 report any partial filesystem failure precisely rather than promising a multi-file transaction.
+The implemented #76 tool contract is documented in [Nano workspace tools](ferrus-nano-workspace.md).
 Keep original/new digests sufficient to reconcile an interrupted edit. Do not silently apply a
 stale edit with fuzzy matching. Binary and oversized content return explicit limitations.
 

--- a/docs/ferrus-nano-workspace.md
+++ b/docs/ferrus-nano-workspace.md
@@ -1,0 +1,98 @@
+# Nano workspace tools
+
+Issue #76 supplies a `Workspace` implementation of Nano's `Tools` port. It does not
+register MCP handlers, start a model, or launch an Executor. The managed host must
+validate the session authority and supply the assigned workspace root; standalone
+hosts can supply an explicitly authorized root through the same constructor.
+
+## Read and search
+
+- `read_file`: `path`, optional 1-based `start_line`, `max_lines`, and `max_bytes`.
+  Returns whole UTF-8 lines, their full-file SHA-256 digest, and explicit truncation.
+  Line endings are returned verbatim. A line exceeding the byte allowance is omitted;
+  `returned_lines = 0` with `truncated = true` means the first selected line did not fit.
+  A range beyond EOF returns no text with `truncated = false`.
+- `search_text`: literal, case-sensitive `query`, optional file/directory `paths`
+  (default `["."]`), and `max_results`. Traversal is lexical within the admitted entry
+  set. Each matching line yields one result with a 1-based line and UTF-8 byte column,
+  a bounded snippet around the first match, and its source digest. Unsupported files,
+  interrupted traversal, and resource caps make incompleteness explicit. This is not
+  a regex or glob API. Overlapping paths are deduplicated.
+
+Every source record has `kind = "workspace"`, an opaque root identity, a local edit
+`generation`, a relative path, and the digest of the bytes observed. These are current
+workspace observations, not graph snapshot evidence. Generation advances for successful
+native publications; external edits do not advance it. Digests remain the precondition
+for writes, including after edits made outside Nano.
+
+Default host limits are 1 MiB per file, 8 MiB of search content, 4096 visited/pending
+entries, a 24 KiB serialized result, and a cooperative five-second operation deadline.
+Read results admit at most 2000 lines; search admits at most 128 matching lines.
+Callers may request smaller outputs. JSON escaping counts toward the output allowance.
+Filesystem work is synchronous and bounded per file; cancellation/deadline checkpoints
+occur between files. No detached filesystem task continues after the engine drops a call.
+
+## Exact patches
+
+`apply_patch` accepts an `edits` array of at most 16 files, encoded within 256 KiB.
+Parents must already exist. Operations are:
+
+```json
+{"operation":"create","path":"src/new.rs","content":"pub fn new() {}\n"}
+```
+
+```json
+{
+  "operation":"update",
+  "path":"src/lib.rs",
+  "expected_digest":"<64 lowercase SHA-256 hex digits from read_file>",
+  "hunks":[{"start_line":3,"old_text":"old line\n","new_text":"new line\n"}]
+}
+```
+
+```json
+{"operation":"delete","path":"src/old.rs","expected_digest":"<SHA-256>"}
+```
+
+Hunks are exact, whole-line replacements against the original file, ordered by their
+1-based start line and without overlaps. At most 128 hunks are allowed per file.
+An empty `old_text` inserts at a line boundary; an empty `new_text` removes the matched
+lines. Include the exact LF/CRLF endings in both strings. Only the final line may omit
+its terminator. There is no fuzzy matching, offset search, or implicit newline conversion.
+
+All paths, bases, and hunks are checked before any publication. A stale base returns
+`conflict`, its current digest when available, and a request to reread the file. No file
+is written when preflight fails. Base digests are checked again before each publication,
+including after staging. Existing permission modes and Windows owner/group/DACL are retained; new files use owner-only permissions on Unix and inherited permissions on Windows. Other file contents and Git staging/history are untouched.
+
+Each file is staged in its destination directory and published individually; creation
+never replaces an existing entry. A result lists `before_digest`, `intended_digest`,
+`after_digest`, and one of `not_applied`, `applied`, or `durability_unconfirmed` per file.
+`after_digest` describes an applied target (null for deletion); `intended_digest` also
+records the target for edits that did not run. If a later file fails, the applied prefix
+remains and later edits are not attempted. There is no multi-file atomicity or rollback.
+A partial result is an unknown-effect tool outcome, so the engine stops for reconciliation.
+
+The protocol is optimistic: digest checks cannot provide a filesystem compare-and-swap
+against an unrelated process writing between the final check and rename. Concurrent
+external writers should be quiesced by the host. A crash or engine interruption can lose
+the returned report; recovery must compare the journaled intent with current content
+before replaying any edit. Crash reconciliation is tracked in #84. Staged files may remain
+after a crash and are excluded from native file access.
+
+## Confinement and limitations
+
+Paths are portable, relative, and at most 256 UTF-8 bytes. Traversal uses held directory
+handles and component-relative no-follow opens on Unix and Windows. Symlinks, Windows
+reparse points/junctions, hardlinks, special files, alternate streams, short-name aliases,
+reserved device names, parent traversal, and nonportable spellings are rejected.
+
+Any `.git` or `.ferrus` component is protected. Ferrus runtime database basenames and their
+WAL/SHM/journal sidecars are also protected, as are owned `.nano-tmp-*` files. This tool set
+never performs Git operations, lifecycle transitions, graph builds, or process execution.
+
+Only UTF-8 text without NUL bytes is supported. Binary and oversized files produce typed
+limitations. Updates preserve ordinary permission modes; preserving inode identity,
+extended attributes, Windows audit SACLs, and concurrent metadata edits is not
+part of this file-replacement contract. Root authority is host-owned; it is not a sandbox
+against another process with the same OS account moving authorized directories.

--- a/docs/ferrus-nano-workspace.md
+++ b/docs/ferrus-nano-workspace.md
@@ -69,6 +69,13 @@ All paths, bases, and hunks are checked before any publication. A stale base ret
 is written when preflight fails. Base digests are checked again before each publication,
 including after staging. Existing permission modes and Windows owner/group/DACL are retained; new files use owner-only permissions on Unix and inherited permissions on Windows. Other file contents and Git staging/history are untouched.
 
+Batch target keys combine the opened parent directory's filesystem identity with the
+filename key. Windows uses NT uppercase mapping. Unix conservatively rejects names
+that collide after canonical Unicode decomposition and lowercase conversion, including
+absent NFC/NFD targets on macOS. This can reject a batch of distinct names on a
+case- or normalization-sensitive Unix volume; submit those edits separately. Names
+in different actual directories remain independent. Keys never change the names written.
+
 Each file is staged in its destination directory and published individually; creation
 never replaces an existing entry. A result lists `before_digest`, `intended_digest`,
 `after_digest`, and one of `not_applied`, `applied`, or `durability_unconfirmed` per file.

--- a/docs/ferrus-nano-workspace.md
+++ b/docs/ferrus-nano-workspace.md
@@ -17,7 +17,8 @@ hosts can supply an explicitly authorized root through the same constructor.
   set. Each matching line yields one result with a 1-based line and UTF-8 byte column,
   a bounded snippet around the first match, and its source digest. Unsupported files,
   interrupted traversal, and resource caps make incompleteness explicit. This is not
-  a regex or glob API. Overlapping paths are deduplicated.
+  a regex or glob API. Overlapping paths are deduplicated using case-sensitive keys
+  on Unix and NT uppercase keys on Windows. Results retain the first admitted spelling.
 
 Every source record has `kind = "workspace"`, an opaque root identity, a local edit
 `generation`, a relative path, and the digest of the bytes observed. These are current

--- a/docs/ferrus-nano-workspace.md
+++ b/docs/ferrus-nano-workspace.md
@@ -17,8 +17,11 @@ hosts can supply an explicitly authorized root through the same constructor.
   set. Each matching line yields one result with a 1-based line and UTF-8 byte column,
   a bounded snippet around the first match, and its source digest. Unsupported files,
   interrupted traversal, and resource caps make incompleteness explicit. This is not
-  a regex or glob API. Overlapping paths are deduplicated using case-sensitive keys
-  on Unix and NT uppercase keys on Windows. Results retain the first admitted spelling.
+  a regex or glob API. Queue keys use exact spelling on Unix and NT uppercase on
+  Windows. Opened objects are deduplicated by filesystem identity before charging
+  scan budgets, including on case-insensitive Unix volumes. Results retain the first
+  visited spelling. Unsupported portable-path names make the search incomplete with
+  bounded diagnostics; intentionally protected metadata remains hidden.
 
 Every source record has `kind = "workspace"`, an opaque root identity, a local edit
 `generation`, a relative path, and the digest of the bytes observed. These are current

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -25,7 +25,7 @@ Last reviewed against the repository: 2026-09-07.
 | Spec closure and project memory | Local baseline implemented | Outcome archival, curated memory indexing, revision-pinned queries, and evidence-backed repository links exist. Raw runtime bodies are excluded from default ingestion. |
 | Repository graph and indexed context | Local baseline implemented | Optional SQLite sidecar, incremental extraction, bounded CLI/MCP retrieval, task overlays, and frozen review views. Rust/Cargo and generic file structure are supported. |
 | Distributed context data plane | Prototype implemented | Opt-in contracts and local prototype adapters for authorized jobs, encrypted storage, publication, queries, and maintenance. No deployed remote service is implied. |
-| Ferrus nano-agent | Foundation implemented; runtime planned | #73 adds native binding and claim/status/heartbeat; #74 adds the bounded engine/journal; #75 adds opt-in LM Studio Chat Completions. Live model validation, HQ launch, interactive UI, and standalone delivery remain pending. |
+| Ferrus nano-agent | Foundation implemented; runtime planned | #73 adds native binding and claim/status/heartbeat; #74 adds the bounded engine/journal; #75 adds opt-in LM Studio Chat Completions; #76 adds bounded native read/search/patch tools. Live model validation, HQ launch, interactive UI, and standalone delivery remain pending. |
 
 ## Milestone 1: Windows Support
 
@@ -150,7 +150,7 @@ Definition of done:
 
 ## Milestone 5: Ferrus Nano-Agent
 
-Status: native session and engine/journal foundations implemented (#73, #74); the runnable harness is not available yet.
+Status: native session, engine/journal, provider, and file tools implemented (#73-#76); the runnable harness is not available yet.
 
 Goal: build `ferrus-nano` (backend `nano`) as a minimal Rust coding-agent harness. Start with a
 headless managed Executor, using Ferrus operations, repository graph, and project memory through
@@ -168,6 +168,7 @@ Implemented foundation:
 - native typed claim, status, and heartbeat, with exact run validation at transaction boundaries;
 - sequential provider/tool/host boundaries, persisted budgets, cancellation, a private single-writer journal, and pure recorded replay;
 - an opt-in Chat Completions adapter targeting LM Studio, with private credential-file references, bounded streaming, and shared retry accounting;
+- bounded native workspace read/search and exact digest-checked patch tools, with protected runtime paths and explicit partial-edit results ([contract](ferrus-nano-workspace.md));
 - regression coverage for bindings, lease ownership, MCP parity, engine limits, effect ordering, journal recovery, and offline provider protocols. The live provider smoke test remains opt-in.
 
 Delivery is tracked in [Ferrus nano-agents](https://github.com/ferrus-dev/ferrus/milestone/6).
@@ -176,7 +177,7 @@ contains one issue per planned PR, dependencies, and acceptance criteria:
 
 | Stage | Issues | Remaining scope |
 | --- | --- | --- |
-| N1: headless Executor | #75-#80 | Live model validation, coding tools, command sessions, native context, lifecycle operations, and HQ launch/events |
+| N1: headless Executor | #77-#80 | Live model validation, command sessions, native context, lifecycle operations, and HQ launch/events |
 | N2: context efficiency | #81-#82 | Working-set invalidation, budgets, and compaction |
 | N3: reliability and extensions | #83-#85 | External MCP via neva, resume/reconciliation, comparative evaluation, and headless release gates |
 | N4/N5: interactive and standalone | #86-#88 | HQ interaction, standalone host/binary, and shared UI |

--- a/src/nano/core_tests.rs
+++ b/src/nano/core_tests.rs
@@ -752,3 +752,59 @@ async fn host_denial_returns_feedback_and_absent_usage_is_estimated() {
         }
     )));
 }
+
+#[tokio::test]
+async fn native_workspace_tools_run_through_the_durable_engine() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().canonicalize().unwrap();
+    let journal_root = TempDir::new().unwrap();
+    let mut create = call("create", 1);
+    create.name = "apply_patch".into();
+    create.arguments = json!({"edits":[{"operation":"create","path":"source.txt","content":"native tool result\n"}]}).to_string();
+    let mut read = call("read", 1);
+    read.name = "read_file".into();
+    read.arguments = json!({"path":"source.txt"}).to_string();
+    let mut engine = Engine::new(
+        identity(),
+        limits(),
+        scripted(vec![
+            response("", vec![create, read]),
+            response("Done", vec![]),
+        ]),
+        super::workspace::Workspace::new(&root, super::workspace::Limits::default()).unwrap(),
+        FakeHost::default(),
+        FileJournal::create(
+            &journal_root.path().canonicalize().unwrap(),
+            "session-1",
+            Quotas::default(),
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    let end = run(&mut engine, &Cancellation::default()).await;
+    assert_eq!(end.reason, EndReason::ModelFinished);
+    assert_eq!(
+        std::fs::read(root.join("source.txt")).unwrap(),
+        b"native tool result\n"
+    );
+    let results: Vec<_> = engine
+        .host
+        .records
+        .iter()
+        .filter_map(|record| match &record.event {
+            SessionEvent::ToolResult {
+                outcome: ToolOutcome::Success(value),
+                ..
+            } => Some(value),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(results.len(), 2);
+    assert_eq!(
+        results[0]["changes"][0]["after_digest"],
+        results[1]["source"]["digest"]
+    );
+    assert_eq!(results[1]["text"], "native tool result\n");
+    let replay = Replay::from_records(&engine.host.records).unwrap();
+    assert_eq!(replay.budget, end.budget);
+}

--- a/src/nano/journal.rs
+++ b/src/nano/journal.rs
@@ -54,7 +54,6 @@ pub(crate) struct Checkpoint {
 
 pub(crate) struct FileJournal {
     directory: PathBuf,
-    _lock: File,
     file: File,
     quotas: Quotas,
     state: Replay,
@@ -64,6 +63,26 @@ pub(crate) struct FileJournal {
     files: usize,
     digest: Sha256,
     poisoned: bool,
+    // Drop the journal file before releasing its writer lock.
+    _lock: WriterLock,
+}
+
+struct WriterLock(File);
+
+impl WriterLock {
+    fn acquire(file: File) -> Result<Self> {
+        file.try_lock_exclusive()
+            .context("Nano journal already has a writer")?;
+        Ok(Self(file))
+    }
+}
+
+impl Drop for WriterLock {
+    fn drop(&mut self) {
+        // Closing alone leaves flock held by duplicates inherited across fork,
+        // even with CLOEXEC, until the child reaches exec or closes its copy.
+        let _ = FileExt::unlock(&self.0);
+    }
 }
 
 pub(crate) fn valid_id(id: &str) -> bool {
@@ -135,9 +154,7 @@ impl FileJournal {
         private::directory(&directory.join("outputs"), true)?;
         private::directory(&directory.join("checkpoints"), true)?;
 
-        let lock = private::file(&directory.join("writer.lock"), true)?;
-        lock.try_lock_exclusive()
-            .context("Nano journal already has a writer")?;
+        let lock = WriterLock::acquire(private::file(&directory.join("writer.lock"), true)?)?;
 
         let file = private::file(&directory.join("events.jsonl"), true)?;
         private::sync_directory(&directory)?;
@@ -172,10 +189,7 @@ impl FileJournal {
             .to_string();
 
         ensure!(valid_id(&session_id), "Invalid nano session ID");
-        let lock = private::file(&directory.join("writer.lock"), false)?;
-
-        lock.try_lock_exclusive()
-            .context("Nano journal already has a writer")?;
+        let lock = WriterLock::acquire(private::file(&directory.join("writer.lock"), false)?)?;
 
         let (mut total_bytes, files) = measure(directory, &quotas)?;
         let mut file = private::file(&directory.join("events.jsonl"), false)?;
@@ -474,4 +488,27 @@ fn hex_digest(digest: Sha256) -> String {
         .iter()
         .map(|byte| format!("{byte:02x}"))
         .collect()
+}
+
+#[cfg(all(test, unix))]
+mod lock_tests {
+    use super::*;
+
+    #[test]
+    fn dropping_a_writer_releases_the_lock_while_a_duplicate_remains_open() {
+        let root = tempfile::TempDir::new().unwrap();
+        let journal = FileJournal::create(root.path(), "s-1", Quotas::default()).unwrap();
+        let directory = journal.directory().to_owned();
+        // dup and fork share the same open file description. Keep the duplicate
+        // alive to model a concurrent child between fork and close-on-exec.
+        let duplicate = journal._lock.0.try_clone().unwrap();
+        assert!(FileJournal::recover(&directory, Quotas::default()).is_err());
+        drop(journal);
+
+        let (recovered, _) = FileJournal::recover(&directory, Quotas::default()).unwrap();
+        drop(duplicate);
+        assert!(FileJournal::recover(&directory, Quotas::default()).is_err());
+        drop(recovered);
+        FileJournal::recover(&directory, Quotas::default()).unwrap();
+    }
 }

--- a/src/nano/mod.rs
+++ b/src/nano/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod providers;
 pub(crate) mod replay;
 pub(crate) mod session;
 pub(crate) mod tools;
+pub(crate) mod workspace;
 
 #[cfg(test)]
 mod core_tests;

--- a/src/nano/mod.rs
+++ b/src/nano/mod.rs
@@ -1,11 +1,12 @@
 //! Native agent core and managed Ferrus adapter; frontend and provider wiring are separate.
 
+mod private;
+
 #[cfg(feature = "nano-openai")]
 pub(crate) mod config;
 pub(crate) mod engine;
 pub(crate) mod ferrus;
 pub(crate) mod journal;
-mod private;
 pub(crate) mod provider;
 #[cfg(feature = "nano-openai")]
 pub(crate) mod providers;

--- a/src/nano/private.rs
+++ b/src/nano/private.rs
@@ -56,6 +56,11 @@ pub(crate) fn read_only_file(path: &Path) -> Result<File> {
 
 pub(crate) use imp::{rename, sync_directory};
 
+#[cfg(all(test, windows))]
+pub(crate) fn check_input_handle(file: &File) -> Result<()> {
+    imp::check_input(file, &file.metadata()?)
+}
+
 #[cfg(unix)]
 mod imp {
     use super::*;

--- a/src/nano/private.rs
+++ b/src/nano/private.rs
@@ -300,13 +300,17 @@ mod imp {
     fn check_input_dacl(descriptor: PSECURITY_DESCRIPTOR) -> Result<()> {
         let owner = input_owner(descriptor)?;
         let actual = text(descriptor)?;
-        // Compare canonical DACLs, accepting a single explicit grant to either Owner
-        // Rights or the owning account. Extra or inherited grants still fail closed.
+        // SetSecurityInfo can add the descriptor's AI bookkeeping flag without
+        // changing its ACEs. Require protection and one explicit owner grant in
+        // either form; an inherited ACE (ID) or any extra grant still fails closed.
         for trustee in ["OW", owner.as_str()] {
             for rights in ["FA", "FR", "GR"] {
-                let expected = descriptor_from_text(&format!("D:P(A;;{rights};;;{trustee})"))?;
-                if actual == text(expected.0)? {
-                    return Ok(());
+                for flags in ["P", "PAI"] {
+                    let expected =
+                        descriptor_from_text(&format!("D:{flags}(A;;{rights};;;{trustee})"))?;
+                    if actual == text(expected.0)? {
+                        return Ok(());
+                    }
                 }
             }
         }
@@ -372,10 +376,12 @@ mod imp {
         fn input_dacl_accepts_owner_account_and_owner_rights_only() {
             for trustee in ["OW", OWNER] {
                 for rights in ["FA", "FR", "GR"] {
-                    let descriptor =
-                        descriptor_from_text(&format!("O:{OWNER}D:P(A;;{rights};;;{trustee})"))
-                            .unwrap();
-                    check_input_dacl(descriptor.0).unwrap();
+                    for flags in ["P", "PAI"] {
+                        let sddl = format!("O:{OWNER}D:{flags}(A;;{rights};;;{trustee})");
+                        let descriptor = descriptor_from_text(&sddl).unwrap();
+                        check_input_dacl(descriptor.0)
+                            .unwrap_or_else(|error| panic!("{sddl}: {error}"));
+                    }
                 }
             }
             for dacl in [
@@ -384,6 +390,12 @@ mod imp {
                 format!("D:P(A;;FR;;;{OWNER})(A;;FR;;;WD)"),
                 format!("D:(A;;FR;;;{OWNER})"),
                 format!("D:P(A;ID;FR;;;{OWNER})"),
+                "D:PAI(A;;FR;;;WD)".to_owned(),
+                "D:PAI(A;;FR;;;S-1-5-21-100-200-300-1002)".to_owned(),
+                format!("D:PAI(A;;FR;;;{OWNER})(A;;FR;;;WD)"),
+                format!("D:AI(A;;FR;;;{OWNER})"),
+                format!("D:PAI(A;ID;FR;;;{OWNER})"),
+                "D:PAI".to_owned(),
             ] {
                 let descriptor = descriptor_from_text(&format!("O:{OWNER}{dacl}")).unwrap();
                 assert!(check_input_dacl(descriptor.0).is_err(), "{dacl}");

--- a/src/nano/tools.rs
+++ b/src/nano/tools.rs
@@ -38,6 +38,8 @@ pub(crate) enum ToolError {
     Failed,
     Interrupted,
     OutputLimit,
+    /// Bounded native file-tool diagnostics, including per-path edit outcomes.
+    Workspace(serde_json::Value),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/nano/workspace.rs
+++ b/src/nano/workspace.rs
@@ -1,0 +1,632 @@
+//! Bounded current-workspace tools. Host roots never come from model arguments.
+
+mod fs;
+pub(crate) mod patch;
+#[cfg(test)]
+mod tests;
+
+use super::{journal::encode, tools::*};
+use crate::repository_graph::domain::RepoPath;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+use std::{
+    collections::BTreeSet,
+    io::Read,
+    path::Path,
+    time::{Duration, Instant},
+};
+
+use patch::PatchRequest;
+
+#[derive(Debug, Clone)]
+pub(crate) struct Limits {
+    pub file_bytes: usize,
+    pub scan_bytes: usize,
+    pub entries: usize,
+    pub output_bytes: usize,
+    pub elapsed_ms: u64,
+}
+impl Default for Limits {
+    fn default() -> Self {
+        Self {
+            file_bytes: 1024 * 1024,
+            scan_bytes: 8 * 1024 * 1024,
+            entries: 4096,
+            output_bytes: 24 * 1024,
+            elapsed_ms: 5000,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum Code {
+    InvalidPath,
+    ProtectedPath,
+    UnsafeFile,
+    NotFound,
+    Io,
+    Binary,
+    FileTooLarge,
+    Conflict,
+    InvalidPatch,
+    OutputLimit,
+    Interrupted,
+}
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct Failure {
+    pub code: Code,
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_digest: Option<String>,
+    pub message: &'static str,
+}
+impl Failure {
+    fn new(code: Code, path: &str) -> Self {
+        Self {
+            code,
+            path: path.chars().take(256).collect(),
+            current_digest: None,
+            message: match code {
+                Code::Conflict => "Base changed; read_file again and rebuild exact hunks.",
+                Code::InvalidPatch => {
+                    "Use ordered, non-overlapping, exact whole-line hunks against the expected digest."
+                }
+                Code::NotFound => {
+                    "Path or parent directory is missing; parents must already exist."
+                }
+                Code::ProtectedPath => {
+                    "Git metadata and Ferrus runtime state are not file-tool targets."
+                }
+                Code::UnsafeFile => {
+                    "Symlinks, reparse points, hardlinks, and non-regular files are unsupported."
+                }
+                Code::Binary => "Only UTF-8 text without NUL bytes is supported.",
+                Code::FileTooLarge => "File exceeds the host's content limit.",
+                Code::InvalidPath => {
+                    "Use a portable relative path inside the authorized workspace."
+                }
+                Code::OutputLimit => "Narrow the request to fit the host's output limit.",
+                Code::Interrupted => {
+                    "Operation stopped at a bounded cancellation or deadline checkpoint."
+                }
+                Code::Io => {
+                    "Filesystem operation failed; inspect the reported per-path state before retrying."
+                }
+            },
+        }
+    }
+    fn io(path: &str, error: std::io::Error) -> Self {
+        Self::new(
+            match error.kind() {
+                std::io::ErrorKind::NotFound => Code::NotFound,
+                std::io::ErrorKind::InvalidInput => Code::InvalidPath,
+                std::io::ErrorKind::Unsupported => Code::UnsafeFile,
+                _ => Code::Io,
+            },
+            path,
+        )
+    }
+}
+
+type Result<T> = std::result::Result<T, Failure>;
+
+pub(crate) struct Workspace {
+    root: fs::Root,
+    id: String,
+    generation: u64,
+    limits: Limits,
+}
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct Source {
+    pub kind: &'static str,
+    pub workspace_id: String,
+    pub generation: u64,
+    pub path: String,
+    pub digest: String,
+}
+#[derive(Debug)]
+struct Content {
+    text: String,
+    digest: String,
+    mode: std::fs::Permissions,
+}
+
+fn digest(bytes: &[u8]) -> String {
+    Sha256::digest(bytes)
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+fn path(value: &str) -> Result<String> {
+    if value.len() > 256 || value.contains('\\') {
+        return Err(Failure::new(Code::InvalidPath, value));
+    }
+    let parsed = RepoPath::new(value).map_err(|_| Failure::new(Code::InvalidPath, value))?;
+    for component in parsed.as_str().split('/') {
+        let lower = component.to_uppercase().to_ascii_lowercase();
+        if matches!(lower.as_str(), ".git" | ".ferrus")
+            || lower.starts_with(".nano-tmp-")
+            || ["ferrus.db", "repo-graph.db", "project-memory.db"]
+                .iter()
+                .any(|name| {
+                    lower == *name
+                        || lower
+                            .strip_prefix(name)
+                            .is_some_and(|suffix| matches!(suffix, "-wal" | "-shm" | "-journal"))
+                })
+        {
+            return Err(Failure::new(Code::ProtectedPath, value));
+        }
+        let stem = lower.split('.').next().unwrap_or_default();
+        if component.ends_with(['.', ' '])
+            || component
+                .chars()
+                .any(|c| c.is_control() || ":*?\"<>|~".contains(c))
+            || matches!(stem, "con" | "prn" | "aux" | "nul" | "conin$" | "conout$")
+            || ["com", "lpt"].iter().any(|prefix| {
+                stem.strip_prefix(prefix).is_some_and(|s| {
+                    s.chars().count() == 1 && "123456789\u{b9}\u{b2}\u{b3}".contains(s)
+                })
+            })
+        {
+            return Err(Failure::new(Code::InvalidPath, value));
+        }
+    }
+    Ok(parsed.as_str().to_owned())
+}
+
+impl Workspace {
+    /// The caller selects an authorized root and limits after validating host authority.
+    pub(crate) fn new(root: &Path, limits: Limits) -> anyhow::Result<Self> {
+        anyhow::ensure!(root.is_absolute(), "Workspace root must be absolute");
+        anyhow::ensure!(
+            limits.file_bytes > 0
+                && limits.file_bytes <= 16 * 1024 * 1024
+                && limits.scan_bytes >= limits.file_bytes
+                && limits.scan_bytes <= 64 * 1024 * 1024
+                && (1..=65_536).contains(&limits.entries)
+                && (4096..=24 * 1024).contains(&limits.output_bytes)
+                && (1..=30_000).contains(&limits.elapsed_ms),
+            "Invalid workspace limits"
+        );
+        let canonical = root.canonicalize()?;
+        let root = fs::Root::new(&canonical)?;
+        Ok(Self {
+            id: digest(canonical.as_os_str().as_encoded_bytes()),
+            root,
+            limits,
+            generation: 0,
+        })
+    }
+    fn source(&self, path: &str, digest: &str) -> Source {
+        Source {
+            kind: "workspace",
+            workspace_id: self.id.clone(),
+            generation: self.generation,
+            path: path.into(),
+            digest: digest.into(),
+        }
+    }
+    fn content(&self, path: &str) -> Result<Content> {
+        let file = self.root.open(path).map_err(|e| Failure::io(path, e))?;
+        self.read_content(file, path)
+    }
+    fn read_content(&self, file: std::fs::File, path: &str) -> Result<Content> {
+        self.read_content_limited(file, path, self.limits.file_bytes, &mut 0)
+    }
+    fn read_content_limited(
+        &self,
+        file: std::fs::File,
+        path: &str,
+        limit: usize,
+        inspected: &mut usize,
+    ) -> Result<Content> {
+        let meta = file.metadata().map_err(|e| Failure::io(path, e))?;
+        fs::regular(&file).map_err(|e| Failure::io(path, e))?;
+        if meta.len() > limit as u64 {
+            return Err(Failure::new(Code::FileTooLarge, path));
+        }
+        let mut bytes = Vec::new();
+        let read = file.take(limit as u64 + 1).read_to_end(&mut bytes);
+        *inspected += bytes.len();
+        read.map_err(|e| Failure::io(path, e))?;
+        if bytes.len() > limit {
+            return Err(Failure::new(Code::FileTooLarge, path));
+        }
+        if bytes.contains(&0) {
+            return Err(Failure::new(Code::Binary, path));
+        }
+        let hash = digest(&bytes);
+        let text = String::from_utf8(bytes).map_err(|_| Failure::new(Code::Binary, path))?;
+        Ok(Content {
+            text,
+            digest: hash,
+            mode: meta.permissions(),
+        })
+    }
+    fn stopped(&self, start: Instant, cancellation: &Cancellation) -> bool {
+        cancellation.is_cancelled()
+            || start.elapsed() >= Duration::from_millis(self.limits.elapsed_ms)
+    }
+    pub(crate) fn read_file(&self, request: ReadRequest) -> Result<ReadResult> {
+        let path = path(&request.path)?;
+        if request.start_line == 0 || request.max_lines == 0 || request.max_bytes == 0 {
+            return Err(Failure::new(Code::InvalidPath, &path));
+        }
+        let content = self.content(&path)?;
+        let lines = request.max_lines.min(2000);
+        // Charge actual JSON escaping while leaving room for source identity and the wrapper.
+        let bytes = request.max_bytes.min(self.limits.output_bytes - 1024);
+        let mut encoded_bytes = 0;
+        let mut text = String::new();
+        let mut returned_lines = 0;
+        let mut truncated = false;
+        for line in content
+            .text
+            .split_inclusive('\n')
+            .skip(request.start_line - 1)
+        {
+            if returned_lines == lines || text.len() + line.len() > bytes {
+                truncated = true;
+                break;
+            }
+            let encoded = serde_json::to_string(line)
+                .expect("serializable text")
+                .len()
+                - 2;
+            if encoded_bytes + encoded > self.limits.output_bytes - 1024 {
+                truncated = true;
+                break;
+            }
+            encoded_bytes += encoded;
+            text.push_str(line);
+            returned_lines += 1;
+        }
+        Ok(ReadResult {
+            source: self.source(&path, &content.digest),
+            start_line: request.start_line,
+            returned_lines,
+            next_line: truncated.then_some(request.start_line + returned_lines),
+            text,
+            truncated,
+        })
+    }
+    pub(crate) async fn search_text(
+        &self,
+        request: SearchRequest,
+        cancellation: &Cancellation,
+    ) -> Result<SearchResult> {
+        let start = Instant::now();
+        let mut pending = BTreeSet::new();
+        for value in &request.paths {
+            pending.insert(if value == "." {
+                String::new()
+            } else {
+                path(value)?
+            });
+        }
+        if pending.is_empty()
+            || pending.len() > 16
+            || request.query.is_empty()
+            || request.query.len() > 4096
+            || request.max_results == 0
+        {
+            return Err(Failure::new(Code::InvalidPath, ""));
+        }
+        let mut result = SearchResult {
+            matches: Vec::new(),
+            issues: Vec::new(),
+            scanned_bytes: 0,
+            visited_entries: 0,
+            listed_entries: 0,
+            truncated: false,
+            suppressed_issues: 0,
+        };
+        let mut seen = BTreeSet::new();
+        let mut output_bytes = 512;
+        let mut output_full = false;
+        while let Some(path) = pending.pop_first() {
+            if self.stopped(start, cancellation) {
+                result.truncated = true;
+                result.issue(
+                    Failure::new(Code::Interrupted, ""),
+                    &mut output_bytes,
+                    self.limits.output_bytes,
+                );
+                break;
+            }
+            if !seen.insert(path.clone()) {
+                continue;
+            }
+            if result.visited_entries == self.limits.entries {
+                result.truncated = true;
+                break;
+            }
+            result.visited_entries += 1;
+            let file = if path.is_empty() {
+                self.root.directory()
+            } else {
+                self.root.open(&path)
+            };
+            let item = (|| {
+                let file = file.map_err(|e| Failure::io(&path, e))?;
+                if file.metadata().map_err(|e| Failure::io(&path, e))?.is_dir() {
+                    let capacity = self.limits.entries.saturating_sub(result.listed_entries);
+                    let (children, truncated) =
+                        fs::children(&file, capacity).map_err(|e| Failure::io(&path, e))?;
+                    result.truncated |= truncated;
+                    result.listed_entries += children.len();
+                    for name in children {
+                        let child = if path.is_empty() {
+                            name
+                        } else {
+                            format!("{path}/{name}")
+                        };
+                        if let Ok(child) = self::path(&child) {
+                            pending.insert(child);
+                        }
+                    }
+                    return Ok(());
+                }
+                let remaining = self.limits.scan_bytes.saturating_sub(result.scanned_bytes);
+                if remaining == 0 {
+                    result.truncated = true;
+                    return Err(Failure::new(Code::FileTooLarge, &path));
+                }
+                let cap = self.limits.file_bytes.min(remaining - 1);
+                let content =
+                    self.read_content_limited(file, &path, cap, &mut result.scanned_bytes)?;
+                for (index, line) in content.text.split_inclusive('\n').enumerate() {
+                    let Some(column) = line.find(&request.query) else {
+                        continue;
+                    };
+                    if result.matches.len() >= request.max_results.min(128) {
+                        result.truncated = true;
+                        break;
+                    }
+                    let mut snippet_start = column.saturating_sub(120);
+                    while !line.is_char_boundary(snippet_start) {
+                        snippet_start -= 1;
+                    }
+                    let snippet = prefix(&line[snippet_start..], 512);
+                    let hit = SearchMatch {
+                        source: self.source(&path, &content.digest),
+                        line: index + 1,
+                        byte_column: column + 1,
+                        snippet_start_column: snippet_start + 1,
+                        text: snippet.to_owned(),
+                        truncated: snippet.len() < line.len(),
+                    };
+                    let size = serde_json::to_vec(&hit).expect("serializable match").len() + 1;
+                    if output_bytes + size > self.limits.output_bytes - 512 {
+                        result.truncated = true;
+                        output_full = true;
+                        break;
+                    }
+                    output_bytes += size;
+                    result.matches.push(hit);
+                }
+                Ok(())
+            })();
+            if let Err(failure) = item {
+                result.truncated = true;
+                result.issue(failure, &mut output_bytes, self.limits.output_bytes);
+            }
+            if result.matches.len() >= request.max_results.min(128) || output_full {
+                result.truncated |= !pending.is_empty();
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        Ok(result)
+    }
+}
+fn prefix(text: &str, bytes: usize) -> &str {
+    let mut end = text.len().min(bytes);
+    while !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    &text[..end]
+}
+fn one() -> usize {
+    1
+}
+fn lines() -> usize {
+    200
+}
+fn bytes() -> usize {
+    16 * 1024
+}
+fn results() -> usize {
+    50
+}
+fn roots() -> Vec<String> {
+    vec![".".into()]
+}
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ReadRequest {
+    pub path: String,
+    #[serde(default = "one")]
+    pub start_line: usize,
+    #[serde(default = "lines")]
+    pub max_lines: usize,
+    #[serde(default = "bytes")]
+    pub max_bytes: usize,
+}
+#[derive(Debug, Serialize)]
+pub(crate) struct ReadResult {
+    pub source: Source,
+    pub start_line: usize,
+    pub returned_lines: usize,
+    pub next_line: Option<usize>,
+    pub text: String,
+    pub truncated: bool,
+}
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct SearchRequest {
+    #[serde(default = "roots")]
+    pub paths: Vec<String>,
+    pub query: String,
+    #[serde(default = "results")]
+    pub max_results: usize,
+}
+#[derive(Debug, Serialize)]
+pub(crate) struct SearchMatch {
+    pub source: Source,
+    pub line: usize,
+    pub byte_column: usize,
+    pub snippet_start_column: usize,
+    pub text: String,
+    pub truncated: bool,
+}
+#[derive(Debug, Serialize)]
+pub(crate) struct SearchResult {
+    pub matches: Vec<SearchMatch>,
+    pub issues: Vec<Failure>,
+    pub suppressed_issues: usize,
+    pub scanned_bytes: usize,
+    pub visited_entries: usize,
+    pub listed_entries: usize,
+    pub truncated: bool,
+}
+
+impl SearchResult {
+    fn issue(&mut self, failure: Failure, used: &mut usize, limit: usize) {
+        let size = serde_json::to_vec(&failure)
+            .expect("serializable issue")
+            .len()
+            + 1;
+        if self.issues.len() < 4 && *used + size <= limit - 512 {
+            *used += size;
+            self.issues.push(failure);
+        } else {
+            self.suppressed_issues += 1;
+        }
+    }
+}
+
+impl Tools for Workspace {
+    fn descriptors(&self) -> Vec<ToolDescriptor> {
+        let string = json!({"type":"string"});
+        let positive = json!({"type":"integer","minimum":1});
+        let hunk = json!({"type":"object","properties":{"start_line":positive,"old_text":string,"new_text":string},
+            "required":["start_line","old_text","new_text"],"additionalProperties":false});
+        let edit = |operation: &str, extra: Value, required: &[&str]| {
+            let mut properties = json!({"operation":{"const":operation},"path":string});
+            properties
+                .as_object_mut()
+                .unwrap()
+                .extend(extra.as_object().unwrap().clone());
+            let mut fields = vec!["operation", "path"];
+            fields.extend_from_slice(required);
+            json!({"type":"object","properties":properties,"required":fields,"additionalProperties":false})
+        };
+        vec![
+            ToolDescriptor { name:"read_file".into(), description:"Read whole UTF-8 lines from the current workspace with a full-file SHA-256 digest. Truncation is explicit; oversized lines may return no text.".into(),
+                input_schema:json!({"type":"object","properties":{"path":string,"start_line":positive,"max_lines":positive,"max_bytes":positive},"required":["path"],"additionalProperties":false}) },
+            ToolDescriptor { name:"search_text".into(), description:"Literal, case-sensitive search in workspace files or directories. One match per line; paths default to the root. No symlinks or runtime metadata. Inspect truncation and skipped-file issues.".into(),
+                input_schema:json!({"type":"object","properties":{"paths":{"type":"array","items":string,"minItems":1,"maxItems":16},"query":{"type":"string","minLength":1},"max_results":positive},"required":["query"],"additionalProperties":false}) },
+            ToolDescriptor { name:"apply_patch".into(), description:"Apply up to 16 exact file edits. Update/delete require read_file's expected_digest. Hunks replace whole lines at 1-based start_line with exact old_text/new_text (including line endings). Parents must exist. All edits are preflighted; per-file publication is not a multi-file transaction.".into(),
+                input_schema:json!({"type":"object","properties":{"edits":{"type":"array","minItems":1,"maxItems":16,"items":{"oneOf":[
+                    edit("create",json!({"content":string}),&["content"]),
+                    edit("update",json!({"expected_digest":string,"hunks":{"type":"array","items":hunk,"minItems":1,"maxItems":128}}),&["expected_digest","hunks"]),
+                    edit("delete",json!({"expected_digest":string}),&["expected_digest"])]}}},"required":["edits"],"additionalProperties":false}) },
+        ]
+    }
+    fn validate(&self, name: &str, arguments: &Value) -> std::result::Result<(), ToolError> {
+        decode(name, arguments).map(|_| ())
+    }
+    async fn execute(&mut self, call: &ValidatedCall, cancellation: &Cancellation) -> ToolOutcome {
+        let request = match decode(&call.name, &call.arguments) {
+            Ok(v) => v,
+            Err(e) => return ToolOutcome::Failed(e),
+        };
+        if cancellation.is_cancelled() {
+            return ToolOutcome::Failed(ToolError::Interrupted);
+        }
+        let result = match request {
+            Request::Read(request) => self
+                .read_file(request)
+                .map(|v| serde_json::to_value(v).unwrap()),
+            Request::Search(request) => self
+                .search_text(request, cancellation)
+                .await
+                .map(|v| serde_json::to_value(v).unwrap()),
+            Request::Patch(request) => {
+                let result = self.apply_patch(request, cancellation).await;
+                if !result.complete {
+                    let partial = result
+                        .changes
+                        .iter()
+                        .any(|change| change.state != patch::State::NotApplied);
+                    let error = ToolError::Workspace(serde_json::to_value(result).unwrap());
+                    return if partial {
+                        ToolOutcome::Unknown(error)
+                    } else {
+                        ToolOutcome::Failed(error)
+                    };
+                }
+                Ok(serde_json::to_value(result).unwrap())
+            }
+        };
+        let outcome = match result {
+            Ok(value) => ToolOutcome::Success(value),
+            Err(failure) => {
+                ToolOutcome::Failed(ToolError::Workspace(serde_json::to_value(failure).unwrap()))
+            }
+        };
+        if encode(&outcome, self.limits.output_bytes).is_err() {
+            ToolOutcome::Failed(ToolError::OutputLimit)
+        } else {
+            outcome
+        }
+    }
+}
+enum Request {
+    Read(ReadRequest),
+    Search(SearchRequest),
+    Patch(PatchRequest),
+}
+fn decode(name: &str, value: &Value) -> std::result::Result<Request, ToolError> {
+    if encode(value, 256 * 1024).is_err() {
+        return Err(ToolError::InvalidArguments);
+    }
+    let parsed = match name {
+        "read_file" => serde_json::from_value(value.clone()).map(Request::Read),
+        "search_text" => serde_json::from_value(value.clone()).map(Request::Search),
+        "apply_patch" => serde_json::from_value(value.clone()).map(Request::Patch),
+        _ => return Err(ToolError::UnknownTool),
+    };
+    let request = parsed.map_err(|_| ToolError::InvalidArguments)?;
+    let valid = match &request {
+        Request::Read(r) => r.start_line > 0 && r.max_lines > 0 && r.max_bytes > 0,
+        Request::Search(r) => {
+            !r.paths.is_empty()
+                && r.paths.len() <= 16
+                && !r.query.is_empty()
+                && r.query.len() <= 4096
+                && r.max_results > 0
+        }
+        Request::Patch(r) => {
+            !r.edits.is_empty()
+                && r.edits.len() <= 16
+                && r.edits.iter().all(|edit| match edit {
+                    patch::Edit::Update { hunks, .. } => {
+                        !hunks.is_empty()
+                            && hunks.len() <= 128
+                            && hunks.iter().all(|h| h.start_line > 0)
+                    }
+                    _ => true,
+                })
+        }
+    };
+    if valid {
+        Ok(request)
+    } else {
+        Err(ToolError::InvalidArguments)
+    }
+}

--- a/src/nano/workspace.rs
+++ b/src/nano/workspace.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeMap, BTreeSet},
     io::Read,
     path::Path,
     time::{Duration, Instant},
@@ -323,13 +323,14 @@ impl Workspace {
         cancellation: &Cancellation,
     ) -> Result<SearchResult> {
         let start = Instant::now();
-        let mut pending = BTreeSet::new();
+        let mut pending = BTreeMap::new();
         for value in &request.paths {
-            pending.insert(if value == "." {
+            let path = if value == "." {
                 String::new()
             } else {
                 path(value)?
-            });
+            };
+            pending.entry(fs::search_key(&path)).or_insert(path);
         }
 
         if pending.is_empty()
@@ -355,7 +356,7 @@ impl Workspace {
         let mut output_bytes = 512;
         let mut output_full = false;
 
-        while let Some(path) = pending.pop_first() {
+        while let Some((key, path)) = pending.pop_first() {
             if self.stopped(start, cancellation) {
                 result.truncated = true;
                 result.issue(
@@ -366,7 +367,7 @@ impl Workspace {
                 break;
             }
 
-            if !seen.insert(path.clone()) {
+            if !seen.insert(key) {
                 continue;
             }
 
@@ -400,7 +401,10 @@ impl Workspace {
                         };
 
                         if let Ok(child) = self::path(&child) {
-                            pending.insert(child);
+                            let key = fs::search_key(&child);
+                            if !seen.contains(&key) {
+                                pending.entry(key).or_insert(child);
+                            }
                         }
                     }
 

--- a/src/nano/workspace.rs
+++ b/src/nano/workspace.rs
@@ -353,6 +353,7 @@ impl Workspace {
         };
 
         let mut seen = BTreeSet::new();
+        let mut objects = BTreeSet::new();
         let mut output_bytes = 512;
         let mut output_full = false;
 
@@ -371,20 +372,30 @@ impl Workspace {
                 continue;
             }
 
+            let file = if path.is_empty() {
+                self.root.directory()
+            } else {
+                self.root.open(&path)
+            }
+            .and_then(|file| fs::identity(&file).map(|identity| (file, identity)));
+
+            // Unix volumes can ignore case or normalize Unicode names. Use the
+            // opened object's identity before charging visits, listing or reads.
+            if let Ok((_, identity)) = &file
+                && !objects.insert(*identity)
+            {
+                continue;
+            }
+
             if result.visited_entries == self.limits.entries {
                 result.truncated = true;
                 break;
             }
 
             result.visited_entries += 1;
-            let file = if path.is_empty() {
-                self.root.directory()
-            } else {
-                self.root.open(&path)
-            };
 
             let item = (|| {
-                let file = file.map_err(|e| Failure::io(&path, e))?;
+                let (file, _) = file.map_err(|e| Failure::io(&path, e))?;
                 if file.metadata().map_err(|e| Failure::io(&path, e))?.is_dir() {
                     let capacity = self.limits.entries.saturating_sub(result.listed_entries);
                     let (children, truncated) =
@@ -400,10 +411,17 @@ impl Workspace {
                             format!("{path}/{name}")
                         };
 
-                        if let Ok(child) = self::path(&child) {
-                            let key = fs::search_key(&child);
-                            if !seen.contains(&key) {
-                                pending.entry(key).or_insert(child);
+                        match self::path(&child) {
+                            Ok(child) => {
+                                let key = fs::search_key(&child);
+                                if !seen.contains(&key) {
+                                    pending.entry(key).or_insert(child);
+                                }
+                            }
+                            Err(failure) if failure.code == Code::ProtectedPath => (),
+                            Err(failure) => {
+                                result.truncated = true;
+                                result.issue(failure, &mut output_bytes, self.limits.output_bytes);
                             }
                         }
                     }

--- a/src/nano/workspace.rs
+++ b/src/nano/workspace.rs
@@ -27,6 +27,7 @@ pub(crate) struct Limits {
     pub output_bytes: usize,
     pub elapsed_ms: u64,
 }
+
 impl Default for Limits {
     fn default() -> Self {
         Self {
@@ -54,6 +55,7 @@ pub(crate) enum Code {
     OutputLimit,
     Interrupted,
 }
+
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct Failure {
     pub code: Code,
@@ -62,6 +64,7 @@ pub(crate) struct Failure {
     pub current_digest: Option<String>,
     pub message: &'static str,
 }
+
 impl Failure {
     fn new(code: Code, path: &str) -> Self {
         Self {
@@ -118,6 +121,7 @@ pub(crate) struct Workspace {
     generation: u64,
     limits: Limits,
 }
+
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct Source {
     pub kind: &'static str,
@@ -126,6 +130,7 @@ pub(crate) struct Source {
     pub path: String,
     pub digest: String,
 }
+
 #[derive(Debug)]
 struct Content {
     text: String,
@@ -143,6 +148,7 @@ fn path(value: &str) -> Result<String> {
     if value.len() > 256 || value.contains('\\') {
         return Err(Failure::new(Code::InvalidPath, value));
     }
+
     let parsed = RepoPath::new(value).map_err(|_| Failure::new(Code::InvalidPath, value))?;
     for component in parsed.as_str().split('/') {
         let lower = component.to_uppercase().to_ascii_lowercase();
@@ -159,6 +165,7 @@ fn path(value: &str) -> Result<String> {
         {
             return Err(Failure::new(Code::ProtectedPath, value));
         }
+
         let stem = lower.split('.').next().unwrap_or_default();
         if component.ends_with(['.', ' '])
             || component
@@ -174,6 +181,7 @@ fn path(value: &str) -> Result<String> {
             return Err(Failure::new(Code::InvalidPath, value));
         }
     }
+
     Ok(parsed.as_str().to_owned())
 }
 
@@ -191,6 +199,7 @@ impl Workspace {
                 && (1..=30_000).contains(&limits.elapsed_ms),
             "Invalid workspace limits"
         );
+
         let canonical = root.canonicalize()?;
         let root = fs::Root::new(&canonical)?;
         Ok(Self {
@@ -200,6 +209,7 @@ impl Workspace {
             generation: 0,
         })
     }
+
     fn source(&self, path: &str, digest: &str) -> Source {
         Source {
             kind: "workspace",
@@ -209,13 +219,16 @@ impl Workspace {
             digest: digest.into(),
         }
     }
+
     fn content(&self, path: &str) -> Result<Content> {
         let file = self.root.open(path).map_err(|e| Failure::io(path, e))?;
         self.read_content(file, path)
     }
+
     fn read_content(&self, file: std::fs::File, path: &str) -> Result<Content> {
         self.read_content_limited(file, path, self.limits.file_bytes, &mut 0)
     }
+
     fn read_content_limited(
         &self,
         file: std::fs::File,
@@ -228,6 +241,7 @@ impl Workspace {
         if meta.len() > limit as u64 {
             return Err(Failure::new(Code::FileTooLarge, path));
         }
+
         let mut bytes = Vec::new();
         let read = file.take(limit as u64 + 1).read_to_end(&mut bytes);
         *inspected += bytes.len();
@@ -235,9 +249,11 @@ impl Workspace {
         if bytes.len() > limit {
             return Err(Failure::new(Code::FileTooLarge, path));
         }
+
         if bytes.contains(&0) {
             return Err(Failure::new(Code::Binary, path));
         }
+
         let hash = digest(&bytes);
         let text = String::from_utf8(bytes).map_err(|_| Failure::new(Code::Binary, path))?;
         Ok(Content {
@@ -246,15 +262,18 @@ impl Workspace {
             mode: meta.permissions(),
         })
     }
+
     fn stopped(&self, start: Instant, cancellation: &Cancellation) -> bool {
         cancellation.is_cancelled()
             || start.elapsed() >= Duration::from_millis(self.limits.elapsed_ms)
     }
+
     pub(crate) fn read_file(&self, request: ReadRequest) -> Result<ReadResult> {
         let path = path(&request.path)?;
         if request.start_line == 0 || request.max_lines == 0 || request.max_bytes == 0 {
             return Err(Failure::new(Code::InvalidPath, &path));
         }
+
         let content = self.content(&path)?;
         let lines = request.max_lines.min(2000);
         // Charge actual JSON escaping while leaving room for source identity and the wrapper.
@@ -263,6 +282,7 @@ impl Workspace {
         let mut text = String::new();
         let mut returned_lines = 0;
         let mut truncated = false;
+
         for line in content
             .text
             .split_inclusive('\n')
@@ -272,18 +292,22 @@ impl Workspace {
                 truncated = true;
                 break;
             }
+
             let encoded = serde_json::to_string(line)
                 .expect("serializable text")
                 .len()
                 - 2;
+
             if encoded_bytes + encoded > self.limits.output_bytes - 1024 {
                 truncated = true;
                 break;
             }
+
             encoded_bytes += encoded;
             text.push_str(line);
             returned_lines += 1;
         }
+
         Ok(ReadResult {
             source: self.source(&path, &content.digest),
             start_line: request.start_line,
@@ -307,6 +331,7 @@ impl Workspace {
                 path(value)?
             });
         }
+
         if pending.is_empty()
             || pending.len() > 16
             || request.query.is_empty()
@@ -315,6 +340,7 @@ impl Workspace {
         {
             return Err(Failure::new(Code::InvalidPath, ""));
         }
+
         let mut result = SearchResult {
             matches: Vec::new(),
             issues: Vec::new(),
@@ -324,9 +350,11 @@ impl Workspace {
             truncated: false,
             suppressed_issues: 0,
         };
+
         let mut seen = BTreeSet::new();
         let mut output_bytes = 512;
         let mut output_full = false;
+
         while let Some(path) = pending.pop_first() {
             if self.stopped(start, cancellation) {
                 result.truncated = true;
@@ -337,37 +365,45 @@ impl Workspace {
                 );
                 break;
             }
+
             if !seen.insert(path.clone()) {
                 continue;
             }
+
             if result.visited_entries == self.limits.entries {
                 result.truncated = true;
                 break;
             }
+
             result.visited_entries += 1;
             let file = if path.is_empty() {
                 self.root.directory()
             } else {
                 self.root.open(&path)
             };
+
             let item = (|| {
                 let file = file.map_err(|e| Failure::io(&path, e))?;
                 if file.metadata().map_err(|e| Failure::io(&path, e))?.is_dir() {
                     let capacity = self.limits.entries.saturating_sub(result.listed_entries);
                     let (children, truncated) =
                         fs::children(&file, capacity).map_err(|e| Failure::io(&path, e))?;
+
                     result.truncated |= truncated;
                     result.listed_entries += children.len();
+
                     for name in children {
                         let child = if path.is_empty() {
                             name
                         } else {
                             format!("{path}/{name}")
                         };
+
                         if let Ok(child) = self::path(&child) {
                             pending.insert(child);
                         }
                     }
+
                     return Ok(());
                 }
                 let remaining = self.limits.scan_bytes.saturating_sub(result.scanned_bytes);
@@ -375,21 +411,26 @@ impl Workspace {
                     result.truncated = true;
                     return Err(Failure::new(Code::FileTooLarge, &path));
                 }
+
                 let cap = self.limits.file_bytes.min(remaining - 1);
                 let content =
                     self.read_content_limited(file, &path, cap, &mut result.scanned_bytes)?;
+
                 for (index, line) in content.text.split_inclusive('\n').enumerate() {
                     let Some(column) = line.find(&request.query) else {
                         continue;
                     };
+
                     if result.matches.len() >= request.max_results.min(128) {
                         result.truncated = true;
                         break;
                     }
+
                     let mut snippet_start = column.saturating_sub(120);
                     while !line.is_char_boundary(snippet_start) {
                         snippet_start -= 1;
                     }
+
                     let snippet = prefix(&line[snippet_start..], 512);
                     let hit = SearchMatch {
                         source: self.source(&path, &content.digest),
@@ -399,30 +440,38 @@ impl Workspace {
                         text: snippet.to_owned(),
                         truncated: snippet.len() < line.len(),
                     };
+
                     let size = serde_json::to_vec(&hit).expect("serializable match").len() + 1;
                     if output_bytes + size > self.limits.output_bytes - 512 {
                         result.truncated = true;
                         output_full = true;
                         break;
                     }
+
                     output_bytes += size;
                     result.matches.push(hit);
                 }
+
                 Ok(())
             })();
+
             if let Err(failure) = item {
                 result.truncated = true;
                 result.issue(failure, &mut output_bytes, self.limits.output_bytes);
             }
+
             if result.matches.len() >= request.max_results.min(128) || output_full {
                 result.truncated |= !pending.is_empty();
                 break;
             }
+
             tokio::task::yield_now().await;
         }
+
         Ok(result)
     }
 }
+
 fn prefix(text: &str, bytes: usize) -> &str {
     let mut end = text.len().min(bytes);
     while !text.is_char_boundary(end) {
@@ -430,21 +479,27 @@ fn prefix(text: &str, bytes: usize) -> &str {
     }
     &text[..end]
 }
+
 fn one() -> usize {
     1
 }
+
 fn lines() -> usize {
     200
 }
+
 fn bytes() -> usize {
     16 * 1024
 }
+
 fn results() -> usize {
     50
 }
+
 fn roots() -> Vec<String> {
     vec![".".into()]
 }
+
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct ReadRequest {
@@ -456,6 +511,7 @@ pub(crate) struct ReadRequest {
     #[serde(default = "bytes")]
     pub max_bytes: usize,
 }
+
 #[derive(Debug, Serialize)]
 pub(crate) struct ReadResult {
     pub source: Source,
@@ -465,6 +521,7 @@ pub(crate) struct ReadResult {
     pub text: String,
     pub truncated: bool,
 }
+
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct SearchRequest {
@@ -474,6 +531,7 @@ pub(crate) struct SearchRequest {
     #[serde(default = "results")]
     pub max_results: usize,
 }
+
 #[derive(Debug, Serialize)]
 pub(crate) struct SearchMatch {
     pub source: Source,
@@ -483,6 +541,7 @@ pub(crate) struct SearchMatch {
     pub text: String,
     pub truncated: bool,
 }
+
 #[derive(Debug, Serialize)]
 pub(crate) struct SearchResult {
     pub matches: Vec<SearchMatch>,
@@ -500,6 +559,7 @@ impl SearchResult {
             .expect("serializable issue")
             .len()
             + 1;
+
         if self.issues.len() < 4 && *used + size <= limit - 512 {
             *used += size;
             self.issues.push(failure);
@@ -515,6 +575,7 @@ impl Tools for Workspace {
         let positive = json!({"type":"integer","minimum":1});
         let hunk = json!({"type":"object","properties":{"start_line":positive,"old_text":string,"new_text":string},
             "required":["start_line","old_text","new_text"],"additionalProperties":false});
+
         let edit = |operation: &str, extra: Value, required: &[&str]| {
             let mut properties = json!({"operation":{"const":operation},"path":string});
             properties
@@ -525,6 +586,7 @@ impl Tools for Workspace {
             fields.extend_from_slice(required);
             json!({"type":"object","properties":properties,"required":fields,"additionalProperties":false})
         };
+
         vec![
             ToolDescriptor { name:"read_file".into(), description:"Read whole UTF-8 lines from the current workspace with a full-file SHA-256 digest. Truncation is explicit; oversized lines may return no text.".into(),
                 input_schema:json!({"type":"object","properties":{"path":string,"start_line":positive,"max_lines":positive,"max_bytes":positive},"required":["path"],"additionalProperties":false}) },
@@ -537,17 +599,21 @@ impl Tools for Workspace {
                     edit("delete",json!({"expected_digest":string}),&["expected_digest"])]}}},"required":["edits"],"additionalProperties":false}) },
         ]
     }
+
     fn validate(&self, name: &str, arguments: &Value) -> std::result::Result<(), ToolError> {
         decode(name, arguments).map(|_| ())
     }
+
     async fn execute(&mut self, call: &ValidatedCall, cancellation: &Cancellation) -> ToolOutcome {
         let request = match decode(&call.name, &call.arguments) {
             Ok(v) => v,
             Err(e) => return ToolOutcome::Failed(e),
         };
+
         if cancellation.is_cancelled() {
             return ToolOutcome::Failed(ToolError::Interrupted);
         }
+
         let result = match request {
             Request::Read(request) => self
                 .read_file(request)
@@ -573,12 +639,14 @@ impl Tools for Workspace {
                 Ok(serde_json::to_value(result).unwrap())
             }
         };
+
         let outcome = match result {
             Ok(value) => ToolOutcome::Success(value),
             Err(failure) => {
                 ToolOutcome::Failed(ToolError::Workspace(serde_json::to_value(failure).unwrap()))
             }
         };
+
         if encode(&outcome, self.limits.output_bytes).is_err() {
             ToolOutcome::Failed(ToolError::OutputLimit)
         } else {
@@ -586,21 +654,25 @@ impl Tools for Workspace {
         }
     }
 }
+
 enum Request {
     Read(ReadRequest),
     Search(SearchRequest),
     Patch(PatchRequest),
 }
+
 fn decode(name: &str, value: &Value) -> std::result::Result<Request, ToolError> {
     if encode(value, 256 * 1024).is_err() {
         return Err(ToolError::InvalidArguments);
     }
+
     let parsed = match name {
         "read_file" => serde_json::from_value(value.clone()).map(Request::Read),
         "search_text" => serde_json::from_value(value.clone()).map(Request::Search),
         "apply_patch" => serde_json::from_value(value.clone()).map(Request::Patch),
         _ => return Err(ToolError::UnknownTool),
     };
+
     let request = parsed.map_err(|_| ToolError::InvalidArguments)?;
     let valid = match &request {
         Request::Read(r) => r.start_line > 0 && r.max_lines > 0 && r.max_bytes > 0,
@@ -624,6 +696,7 @@ fn decode(name: &str, value: &Value) -> std::result::Result<Request, ToolError> 
                 })
         }
     };
+
     if valid {
         Ok(request)
     } else {

--- a/src/nano/workspace/fs.rs
+++ b/src/nano/workspace/fs.rs
@@ -94,6 +94,14 @@ impl Parent {
         platform::child(&self.directory, &self.name, false, false)
     }
 
+    pub(super) fn patch_key(&self) -> io::Result<impl Ord + use<>> {
+        #[cfg(unix)]
+        let name = platform::patch_name_key(&self.name);
+        #[cfg(windows)]
+        let name = platform::search_key(&self.name);
+        Ok((identity(&self.directory)?, name))
+    }
+
     pub(super) fn stage(&self, bytes: &[u8], mode: Option<&Permissions>) -> io::Result<Staged> {
         static SEQUENCE: AtomicU64 = AtomicU64::new(0);
 

--- a/src/nano/workspace/fs.rs
+++ b/src/nano/workspace/fs.rs
@@ -44,6 +44,17 @@ pub(super) fn children(file: &File, limit: usize) -> io::Result<(Vec<String>, bo
     platform::children(file, limit)
 }
 
+pub(super) fn search_key(path: &str) -> impl Ord + use<> {
+    #[cfg(unix)]
+    {
+        path.to_owned()
+    }
+    #[cfg(windows)]
+    {
+        platform::search_key(path)
+    }
+}
+
 impl Root {
     pub(super) fn new(path: &Path) -> io::Result<Self> {
         platform::root(path).map(Self)
@@ -175,6 +186,19 @@ impl Drop for Staged {
 mod tests {
     use super::*;
     use std::{fs, io::Read};
+
+    #[test]
+    fn search_keys_follow_platform_case_rules() {
+        #[cfg(unix)]
+        assert!(search_key("src/file") != search_key("SRC/FILE"));
+        #[cfg(windows)]
+        {
+            assert!(search_key("src/file") == search_key("SRC/FILE"));
+            assert!(search_key("caf\u{e9}/file") == search_key("CAF\u{c9}/FILE"));
+            // NT upcasing preserves UTF-16 length; Unicode expansion is not a path alias.
+            assert!(search_key("stra\u{df}e") != search_key("STRASSE"));
+        }
+    }
 
     #[test]
     fn create_publication_never_clobbers_an_existing_entry() {

--- a/src/nano/workspace/fs.rs
+++ b/src/nano/workspace/fs.rs
@@ -263,8 +263,9 @@ mod tests {
         let parent = root.parent("private.txt").unwrap();
         let mode = parent.open().unwrap().metadata().unwrap().permissions();
         let staged = parent.stage(b"new\n", Some(&mode)).unwrap();
-        crate::nano::private::read_only_file(&directory.path().join(&staged.name))
-            .expect("staged owner-only DACL");
+        // Staging holds DELETE access for publication. Inspect its existing handle;
+        // reopening through the private reader would deny that access via sharing.
+        crate::nano::private::check_input_handle(&staged.file).expect("staged owner-only DACL");
         parent
             .publish(staged, false)
             .unwrap_or_else(|error| panic!("private publication failed: {}", error.error));

--- a/src/nano/workspace/fs.rs
+++ b/src/nano/workspace/fs.rs
@@ -55,6 +55,10 @@ pub(super) fn search_key(path: &str) -> impl Ord + use<> {
     }
 }
 
+pub(super) fn identity(file: &File) -> io::Result<(u64, u128)> {
+    platform::identity(file)
+}
+
 impl Root {
     pub(super) fn new(path: &Path) -> io::Result<Self> {
         platform::root(path).map(Self)
@@ -254,12 +258,15 @@ mod tests {
         let directory = tempfile::TempDir::new().unwrap();
         let root = Root::new(&directory.path().canonicalize().unwrap()).unwrap();
         fs::write(directory.path().join("file"), "body").unwrap();
+        let file_identity = identity(&root.open("file").unwrap()).unwrap();
+        assert_ne!(file_identity, identity(&root.directory().unwrap()).unwrap());
         for _ in 0..2 {
             assert_eq!(
                 children(&root.directory().unwrap(), 10).unwrap(),
                 (vec!["file".to_owned()], false)
             );
             let mut file = root.open("file").unwrap();
+            assert_eq!(identity(&file).unwrap(), file_identity);
             let mut text = String::new();
             file.read_to_string(&mut text).unwrap();
             assert_eq!(text, "body");

--- a/src/nano/workspace/fs.rs
+++ b/src/nano/workspace/fs.rs
@@ -258,15 +258,18 @@ mod tests {
             .unwrap()
             .write_all(b"old\n")
             .unwrap();
+        crate::nano::private::read_only_file(&path).expect("original owner-only DACL");
         let root = Root::new(&directory.path().canonicalize().unwrap()).unwrap();
         let parent = root.parent("private.txt").unwrap();
         let mode = parent.open().unwrap().metadata().unwrap().permissions();
         let staged = parent.stage(b"new\n", Some(&mode)).unwrap();
+        crate::nano::private::read_only_file(&directory.path().join(&staged.name))
+            .expect("staged owner-only DACL");
         parent
             .publish(staged, false)
             .unwrap_or_else(|error| panic!("private publication failed: {}", error.error));
         // Validate the protected DACL from the opened handle, not just readonly.
-        crate::nano::private::read_only_file(&path).unwrap();
+        crate::nano::private::read_only_file(&path).expect("published owner-only DACL");
         assert_eq!(fs::read(path).unwrap(), b"new\n");
     }
 

--- a/src/nano/workspace/fs.rs
+++ b/src/nano/workspace/fs.rs
@@ -1,0 +1,231 @@
+//! Handle-relative filesystem operations; no model path is opened by an absolute join.
+
+use std::{
+    fs::{File, Permissions},
+    io::{self, Write},
+    path::Path,
+    sync::atomic::{AtomicU64, Ordering},
+};
+#[cfg(unix)]
+#[path = "unix.rs"]
+mod platform;
+#[cfg(windows)]
+#[path = "windows.rs"]
+mod platform;
+
+pub(super) struct Root(File);
+pub(super) struct Parent {
+    directory: File,
+    name: String,
+}
+pub(super) struct Staged {
+    directory: File,
+    name: String,
+    file: File,
+    published: bool,
+}
+pub(super) struct CommitError {
+    pub changed: bool,
+    pub error: io::Error,
+}
+
+pub(super) fn unsafe_file() -> io::Error {
+    io::Error::new(io::ErrorKind::Unsupported, "unsafe file")
+}
+pub(super) fn regular(file: &File) -> io::Result<()> {
+    platform::regular(file)
+}
+pub(super) fn children(file: &File, limit: usize) -> io::Result<(Vec<String>, bool)> {
+    platform::children(file, limit)
+}
+impl Root {
+    pub(super) fn new(path: &Path) -> io::Result<Self> {
+        platform::root(path).map(Self)
+    }
+    pub(super) fn directory(&self) -> io::Result<File> {
+        platform::child(&self.0, ".", true, false)
+    }
+    pub(super) fn parent(&self, path: &str) -> io::Result<Parent> {
+        let mut parts = path.split('/').peekable();
+        let mut directory = self.directory()?;
+        while let Some(name) = parts.next() {
+            if parts.peek().is_none() {
+                return Ok(Parent {
+                    directory,
+                    name: name.into(),
+                });
+            }
+            directory = platform::child(&directory, name, true, false)?;
+        }
+        Err(io::Error::new(io::ErrorKind::InvalidInput, "empty path"))
+    }
+    pub(super) fn open(&self, path: &str) -> io::Result<File> {
+        self.parent(path)?.open()
+    }
+}
+impl Parent {
+    pub(super) fn open(&self) -> io::Result<File> {
+        platform::child(&self.directory, &self.name, false, false)
+    }
+    pub(super) fn stage(&self, bytes: &[u8], mode: Option<&Permissions>) -> io::Result<Staged> {
+        static SEQUENCE: AtomicU64 = AtomicU64::new(0);
+        let name = format!(
+            ".nano-tmp-{}-{}",
+            std::process::id(),
+            SEQUENCE.fetch_add(1, Ordering::Relaxed)
+        );
+        let directory = self.directory.try_clone()?;
+        let file = platform::child(&directory, &name, false, true)?;
+        let mut staged = Staged {
+            directory,
+            name,
+            file,
+            published: false,
+        };
+        #[cfg(windows)]
+        if mode.is_some() {
+            platform::copy_security(&self.open()?, &staged.file)?;
+        }
+        staged.file.write_all(bytes)?;
+        if let Some(mode) = mode {
+            staged.file.set_permissions(mode.clone())?;
+        }
+        staged.file.sync_all()?;
+        Ok(staged)
+    }
+    pub(super) fn publish(&self, mut staged: Staged, create: bool) -> Result<(), CommitError> {
+        platform::publish(
+            &self.directory,
+            &self.name,
+            &staged.name,
+            &staged.file,
+            create,
+        )
+        .map_err(|error| CommitError {
+            changed: false,
+            error,
+        })?;
+        staged.published = true;
+        platform::finish_publish(&self.directory, &staged.name, create).map_err(|error| {
+            CommitError {
+                changed: true,
+                error,
+            }
+        })?;
+        platform::sync(&self.directory).map_err(|error| CommitError {
+            changed: true,
+            error,
+        })
+    }
+    pub(super) fn delete(&self) -> Result<(), CommitError> {
+        platform::delete(&self.directory, &self.name).map_err(|error| CommitError {
+            changed: false,
+            error,
+        })?;
+        platform::sync(&self.directory).map_err(|error| CommitError {
+            changed: true,
+            error,
+        })
+    }
+}
+impl Drop for Staged {
+    fn drop(&mut self) {
+        if !self.published {
+            #[cfg(windows)]
+            if let Ok(metadata) = self.file.metadata() {
+                let mut permissions = metadata.permissions();
+                // This changes only a Windows attribute on our owned temporary file.
+                #[allow(clippy::permissions_set_readonly_false)]
+                permissions.set_readonly(false);
+                let _ = self.file.set_permissions(permissions);
+            }
+            #[cfg(unix)]
+            let _ = platform::delete(&self.directory, &self.name);
+            #[cfg(windows)]
+            let _ = platform::discard(&self.file);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{fs, io::Read};
+
+    #[test]
+    fn create_publication_never_clobbers_an_existing_entry() {
+        let directory = tempfile::TempDir::new().unwrap();
+        let root = Root::new(&directory.path().canonicalize().unwrap()).unwrap();
+        let parent = root.parent("file").unwrap();
+        let staged = parent.stage(b"agent", None).unwrap();
+        fs::write(directory.path().join("file"), "human").unwrap();
+        assert!(parent.publish(staged, true).is_err());
+        assert_eq!(fs::read(directory.path().join("file")).unwrap(), b"human");
+        assert_eq!(fs::read_dir(directory.path()).unwrap().count(), 1);
+    }
+
+    #[test]
+    fn enumeration_restarts_and_hardlink_aliases_are_rejected() {
+        let directory = tempfile::TempDir::new().unwrap();
+        let root = Root::new(&directory.path().canonicalize().unwrap()).unwrap();
+        fs::write(directory.path().join("file"), "body").unwrap();
+        for _ in 0..2 {
+            assert_eq!(
+                children(&root.directory().unwrap(), 10).unwrap(),
+                (vec!["file".to_owned()], false)
+            );
+            let mut file = root.open("file").unwrap();
+            let mut text = String::new();
+            file.read_to_string(&mut text).unwrap();
+            assert_eq!(text, "body");
+        }
+        fs::hard_link(
+            directory.path().join("file"),
+            directory.path().join("alias"),
+        )
+        .unwrap();
+        assert!(root.open("alias").is_err());
+        assert!(root.open("file").is_err());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_updates_preserve_protected_owner_only_access() {
+        let directory = tempfile::TempDir::new().unwrap();
+        let path = directory.path().join("private.txt");
+        crate::nano::private::file(&path, true)
+            .unwrap()
+            .write_all(b"old\n")
+            .unwrap();
+        let root = Root::new(&directory.path().canonicalize().unwrap()).unwrap();
+        let parent = root.parent("private.txt").unwrap();
+        let mode = parent.open().unwrap().metadata().unwrap().permissions();
+        let staged = parent.stage(b"new\n", Some(&mode)).unwrap();
+        assert!(parent.publish(staged, false).is_ok());
+        // Validate the protected DACL from the opened handle, not just readonly.
+        crate::nano::private::read_only_file(&path).unwrap();
+        assert_eq!(fs::read(path).unwrap(), b"new\n");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_junctions_cannot_redirect_reads_or_writes() {
+        let directory = tempfile::TempDir::new().unwrap();
+        let outside = tempfile::TempDir::new().unwrap();
+        fs::write(outside.path().join("file"), "outside").unwrap();
+        let link = directory.path().join("junction");
+        let output = std::process::Command::new("cmd")
+            .args(["/C", "mklink", "/J"])
+            .arg(&link)
+            .arg(outside.path())
+            .stdin(std::process::Stdio::null())
+            .output()
+            .unwrap();
+        assert!(output.status.success(), "junction fixture setup failed");
+        let root = Root::new(&directory.path().canonicalize().unwrap()).unwrap();
+        assert!(root.open("junction/file").is_err());
+        assert!(root.parent("junction/new").is_err());
+        assert_eq!(fs::read(outside.path().join("file")).unwrap(), b"outside");
+        fs::remove_dir(link).unwrap();
+    }
+}

--- a/src/nano/workspace/fs.rs
+++ b/src/nano/workspace/fs.rs
@@ -14,16 +14,19 @@ mod platform;
 mod platform;
 
 pub(super) struct Root(File);
+
 pub(super) struct Parent {
     directory: File,
     name: String,
 }
+
 pub(super) struct Staged {
     directory: File,
     name: String,
     file: File,
     published: bool,
 }
+
 pub(super) struct CommitError {
     pub changed: bool,
     pub error: io::Error,
@@ -32,19 +35,24 @@ pub(super) struct CommitError {
 pub(super) fn unsafe_file() -> io::Error {
     io::Error::new(io::ErrorKind::Unsupported, "unsafe file")
 }
+
 pub(super) fn regular(file: &File) -> io::Result<()> {
     platform::regular(file)
 }
+
 pub(super) fn children(file: &File, limit: usize) -> io::Result<(Vec<String>, bool)> {
     platform::children(file, limit)
 }
+
 impl Root {
     pub(super) fn new(path: &Path) -> io::Result<Self> {
         platform::root(path).map(Self)
     }
+
     pub(super) fn directory(&self) -> io::Result<File> {
         platform::child(&self.0, ".", true, false)
     }
+
     pub(super) fn parent(&self, path: &str) -> io::Result<Parent> {
         let mut parts = path.split('/').peekable();
         let mut directory = self.directory()?;
@@ -57,23 +65,29 @@ impl Root {
             }
             directory = platform::child(&directory, name, true, false)?;
         }
+
         Err(io::Error::new(io::ErrorKind::InvalidInput, "empty path"))
     }
+
     pub(super) fn open(&self, path: &str) -> io::Result<File> {
         self.parent(path)?.open()
     }
 }
+
 impl Parent {
     pub(super) fn open(&self) -> io::Result<File> {
         platform::child(&self.directory, &self.name, false, false)
     }
+
     pub(super) fn stage(&self, bytes: &[u8], mode: Option<&Permissions>) -> io::Result<Staged> {
         static SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
         let name = format!(
             ".nano-tmp-{}-{}",
             std::process::id(),
             SEQUENCE.fetch_add(1, Ordering::Relaxed)
         );
+
         let directory = self.directory.try_clone()?;
         let file = platform::child(&directory, &name, false, true)?;
         let mut staged = Staged {
@@ -82,17 +96,22 @@ impl Parent {
             file,
             published: false,
         };
+
         #[cfg(windows)]
         if mode.is_some() {
             platform::copy_security(&self.open()?, &staged.file)?;
         }
+
         staged.file.write_all(bytes)?;
+
         if let Some(mode) = mode {
             staged.file.set_permissions(mode.clone())?;
         }
+
         staged.file.sync_all()?;
         Ok(staged)
     }
+
     pub(super) fn publish(&self, mut staged: Staged, create: bool) -> Result<(), CommitError> {
         platform::publish(
             &self.directory,
@@ -105,23 +124,28 @@ impl Parent {
             changed: false,
             error,
         })?;
+
         staged.published = true;
+
         platform::finish_publish(&self.directory, &staged.name, create).map_err(|error| {
             CommitError {
                 changed: true,
                 error,
             }
         })?;
+
         platform::sync(&self.directory).map_err(|error| CommitError {
             changed: true,
             error,
         })
     }
+
     pub(super) fn delete(&self) -> Result<(), CommitError> {
         platform::delete(&self.directory, &self.name).map_err(|error| CommitError {
             changed: false,
             error,
         })?;
+
         platform::sync(&self.directory).map_err(|error| CommitError {
             changed: true,
             error,
@@ -159,9 +183,46 @@ mod tests {
         let parent = root.parent("file").unwrap();
         let staged = parent.stage(b"agent", None).unwrap();
         fs::write(directory.path().join("file"), "human").unwrap();
-        assert!(parent.publish(staged, true).is_err());
+        let error = parent.publish(staged, true).expect_err("target exists");
+        assert!(!error.changed);
+        assert_eq!(error.error.kind(), io::ErrorKind::AlreadyExists);
         assert_eq!(fs::read(directory.path().join("file")).unwrap(), b"human");
         assert_eq!(fs::read_dir(directory.path()).unwrap().count(), 1);
+    }
+
+    #[test]
+    fn publications_use_the_held_parent_for_create_replace_and_delete() {
+        let directory = tempfile::TempDir::new().unwrap();
+        fs::create_dir(directory.path().join("nested")).unwrap();
+        let root = Root::new(&directory.path().canonicalize().unwrap()).unwrap();
+
+        // Exercise short and variable-length UTF-16 rename buffers on Windows.
+        for name in ["a", "longer-\u{e9}-\u{1f980}.txt"] {
+            fs::write(directory.path().join(name), b"unrelated").unwrap();
+            let parent = root.parent(&format!("nested/{name}")).unwrap();
+            let target = directory.path().join("nested").join(name);
+            for (bytes, create) in [(b"created".as_slice(), true), (b"replaced", false)] {
+                let staged = parent.stage(bytes, None).unwrap();
+                parent.publish(staged, create).unwrap_or_else(|error| {
+                    panic!(
+                        "publication failed (changed={}): {}",
+                        error.changed, error.error
+                    )
+                });
+                assert_eq!(fs::read(&target).unwrap(), bytes);
+                assert_eq!(fs::read(directory.path().join(name)).unwrap(), b"unrelated");
+                assert_eq!(fs::read_dir(target.parent().unwrap()).unwrap().count(), 1);
+            }
+            parent.delete().unwrap_or_else(|error| {
+                panic!(
+                    "deletion failed (changed={}): {}",
+                    error.changed, error.error
+                )
+            });
+            assert!(!target.exists());
+            assert_eq!(fs::read(directory.path().join(name)).unwrap(), b"unrelated");
+            assert_eq!(fs::read_dir(target.parent().unwrap()).unwrap().count(), 0);
+        }
     }
 
     #[test]
@@ -201,7 +262,9 @@ mod tests {
         let parent = root.parent("private.txt").unwrap();
         let mode = parent.open().unwrap().metadata().unwrap().permissions();
         let staged = parent.stage(b"new\n", Some(&mode)).unwrap();
-        assert!(parent.publish(staged, false).is_ok());
+        parent
+            .publish(staged, false)
+            .unwrap_or_else(|error| panic!("private publication failed: {}", error.error));
         // Validate the protected DACL from the opened handle, not just readonly.
         crate::nano::private::read_only_file(&path).unwrap();
         assert_eq!(fs::read(path).unwrap(), b"new\n");

--- a/src/nano/workspace/patch.rs
+++ b/src/nano/workspace/patch.rs
@@ -9,6 +9,7 @@ pub(crate) struct Hunk {
     pub old_text: String,
     pub new_text: String,
 }
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "operation", rename_all = "snake_case", deny_unknown_fields)]
 pub(crate) enum Edit {
@@ -26,6 +27,7 @@ pub(crate) enum Edit {
         expected_digest: String,
     },
 }
+
 impl Edit {
     fn path(&self) -> &str {
         match self {
@@ -35,11 +37,13 @@ impl Edit {
         }
     }
 }
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct PatchRequest {
     pub edits: Vec<Edit>,
 }
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum State {
@@ -47,6 +51,7 @@ pub(crate) enum State {
     Applied,
     DurabilityUnconfirmed,
 }
+
 #[derive(Debug, Serialize)]
 pub(crate) struct Change {
     pub path: String,
@@ -55,6 +60,7 @@ pub(crate) struct Change {
     pub after_digest: Option<String>,
     pub state: State,
 }
+
 #[derive(Debug, Serialize)]
 pub(crate) struct PatchResult {
     pub source_kind: &'static str,
@@ -64,6 +70,7 @@ pub(crate) struct PatchResult {
     pub changes: Vec<Change>,
     pub failure: Option<Failure>,
 }
+
 struct Plan {
     path: String,
     before: Option<String>,
@@ -81,8 +88,10 @@ impl Workspace {
             Ok(plans) => plans,
             Err(failure) => return self.patch_result(Vec::new(), Some(failure)),
         };
+
         self.commit_plans(plans, start, cancellation).await
     }
+
     fn prepare(
         &self,
         request: PatchRequest,
@@ -95,17 +104,20 @@ impl Workspace {
         {
             return Err(Failure::new(Code::InvalidPatch, ""));
         }
+
         let mut names = BTreeSet::new();
         let mut plans = Vec::new();
         for edit in request.edits {
             if self.stopped(start, cancellation) {
                 return Err(Failure::new(Code::Interrupted, edit.path()));
             }
+
             let path = path(edit.path())?;
             // Also reject case aliases on platforms where spelling is not identity.
             if !names.insert(path.to_lowercase()) {
                 return Err(Failure::new(Code::InvalidPatch, &path));
             }
+
             let parent = self.root.parent(&path).map_err(|e| Failure::io(&path, e))?;
             let (before, after) = match edit {
                 Edit::Create { content, .. } => {
@@ -134,23 +146,29 @@ impl Workspace {
                     (Some(current.digest), None)
                 }
             };
+
             plans.push(Plan {
                 path,
                 before,
                 after,
             });
         }
+
         Ok(plans)
     }
+
     fn check_text(&self, path: &str, text: &str) -> Result<()> {
         if text.len() > self.limits.file_bytes {
             return Err(Failure::new(Code::FileTooLarge, path));
         }
+
         if text.contains('\0') {
             return Err(Failure::new(Code::Binary, path));
         }
+
         Ok(())
     }
+
     fn check_base(
         &self,
         parent: &fs::Parent,
@@ -165,18 +183,22 @@ impl Workspace {
         }) {
             return Err(Failure::new(Code::InvalidPatch, path));
         }
+
         let current = match parent.open() {
             Ok(file) => Some(self.read_content(file, path)?),
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
             Err(error) => return Err(Failure::io(path, error)),
         };
+
         if current.as_ref().map(|c| c.digest.as_str()) != expected {
             let mut failure = Failure::new(Code::Conflict, path);
             failure.current_digest = current.map(|c| c.digest);
             return Err(failure);
         }
+
         Ok(current)
     }
+
     fn patch_result(&self, changes: Vec<Change>, failure: Option<Failure>) -> PatchResult {
         PatchResult {
             source_kind: "workspace",
@@ -187,6 +209,7 @@ impl Workspace {
             failure,
         }
     }
+
     async fn commit_plans(
         &mut self,
         plans: Vec<Plan>,
@@ -203,21 +226,25 @@ impl Workspace {
                 state: State::NotApplied,
             })
             .collect();
+
         let mut result = self.patch_result(changes, None);
         // Reserve space for the error and wrapper before any effect is possible.
         if encode(&result, self.limits.output_bytes.saturating_sub(2048)).is_err() {
             return self.patch_result(Vec::new(), Some(Failure::new(Code::OutputLimit, "")));
         }
+
         for (index, plan) in plans.into_iter().enumerate() {
             if self.stopped(start, cancellation) {
                 result.failure = Some(Failure::new(Code::Interrupted, &plan.path));
                 break;
             }
+
             let applied = (|| -> Result<_> {
                 let parent = self
                     .root
                     .parent(&plan.path)
                     .map_err(|e| Failure::io(&plan.path, e))?;
+
                 let current = self.check_base(&parent, &plan.path, plan.before.as_deref())?;
                 let staged = plan
                     .after
@@ -228,6 +255,7 @@ impl Workspace {
                             .map_err(|e| Failure::io(&plan.path, e))
                     })
                     .transpose()?;
+
                 // Catch changes during staging. No fuzzy merge, rebasing, or rollback of other files.
                 self.check_base(&parent, &plan.path, plan.before.as_deref())?;
                 Ok(match staged {
@@ -235,6 +263,7 @@ impl Workspace {
                     None => parent.delete(),
                 })
             })();
+
             match applied {
                 Ok(Ok(())) => {
                     result.changes[index].state = State::Applied;
@@ -257,8 +286,10 @@ impl Workspace {
                     break;
                 }
             }
+
             tokio::task::yield_now().await;
         }
+
         result.generation = self.generation;
         result.complete = result.failure.is_none();
         result
@@ -269,8 +300,10 @@ fn apply_hunks(path: &str, before: &str, hunks: &[Hunk], limit: usize) -> Result
     if hunks.is_empty() || hunks.len() > 128 {
         return Err(Failure::new(Code::InvalidPatch, path));
     }
+
     let mut offsets = vec![0];
     offsets.extend(before.match_indices('\n').map(|(index, _)| index + 1));
+
     let mut output = String::new();
     let mut consumed = 0;
     let mut previous_start = None;
@@ -281,10 +314,12 @@ fn apply_hunks(path: &str, before: &str, hunks: &[Hunk], limit: usize) -> Result
             .and_then(|index| offsets.get(index))
             .copied()
             .ok_or_else(|| Failure::new(Code::InvalidPatch, path))?;
+
         let end = start
             .checked_add(hunk.old_text.len())
             .filter(|end| *end <= before.len())
             .ok_or_else(|| Failure::new(Code::InvalidPatch, path))?;
+
         if start < consumed
             || previous_start.is_some_and(|previous| start <= previous)
             || !before[start..].starts_with(&hunk.old_text)
@@ -293,6 +328,7 @@ fn apply_hunks(path: &str, before: &str, hunks: &[Hunk], limit: usize) -> Result
         {
             return Err(Failure::new(Code::InvalidPatch, path));
         }
+
         if output
             .len()
             .saturating_add(start - consumed)
@@ -301,14 +337,18 @@ fn apply_hunks(path: &str, before: &str, hunks: &[Hunk], limit: usize) -> Result
         {
             return Err(Failure::new(Code::FileTooLarge, path));
         }
+
         output.push_str(&before[consumed..start]);
         output.push_str(&hunk.new_text);
+
         consumed = end;
         previous_start = Some(start);
     }
+
     if output.len().saturating_add(before.len() - consumed) > limit {
         return Err(Failure::new(Code::FileTooLarge, path));
     }
+
     output.push_str(&before[consumed..]);
     Ok(output)
 }

--- a/src/nano/workspace/patch.rs
+++ b/src/nano/workspace/patch.rs
@@ -1,0 +1,394 @@
+//! Exact line hunks with full-set preflight and explicitly non-atomic file-set commits.
+
+use super::*;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct Hunk {
+    pub start_line: usize,
+    pub old_text: String,
+    pub new_text: String,
+}
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "operation", rename_all = "snake_case", deny_unknown_fields)]
+pub(crate) enum Edit {
+    Create {
+        path: String,
+        content: String,
+    },
+    Update {
+        path: String,
+        expected_digest: String,
+        hunks: Vec<Hunk>,
+    },
+    Delete {
+        path: String,
+        expected_digest: String,
+    },
+}
+impl Edit {
+    fn path(&self) -> &str {
+        match self {
+            Self::Create { path, .. } | Self::Update { path, .. } | Self::Delete { path, .. } => {
+                path
+            }
+        }
+    }
+}
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PatchRequest {
+    pub edits: Vec<Edit>,
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum State {
+    NotApplied,
+    Applied,
+    DurabilityUnconfirmed,
+}
+#[derive(Debug, Serialize)]
+pub(crate) struct Change {
+    pub path: String,
+    pub before_digest: Option<String>,
+    pub intended_digest: Option<String>,
+    pub after_digest: Option<String>,
+    pub state: State,
+}
+#[derive(Debug, Serialize)]
+pub(crate) struct PatchResult {
+    pub source_kind: &'static str,
+    pub workspace_id: String,
+    pub generation: u64,
+    pub complete: bool,
+    pub changes: Vec<Change>,
+    pub failure: Option<Failure>,
+}
+struct Plan {
+    path: String,
+    before: Option<String>,
+    after: Option<String>,
+}
+
+impl Workspace {
+    pub(crate) async fn apply_patch(
+        &mut self,
+        request: PatchRequest,
+        cancellation: &Cancellation,
+    ) -> PatchResult {
+        let start = Instant::now();
+        let plans = match self.prepare(request, start, cancellation) {
+            Ok(plans) => plans,
+            Err(failure) => return self.patch_result(Vec::new(), Some(failure)),
+        };
+        self.commit_plans(plans, start, cancellation).await
+    }
+    fn prepare(
+        &self,
+        request: PatchRequest,
+        start: Instant,
+        cancellation: &Cancellation,
+    ) -> Result<Vec<Plan>> {
+        if request.edits.is_empty()
+            || request.edits.len() > 16
+            || encode(&request, 256 * 1024).is_err()
+        {
+            return Err(Failure::new(Code::InvalidPatch, ""));
+        }
+        let mut names = BTreeSet::new();
+        let mut plans = Vec::new();
+        for edit in request.edits {
+            if self.stopped(start, cancellation) {
+                return Err(Failure::new(Code::Interrupted, edit.path()));
+            }
+            let path = path(edit.path())?;
+            // Also reject case aliases on platforms where spelling is not identity.
+            if !names.insert(path.to_lowercase()) {
+                return Err(Failure::new(Code::InvalidPatch, &path));
+            }
+            let parent = self.root.parent(&path).map_err(|e| Failure::io(&path, e))?;
+            let (before, after) = match edit {
+                Edit::Create { content, .. } => {
+                    self.check_base(&parent, &path, None)?;
+                    self.check_text(&path, &content)?;
+                    (None, Some(content))
+                }
+                Edit::Update {
+                    expected_digest,
+                    hunks,
+                    ..
+                } => {
+                    let current = self
+                        .check_base(&parent, &path, Some(&expected_digest))?
+                        .unwrap();
+                    let after = apply_hunks(&path, &current.text, &hunks, self.limits.file_bytes)?;
+                    self.check_text(&path, &after)?;
+                    (Some(current.digest), Some(after))
+                }
+                Edit::Delete {
+                    expected_digest, ..
+                } => {
+                    let current = self
+                        .check_base(&parent, &path, Some(&expected_digest))?
+                        .unwrap();
+                    (Some(current.digest), None)
+                }
+            };
+            plans.push(Plan {
+                path,
+                before,
+                after,
+            });
+        }
+        Ok(plans)
+    }
+    fn check_text(&self, path: &str, text: &str) -> Result<()> {
+        if text.len() > self.limits.file_bytes {
+            return Err(Failure::new(Code::FileTooLarge, path));
+        }
+        if text.contains('\0') {
+            return Err(Failure::new(Code::Binary, path));
+        }
+        Ok(())
+    }
+    fn check_base(
+        &self,
+        parent: &fs::Parent,
+        path: &str,
+        expected: Option<&str>,
+    ) -> Result<Option<Content>> {
+        if expected.is_some_and(|value| {
+            value.len() != 64
+                || !value
+                    .bytes()
+                    .all(|c| c.is_ascii_digit() || (b'a'..=b'f').contains(&c))
+        }) {
+            return Err(Failure::new(Code::InvalidPatch, path));
+        }
+        let current = match parent.open() {
+            Ok(file) => Some(self.read_content(file, path)?),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => return Err(Failure::io(path, error)),
+        };
+        if current.as_ref().map(|c| c.digest.as_str()) != expected {
+            let mut failure = Failure::new(Code::Conflict, path);
+            failure.current_digest = current.map(|c| c.digest);
+            return Err(failure);
+        }
+        Ok(current)
+    }
+    fn patch_result(&self, changes: Vec<Change>, failure: Option<Failure>) -> PatchResult {
+        PatchResult {
+            source_kind: "workspace",
+            workspace_id: self.id.clone(),
+            generation: self.generation,
+            complete: failure.is_none(),
+            changes,
+            failure,
+        }
+    }
+    async fn commit_plans(
+        &mut self,
+        plans: Vec<Plan>,
+        start: Instant,
+        cancellation: &Cancellation,
+    ) -> PatchResult {
+        let changes = plans
+            .iter()
+            .map(|plan| Change {
+                path: plan.path.clone(),
+                before_digest: plan.before.clone(),
+                intended_digest: plan.after.as_ref().map(|text| digest(text.as_bytes())),
+                after_digest: None,
+                state: State::NotApplied,
+            })
+            .collect();
+        let mut result = self.patch_result(changes, None);
+        // Reserve space for the error and wrapper before any effect is possible.
+        if encode(&result, self.limits.output_bytes.saturating_sub(2048)).is_err() {
+            return self.patch_result(Vec::new(), Some(Failure::new(Code::OutputLimit, "")));
+        }
+        for (index, plan) in plans.into_iter().enumerate() {
+            if self.stopped(start, cancellation) {
+                result.failure = Some(Failure::new(Code::Interrupted, &plan.path));
+                break;
+            }
+            let applied = (|| -> Result<_> {
+                let parent = self
+                    .root
+                    .parent(&plan.path)
+                    .map_err(|e| Failure::io(&plan.path, e))?;
+                let current = self.check_base(&parent, &plan.path, plan.before.as_deref())?;
+                let staged = plan
+                    .after
+                    .as_ref()
+                    .map(|text| {
+                        parent
+                            .stage(text.as_bytes(), current.as_ref().map(|c| &c.mode))
+                            .map_err(|e| Failure::io(&plan.path, e))
+                    })
+                    .transpose()?;
+                // Catch changes during staging. No fuzzy merge, rebasing, or rollback of other files.
+                self.check_base(&parent, &plan.path, plan.before.as_deref())?;
+                Ok(match staged {
+                    Some(staged) => parent.publish(staged, plan.before.is_none()),
+                    None => parent.delete(),
+                })
+            })();
+            match applied {
+                Ok(Ok(())) => {
+                    result.changes[index].state = State::Applied;
+                    result.changes[index].after_digest =
+                        result.changes[index].intended_digest.clone();
+                    self.generation = self.generation.saturating_add(1);
+                }
+                Ok(Err(error)) => {
+                    if error.changed {
+                        result.changes[index].state = State::DurabilityUnconfirmed;
+                        result.changes[index].after_digest =
+                            result.changes[index].intended_digest.clone();
+                        self.generation = self.generation.saturating_add(1);
+                    }
+                    result.failure = Some(Failure::io(&plan.path, error.error));
+                    break;
+                }
+                Err(failure) => {
+                    result.failure = Some(failure);
+                    break;
+                }
+            }
+            tokio::task::yield_now().await;
+        }
+        result.generation = self.generation;
+        result.complete = result.failure.is_none();
+        result
+    }
+}
+
+fn apply_hunks(path: &str, before: &str, hunks: &[Hunk], limit: usize) -> Result<String> {
+    if hunks.is_empty() || hunks.len() > 128 {
+        return Err(Failure::new(Code::InvalidPatch, path));
+    }
+    let mut offsets = vec![0];
+    offsets.extend(before.match_indices('\n').map(|(index, _)| index + 1));
+    let mut output = String::new();
+    let mut consumed = 0;
+    let mut previous_start = None;
+    for hunk in hunks {
+        let start = hunk
+            .start_line
+            .checked_sub(1)
+            .and_then(|index| offsets.get(index))
+            .copied()
+            .ok_or_else(|| Failure::new(Code::InvalidPatch, path))?;
+        let end = start
+            .checked_add(hunk.old_text.len())
+            .filter(|end| *end <= before.len())
+            .ok_or_else(|| Failure::new(Code::InvalidPatch, path))?;
+        if start < consumed
+            || previous_start.is_some_and(|previous| start <= previous)
+            || !before[start..].starts_with(&hunk.old_text)
+            || (end < before.len() && !hunk.old_text.is_empty() && !hunk.old_text.ends_with('\n'))
+            || (end < before.len() && !hunk.new_text.is_empty() && !hunk.new_text.ends_with('\n'))
+        {
+            return Err(Failure::new(Code::InvalidPatch, path));
+        }
+        if output
+            .len()
+            .saturating_add(start - consumed)
+            .saturating_add(hunk.new_text.len())
+            > limit
+        {
+            return Err(Failure::new(Code::FileTooLarge, path));
+        }
+        output.push_str(&before[consumed..start]);
+        output.push_str(&hunk.new_text);
+        consumed = end;
+        previous_start = Some(start);
+    }
+    if output.len().saturating_add(before.len() - consumed) > limit {
+        return Err(Failure::new(Code::FileTooLarge, path));
+    }
+    output.push_str(&before[consumed..]);
+    Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[tokio::test]
+    async fn late_filesystem_failure_reports_the_applied_prefix() {
+        let directory = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir(directory.path().join("parent")).unwrap();
+        let mut workspace =
+            Workspace::new(&directory.path().canonicalize().unwrap(), Limits::default()).unwrap();
+        let start = Instant::now();
+        let cancel = Cancellation::default();
+        let plans = workspace
+            .prepare(
+                PatchRequest {
+                    edits: vec![
+                        Edit::Create {
+                            path: "first".into(),
+                            content: "one".into(),
+                        },
+                        Edit::Create {
+                            path: "parent/second".into(),
+                            content: "two".into(),
+                        },
+                        Edit::Create {
+                            path: "third".into(),
+                            content: "three".into(),
+                        },
+                    ],
+                },
+                start,
+                &cancel,
+            )
+            .unwrap();
+        std::fs::remove_dir(directory.path().join("parent")).unwrap();
+        let result = workspace.commit_plans(plans, start, &cancel).await;
+        assert!(!result.complete);
+        assert_eq!(
+            result.changes.iter().map(|c| c.state).collect::<Vec<_>>(),
+            [State::Applied, State::NotApplied, State::NotApplied]
+        );
+        assert_eq!(result.changes[0].after_digest, Some(digest(b"one")));
+        assert_eq!(result.generation, 1);
+        assert_eq!(result.failure.unwrap().code, Code::NotFound);
+        assert_eq!(
+            std::fs::read(directory.path().join("first")).unwrap(),
+            b"one"
+        );
+        assert!(!directory.path().join("third").exists());
+    }
+    #[tokio::test]
+    async fn a_concurrent_create_is_not_overwritten_and_temporary_files_are_removed() {
+        let directory = tempfile::TempDir::new().unwrap();
+        let mut workspace =
+            Workspace::new(&directory.path().canonicalize().unwrap(), Limits::default()).unwrap();
+        let start = Instant::now();
+        let cancel = Cancellation::default();
+        let plans = workspace
+            .prepare(
+                PatchRequest {
+                    edits: vec![Edit::Create {
+                        path: "file".into(),
+                        content: "agent".into(),
+                    }],
+                },
+                start,
+                &cancel,
+            )
+            .unwrap();
+        std::fs::write(directory.path().join("file"), "human").unwrap();
+        let result = workspace.commit_plans(plans, start, &cancel).await;
+        assert_eq!(result.failure.unwrap().code, Code::Conflict);
+        assert!(result.changes.iter().all(|c| c.state == State::NotApplied));
+        assert_eq!(
+            std::fs::read(directory.path().join("file")).unwrap(),
+            b"human"
+        );
+        assert_eq!(std::fs::read_dir(directory.path()).unwrap().count(), 1);
+    }
+}

--- a/src/nano/workspace/patch.rs
+++ b/src/nano/workspace/patch.rs
@@ -113,8 +113,13 @@ impl Workspace {
             }
 
             let path = path(edit.path())?;
-            // Also reject case aliases on platforms where spelling is not identity.
-            if !names.insert(path.to_lowercase()) {
+            // NT case mapping includes aliases that Rust's Unicode lowercase misses.
+            #[cfg(windows)]
+            let key = fs::search_key(&path);
+            // Retain the conservative case-collision check for planned Unix targets.
+            #[cfg(unix)]
+            let key = path.to_lowercase();
+            if !names.insert(key) {
                 return Err(Failure::new(Code::InvalidPatch, &path));
             }
 

--- a/src/nano/workspace/patch.rs
+++ b/src/nano/workspace/patch.rs
@@ -113,17 +113,12 @@ impl Workspace {
             }
 
             let path = path(edit.path())?;
-            // NT case mapping includes aliases that Rust's Unicode lowercase misses.
-            #[cfg(windows)]
-            let key = fs::search_key(&path);
-            // Retain the conservative case-collision check for planned Unix targets.
-            #[cfg(unix)]
-            let key = path.to_lowercase();
+            let parent = self.root.parent(&path).map_err(|e| Failure::io(&path, e))?;
+            let key = parent.patch_key().map_err(|e| Failure::io(&path, e))?;
             if !names.insert(key) {
                 return Err(Failure::new(Code::InvalidPatch, &path));
             }
 
-            let parent = self.root.parent(&path).map_err(|e| Failure::io(&path, e))?;
             let (before, after) = match edit {
                 Edit::Create { content, .. } => {
                     self.check_base(&parent, &path, None)?;

--- a/src/nano/workspace/tests.rs
+++ b/src/nano/workspace/tests.rs
@@ -219,30 +219,60 @@ async fn search_reports_unsupported_names_but_hides_protected_metadata() {
 
 #[cfg(windows)]
 #[tokio::test]
-async fn patches_reject_nt_case_aliases_before_any_publication() {
-    let (dir, mut workspace) = setup();
-    disk::write(dir.path().join("source"), "old\n").unwrap();
-    for edits in [
-        vec![
-            update("source", "old\n", 1, "old\n", "new\n"),
-            update("\u{17f}ource", "old\n", 1, "old\n", "other\n"),
-        ],
-        vec![
-            Edit::Create {
-                path: "second".into(),
-                content: "first".into(),
-            },
-            Edit::Create {
-                path: "\u{17f}econd".into(),
-                content: "second".into(),
-            },
-        ],
+async fn patches_follow_nt_case_identity_before_any_publication() {
+    for (first, second, required_alias) in [
+        ("source", "SOURCE", true),
+        ("caf\u{e9}", "CAF\u{c9}", true),
+        ("source", "\u{17f}ource", false),
     ] {
-        let result = apply(&mut workspace, edits).await;
-        assert!(!result.complete && result.changes.is_empty(), "{result:?}");
-        assert_eq!(result.failure.unwrap().code, Code::InvalidPatch);
-        assert_eq!(disk::read(dir.path().join("source")).unwrap(), b"old\n");
-        assert!(!dir.path().join("second").exists());
+        // Unicode lowercase/uppercase rules do not determine NT path equivalence.
+        let aliases = fs::search_key(first) == fs::search_key(second);
+        if required_alias {
+            assert!(aliases, "expected case alias: {first} / {second}");
+        }
+        for create in [false, true] {
+            let (dir, mut workspace) = setup();
+            let edits = if create {
+                vec![
+                    Edit::Create {
+                        path: first.into(),
+                        content: "new\n".into(),
+                    },
+                    Edit::Create {
+                        path: second.into(),
+                        content: "other\n".into(),
+                    },
+                ]
+            } else {
+                disk::write(dir.path().join(first), "old\n").unwrap();
+                if !aliases {
+                    disk::write(dir.path().join(second), "old\n").unwrap();
+                }
+                vec![
+                    update(first, "old\n", 1, "old\n", "new\n"),
+                    update(second, "old\n", 1, "old\n", "other\n"),
+                ]
+            };
+            let result = apply(&mut workspace, edits).await;
+            if aliases {
+                assert!(!result.complete && result.changes.is_empty(), "{result:?}");
+                assert_eq!(result.failure.unwrap().code, Code::InvalidPatch);
+                if create {
+                    assert!(!dir.path().join(first).exists());
+                    assert!(!dir.path().join(second).exists());
+                } else {
+                    assert_eq!(disk::read(dir.path().join(first)).unwrap(), b"old\n");
+                    assert_eq!(disk::read(dir.path().join(second)).unwrap(), b"old\n");
+                }
+            } else {
+                // Distinct NT names must remain independently writable, even if
+                // Rust's Unicode uppercase would merge them (for example long-s).
+                assert!(result.complete, "{result:?}");
+                assert_eq!(result.changes.len(), 2);
+                assert_eq!(disk::read(dir.path().join(first)).unwrap(), b"new\n");
+                assert_eq!(disk::read(dir.path().join(second)).unwrap(), b"other\n");
+            }
+        }
     }
 }
 

--- a/src/nano/workspace/tests.rs
+++ b/src/nano/workspace/tests.rs
@@ -1,0 +1,567 @@
+//! Native file-tool behavior, confinement, bounds, and exact patch regressions.
+
+use super::patch::{Edit, Hunk, State};
+use super::*;
+use std::fs as disk;
+use tempfile::TempDir;
+
+fn setup() -> (TempDir, Workspace) {
+    let dir = TempDir::new().unwrap();
+    let workspace = Workspace::new(&dir.path().canonicalize().unwrap(), Limits::default()).unwrap();
+    (dir, workspace)
+}
+fn read(workspace: &Workspace, path: &str) -> ReadResult {
+    workspace
+        .read_file(serde_json::from_value(json!({"path":path})).unwrap())
+        .unwrap()
+}
+fn update(path: &str, before: &str, start_line: usize, old: &str, new: &str) -> Edit {
+    Edit::Update {
+        path: path.into(),
+        expected_digest: digest(before.as_bytes()),
+        hunks: vec![Hunk {
+            start_line,
+            old_text: old.into(),
+            new_text: new.into(),
+        }],
+    }
+}
+async fn apply(workspace: &mut Workspace, edits: Vec<Edit>) -> PatchResult {
+    workspace
+        .apply_patch(PatchRequest { edits }, &Cancellation::default())
+        .await
+}
+use super::patch::PatchResult;
+
+#[test]
+fn range_reads_preserve_bytes_identity_and_explicit_limits() {
+    let (dir, workspace) = setup();
+    let text = "one\r\ncaf\u{e9}\r\nlast";
+    disk::write(dir.path().join("source.txt"), text).unwrap();
+    let result = workspace
+        .read_file(
+            serde_json::from_value(json!({"path":"source.txt","start_line":2,"max_lines":1}))
+                .unwrap(),
+        )
+        .unwrap();
+    assert_eq!(result.text, "caf\u{e9}\r\n");
+    assert!(result.truncated);
+    assert_eq!(result.next_line, Some(3));
+    assert_eq!(result.source.digest, digest(text.as_bytes()));
+    assert_eq!(result.source.kind, "workspace");
+    let short = workspace
+        .read_file(serde_json::from_value(json!({"path":"source.txt","max_bytes":2})).unwrap())
+        .unwrap();
+    assert!(short.text.is_empty() && short.truncated);
+    assert_eq!(short.next_line, Some(1));
+    let past = workspace
+        .read_file(serde_json::from_value(json!({"path":"source.txt","start_line":100})).unwrap())
+        .unwrap();
+    assert!(past.text.is_empty() && !past.truncated);
+    let (_other, other) = setup();
+    assert_ne!(workspace.id, other.id);
+}
+
+#[tokio::test]
+async fn literal_search_is_sorted_bounded_and_reports_skips() {
+    let (dir, mut workspace) = setup();
+    disk::create_dir(dir.path().join("src")).unwrap();
+    disk::write(dir.path().join("src/b.rs"), "needle second\r\nneedle third").unwrap();
+    disk::write(dir.path().join("src/a.rs"), "caf\u{e9} needle first\n").unwrap();
+    disk::write(dir.path().join("binary"), [0, 1, 2]).unwrap();
+    disk::create_dir(dir.path().join(".git")).unwrap();
+    disk::write(dir.path().join(".git/config"), "needle protected").unwrap();
+    let request = || {
+        serde_json::from_value(json!({"paths":["src"],"query":"needle","max_results":2})).unwrap()
+    };
+    let result = workspace
+        .search_text(request(), &Cancellation::default())
+        .await
+        .unwrap();
+    assert_eq!(result.matches.len(), 2);
+    assert_eq!(result.matches[0].source.path, "src/a.rs");
+    assert_eq!(result.matches[0].byte_column, 7);
+    assert_eq!(
+        result.matches[1].source.digest,
+        digest(b"needle second\r\nneedle third")
+    );
+    assert!(result.truncated);
+    workspace.limits.entries = 2;
+    let result = workspace
+        .search_text(request(), &Cancellation::default())
+        .await
+        .unwrap();
+    assert!(result.truncated && result.visited_entries <= 2);
+    workspace.limits = Limits::default();
+    let result = workspace
+        .search_text(
+            serde_json::from_value(json!({"query":"needle"})).unwrap(),
+            &Cancellation::default(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.matches.len(), 3);
+    assert_eq!(result.issues[0].code, Code::Binary);
+    assert!(result.truncated);
+    assert!(
+        result
+            .matches
+            .iter()
+            .all(|m| !m.source.path.starts_with(".git"))
+    );
+}
+
+#[tokio::test]
+async fn search_caps_content_and_serialized_output_even_with_long_escaped_lines() {
+    let (dir, mut workspace) = setup();
+    for i in 0..20 {
+        disk::write(
+            dir.path().join(format!("file{i:02}")),
+            format!("hit {}\n", "\u{1}".repeat(1000)),
+        )
+        .unwrap();
+    }
+    workspace.limits.output_bytes = 4096;
+    let request = || serde_json::from_value(json!({"query":"hit"})).unwrap();
+    let result = workspace
+        .search_text(request(), &Cancellation::default())
+        .await
+        .unwrap();
+    assert!(result.truncated);
+    assert!(encode(&result, 4096).is_ok());
+    workspace.limits.file_bytes = 512;
+    workspace.limits.scan_bytes = 1024;
+    let result = workspace
+        .search_text(request(), &Cancellation::default())
+        .await
+        .unwrap();
+    assert!(result.truncated && result.scanned_bytes <= 1024);
+    assert!(result.matches.is_empty());
+}
+
+#[tokio::test]
+async fn patches_create_update_delete_and_preserve_unrelated_content() {
+    let (dir, mut workspace) = setup();
+    for text in [
+        "alpha\nbeta\nkeep",
+        "alpha\r\nbeta\r\nkeep",
+        "alpha\nbeta\r\nkeep",
+        "",
+    ] {
+        disk::write(dir.path().join("source"), text).unwrap();
+        disk::write(dir.path().join("untouched"), "human edit").unwrap();
+        let old = text.split_inclusive('\n').next().unwrap_or("");
+        let replacement = "caf\u{e9}\n";
+        let result = apply(
+            &mut workspace,
+            vec![
+                update("source", text, 1, old, replacement),
+                Edit::Create {
+                    path: "new".into(),
+                    content: "new file\n".into(),
+                },
+            ],
+        )
+        .await;
+        assert!(result.complete, "{result:?}");
+        assert!(result.changes.iter().all(|c| c.state == State::Applied));
+        let expected = format!("{replacement}{}", &text[old.len()..]);
+        assert_eq!(
+            disk::read_to_string(dir.path().join("source")).unwrap(),
+            expected
+        );
+        assert_eq!(
+            read(&workspace, "source").source.digest,
+            result.changes[0].after_digest.clone().unwrap()
+        );
+        assert_eq!(
+            disk::read_to_string(dir.path().join("untouched")).unwrap(),
+            "human edit"
+        );
+        assert!(
+            apply(
+                &mut workspace,
+                vec![Edit::Delete {
+                    path: "new".into(),
+                    expected_digest: digest(b"new file\n")
+                }]
+            )
+            .await
+            .complete
+        );
+        assert!(!dir.path().join("new").exists());
+    }
+    assert!(disk::read_dir(dir.path()).unwrap().all(|e| {
+        !e.unwrap()
+            .file_name()
+            .to_string_lossy()
+            .starts_with(".nano-tmp-")
+    }));
+}
+
+#[tokio::test]
+async fn stale_bases_and_bad_late_hunks_leave_all_files_unchanged() {
+    let (dir, mut workspace) = setup();
+    disk::write(dir.path().join("a"), "human\n").unwrap();
+    let result = apply(
+        &mut workspace,
+        vec![
+            Edit::Create {
+                path: "new".into(),
+                content: "new".into(),
+            },
+            update("a", "old\n", 1, "old\n", "new\n"),
+        ],
+    )
+    .await;
+    assert!(!result.complete && result.changes.is_empty());
+    let failure = result.failure.unwrap();
+    assert_eq!(failure.code, Code::Conflict);
+    assert_eq!(failure.current_digest, Some(digest(b"human\n")));
+    assert!(failure.message.contains("read_file"));
+    assert!(!dir.path().join("new").exists());
+    for hunks in [
+        vec![Hunk {
+            start_line: 1,
+            old_text: "wrong\n".into(),
+            new_text: "new\n".into(),
+        }],
+        vec![Hunk {
+            start_line: 0,
+            old_text: "human\n".into(),
+            new_text: "new\n".into(),
+        }],
+        vec![
+            Hunk {
+                start_line: 1,
+                old_text: "human\n".into(),
+                new_text: "new\n".into(),
+            },
+            Hunk {
+                start_line: 1,
+                old_text: "".into(),
+                new_text: "dup\n".into(),
+            },
+        ],
+        vec![Hunk {
+            start_line: 1,
+            old_text: "hu".into(),
+            new_text: "cut".into(),
+        }],
+    ] {
+        let result = apply(
+            &mut workspace,
+            vec![
+                Edit::Create {
+                    path: "new".into(),
+                    content: "new".into(),
+                },
+                Edit::Update {
+                    path: "a".into(),
+                    expected_digest: digest(b"human\n"),
+                    hunks,
+                },
+            ],
+        )
+        .await;
+        assert_eq!(result.failure.unwrap().code, Code::InvalidPatch);
+        assert!(!dir.path().join("new").exists());
+        assert_eq!(disk::read(dir.path().join("a")).unwrap(), b"human\n");
+    }
+}
+
+#[test]
+fn protected_and_nonportable_paths_fail_closed() {
+    for value in [
+        "../escape",
+        "/absolute",
+        "C:/drive",
+        "a\\b",
+        "a/../b",
+        "a//b",
+        "a:stream",
+        "a.",
+        "a ",
+        "NUL.txt",
+        "COM1",
+        "a/FERRUS~1.DB",
+        "a\0b",
+    ] {
+        assert_eq!(path(value).unwrap_err().code, Code::InvalidPath, "{value}");
+    }
+    for value in [
+        ".git/config",
+        "a/.GIT/index",
+        ".ferrus/tasks/x",
+        "a/ferrus.db",
+        "repo-graph.db-wal",
+        "project-memory.db-shm",
+        ".nano-tmp-12-1",
+    ] {
+        assert_eq!(
+            path(value).unwrap_err().code,
+            Code::ProtectedPath,
+            "{value}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn binary_oversized_directory_and_duplicate_targets_cannot_be_patched() {
+    let (dir, mut workspace) = setup();
+    disk::write(dir.path().join("binary"), [0, 1]).unwrap();
+    disk::create_dir(dir.path().join("directory")).unwrap();
+    let result = apply(
+        &mut workspace,
+        vec![Edit::Delete {
+            path: "binary".into(),
+            expected_digest: digest(&[0, 1]),
+        }],
+    )
+    .await;
+    assert_eq!(result.failure.unwrap().code, Code::Binary);
+    assert_eq!(
+        workspace.content("directory").unwrap_err().code,
+        Code::UnsafeFile
+    );
+    workspace.limits.file_bytes = 4;
+    disk::write(dir.path().join("large"), "12345").unwrap();
+    assert_eq!(
+        workspace.content("large").unwrap_err().code,
+        Code::FileTooLarge
+    );
+    let result = apply(
+        &mut workspace,
+        vec![Edit::Create {
+            path: "x".into(),
+            content: "12345".into(),
+        }],
+    )
+    .await;
+    assert_eq!(result.failure.unwrap().code, Code::FileTooLarge);
+    let result = apply(
+        &mut workspace,
+        vec![
+            Edit::Create {
+                path: "x".into(),
+                content: "1".into(),
+            },
+            Edit::Create {
+                path: "X".into(),
+                content: "2".into(),
+            },
+        ],
+    )
+    .await;
+    assert_eq!(result.failure.unwrap().code, Code::InvalidPatch);
+    assert!(!dir.path().join("x").exists());
+}
+
+#[tokio::test]
+async fn cancellation_and_schema_validation_precede_effects() {
+    let (dir, mut workspace) = setup();
+    let cancel = Cancellation::default();
+    cancel.cancel();
+    let result = workspace
+        .apply_patch(
+            PatchRequest {
+                edits: vec![Edit::Create {
+                    path: "x".into(),
+                    content: "hello".into(),
+                }],
+            },
+            &cancel,
+        )
+        .await;
+    assert_eq!(result.failure.unwrap().code, Code::Interrupted);
+    assert!(!dir.path().join("x").exists());
+    assert_eq!(workspace.descriptors().len(), 3);
+    assert!(workspace.validate("apply_patch", &json!({"edits":[{"operation":"create","path":"x","content":"hello","unexpected":true}]})).is_err());
+    assert!(
+        workspace
+            .validate("read_file", &json!({"path":"x","start_line":-1}))
+            .is_err()
+    );
+    assert_eq!(
+        workspace.validate("exec", &json!({})),
+        Err(ToolError::UnknownTool)
+    );
+    let call = ValidatedCall {
+        call_id: "c1".into(),
+        provider_call_id: "p1".into(),
+        name: "apply_patch".into(),
+        arguments: json!({"edits":[{"operation":"create","path":".git/index","content":"bad"}]}),
+    };
+    assert!(matches!(
+        workspace.execute(&call, &Cancellation::default()).await,
+        ToolOutcome::Failed(ToolError::Workspace(_))
+    ));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn symlinks_hardlinks_and_modes_are_handled_without_escapes() {
+    use std::os::unix::fs::{PermissionsExt, symlink};
+    let (dir, mut workspace) = setup();
+    let outside = TempDir::new().unwrap();
+    disk::write(outside.path().join("secret"), "secret\n").unwrap();
+    symlink(outside.path(), dir.path().join("link")).unwrap();
+    symlink(outside.path().join("secret"), dir.path().join("file-link")).unwrap();
+    disk::hard_link(outside.path().join("secret"), dir.path().join("hard")).unwrap();
+    for value in ["link/secret", "file-link", "hard"] {
+        assert_eq!(workspace.content(value).unwrap_err().code, Code::UnsafeFile);
+        let result = apply(
+            &mut workspace,
+            vec![update(value, "secret\n", 1, "secret\n", "bad\n")],
+        )
+        .await;
+        assert_eq!(result.failure.unwrap().code, Code::UnsafeFile);
+    }
+    assert_eq!(
+        disk::read_to_string(outside.path().join("secret")).unwrap(),
+        "secret\n"
+    );
+    disk::write(dir.path().join("run"), "old\n").unwrap();
+    disk::set_permissions(dir.path().join("run"), disk::Permissions::from_mode(0o751)).unwrap();
+    assert!(
+        apply(
+            &mut workspace,
+            vec![update("run", "old\n", 1, "old\n", "new\n")]
+        )
+        .await
+        .complete
+    );
+    assert_eq!(
+        disk::metadata(dir.path().join("run"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777,
+        0o751
+    );
+    disk::create_dir(dir.path().join("parent")).unwrap();
+    let held = workspace.root.parent("parent/new").unwrap();
+    disk::rename(dir.path().join("parent"), dir.path().join("moved")).unwrap();
+    symlink(outside.path(), dir.path().join("parent")).unwrap();
+    let staged = held.stage(b"safe", None).unwrap();
+    held.publish(staged, true)
+        .unwrap_or_else(|_| panic!("confined publication failed"));
+    assert!(!outside.path().join("new").exists());
+    assert_eq!(disk::read(dir.path().join("moved/new")).unwrap(), b"safe");
+}
+
+#[tokio::test]
+async fn ordered_hunks_insert_and_delete_against_original_line_numbers() {
+    let (dir, mut workspace) = setup();
+    let before = "one\r\ntwo\nthree\r\nlast";
+    disk::write(dir.path().join("source"), before).unwrap();
+    let result = apply(
+        &mut workspace,
+        vec![Edit::Update {
+            path: "source".into(),
+            expected_digest: digest(before.as_bytes()),
+            hunks: vec![
+                Hunk {
+                    start_line: 2,
+                    old_text: String::new(),
+                    new_text: "insert\n".into(),
+                },
+                Hunk {
+                    start_line: 3,
+                    old_text: "three\r\n".into(),
+                    new_text: String::new(),
+                },
+                Hunk {
+                    start_line: 4,
+                    old_text: "last".into(),
+                    new_text: "end".into(),
+                },
+            ],
+        }],
+    )
+    .await;
+    assert!(result.complete, "{result:?}");
+    assert_eq!(
+        disk::read(dir.path().join("source")).unwrap(),
+        b"one\r\ninsert\ntwo\nend"
+    );
+    assert_eq!(
+        path(".g\u{131}t/config").unwrap_err().code,
+        Code::ProtectedPath
+    );
+    assert_eq!(
+        path("ferru\u{17f}.db").unwrap_err().code,
+        Code::ProtectedPath
+    );
+    assert!(
+        workspace
+            .validate("read_file", &json!({"path":"source","start_line":0}))
+            .is_err()
+    );
+}
+
+#[tokio::test]
+async fn partial_tool_outcomes_retain_reconciliation_details() {
+    use std::{future::Future, task::Poll};
+    let (dir, mut workspace) = setup();
+    disk::create_dir(dir.path().join("parent")).unwrap();
+    let call = ValidatedCall {
+        call_id: "c1".into(),
+        provider_call_id: "p1".into(),
+        name: "apply_patch".into(),
+        arguments: json!({"edits":[
+            {"operation":"create","path":"first","content":"one"},
+            {"operation":"create","path":"parent/second","content":"two"}
+        ]}),
+    };
+    let cancel = Cancellation::default();
+    let mut operation = std::pin::pin!(workspace.execute(&call, &cancel));
+    // The first publication yields before attempting the second one.
+    std::future::poll_fn(|cx| {
+        assert!(operation.as_mut().poll(cx).is_pending());
+        Poll::Ready(())
+    })
+    .await;
+    disk::remove_dir(dir.path().join("parent")).unwrap();
+    let outcome = operation.await;
+    assert!(encode(&outcome, 24 * 1024).is_ok());
+    let ToolOutcome::Unknown(ToolError::Workspace(result)) = outcome else {
+        panic!("missing partial outcome")
+    };
+    assert_eq!(result["changes"][0]["state"], "applied");
+    assert_eq!(result["changes"][0]["after_digest"], digest(b"one"));
+    assert_eq!(result["changes"][1]["state"], "not_applied");
+    assert_eq!(result["failure"]["code"], "not_found");
+}
+
+#[tokio::test]
+async fn edit_reports_are_bounded_before_writing_and_search_snippets_include_the_match() {
+    let (dir, mut workspace) = setup();
+    workspace.limits.output_bytes = 4096;
+    let edits = (0..16)
+        .map(|i| Edit::Create {
+            path: format!("{i}{}", "a".repeat(240)),
+            content: "small".into(),
+        })
+        .collect();
+    let result = apply(&mut workspace, edits).await;
+    assert_eq!(result.failure.unwrap().code, Code::OutputLimit);
+    assert_eq!(disk::read_dir(dir.path()).unwrap().count(), 0);
+    disk::write(
+        dir.path().join("source"),
+        format!("{}needle\n", "x".repeat(1000)),
+    )
+    .unwrap();
+    let result = workspace
+        .search_text(
+            serde_json::from_value(json!({"query":"needle"})).unwrap(),
+            &Cancellation::default(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.matches.len(), 1);
+    assert!(result.matches[0].text.contains("needle"));
+    assert!(result.matches[0].snippet_start_column > 1);
+    assert_eq!(result.scanned_bytes, 1007);
+    assert!(encode(&result, 4096).is_ok());
+}

--- a/src/nano/workspace/tests.rs
+++ b/src/nano/workspace/tests.rs
@@ -67,6 +67,56 @@ fn range_reads_preserve_bytes_identity_and_explicit_limits() {
 }
 
 #[tokio::test]
+async fn overlapping_search_paths_do_not_repeat_results_or_charge_budgets() {
+    let (dir, mut workspace) = setup();
+    disk::create_dir(dir.path().join("src")).unwrap();
+    let content = "needle once\n";
+    disk::write(dir.path().join("src/File.rs"), content).unwrap();
+    workspace.limits.entries = 3; // root, directory, file
+
+    #[cfg(windows)]
+    let paths = [".", "SRC", "src", "SRC/FILE.RS", "src/File.rs"];
+    #[cfg(unix)]
+    let paths = [".", "src", "src/File.rs"];
+    let result = workspace
+        .search_text(
+            serde_json::from_value(json!({"paths":paths,"query":"needle"})).unwrap(),
+            &Cancellation::default(),
+        )
+        .await
+        .unwrap();
+    assert!(!result.truncated);
+    assert!(result.issues.is_empty());
+    assert_eq!(result.matches.len(), 1);
+    assert_eq!(result.scanned_bytes, content.len());
+    assert_eq!(result.visited_entries, 3);
+    assert_eq!(result.listed_entries, 2);
+    assert_eq!(result.matches[0].source.digest, digest(content.as_bytes()));
+    #[cfg(windows)]
+    assert_eq!(result.matches[0].source.path, "SRC/FILE.RS");
+    #[cfg(unix)]
+    assert_eq!(result.matches[0].source.path, "src/File.rs");
+
+    #[cfg(windows)]
+    let paths = ["src/File.rs", "SRC/FILE.RS"];
+    #[cfg(unix)]
+    let paths = ["src/File.rs", "src/File.rs"];
+    let result = workspace
+        .search_text(
+            serde_json::from_value(json!({"paths":paths,"query":"needle"})).unwrap(),
+            &Cancellation::default(),
+        )
+        .await
+        .unwrap();
+    assert!(!result.truncated);
+    assert_eq!(result.matches.len(), 1);
+    assert_eq!(result.matches[0].source.path, "src/File.rs");
+    assert_eq!(result.scanned_bytes, content.len());
+    assert_eq!(result.visited_entries, 1);
+    assert_eq!(result.listed_entries, 0);
+}
+
+#[tokio::test]
 async fn literal_search_is_sorted_bounded_and_reports_skips() {
     let (dir, mut workspace) = setup();
     disk::create_dir(dir.path().join("src")).unwrap();

--- a/src/nano/workspace/tests.rs
+++ b/src/nano/workspace/tests.rs
@@ -276,6 +276,71 @@ async fn patches_follow_nt_case_identity_before_any_publication() {
     }
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn unix_patch_preflight_rejects_canonically_equivalent_new_targets() {
+    for (first, second) in [
+        ("caf\u{e9}", "cafe\u{301}"),
+        ("CAF\u{c9}", "cafe\u{301}"),
+        ("a\u{301}\u{327}", "a\u{327}\u{301}"),
+    ] {
+        let (dir, mut workspace) = setup();
+        let result = apply(
+            &mut workspace,
+            ["unrelated", first, second]
+                .into_iter()
+                .map(|path| Edit::Create {
+                    path: path.into(),
+                    content: "new\n".into(),
+                })
+                .collect(),
+        )
+        .await;
+        assert!(!result.complete && result.changes.is_empty(), "{result:?}");
+        assert_eq!(result.failure.unwrap().code, Code::InvalidPatch);
+        assert_eq!(disk::read_dir(dir.path()).unwrap().count(), 0);
+    }
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn unix_patch_target_keys_use_the_opened_parent_identity() {
+    let (dir, mut workspace) = setup();
+    let first = "caf\u{e9}";
+    let second = "cafe\u{301}";
+    disk::create_dir(dir.path().join(first)).unwrap();
+    let aliases = dir.path().join(second).exists();
+    if !aliases {
+        disk::create_dir(dir.path().join(second)).unwrap();
+    }
+    let result = apply(
+        &mut workspace,
+        [first, second]
+            .into_iter()
+            .map(|parent| Edit::Create {
+                path: format!("{parent}/new"),
+                content: parent.into(),
+            })
+            .collect(),
+    )
+    .await;
+    if aliases {
+        assert!(!result.complete && result.changes.is_empty(), "{result:?}");
+        assert_eq!(result.failure.unwrap().code, Code::InvalidPatch);
+        assert!(!dir.path().join(first).join("new").exists());
+    } else {
+        assert!(result.complete, "{result:?}");
+        assert_eq!(
+            disk::read_to_string(dir.path().join(first).join("new")).unwrap(),
+            first
+        );
+        assert_eq!(
+            disk::read_to_string(dir.path().join(second).join("new")).unwrap(),
+            second
+        );
+    }
+}
+
 #[tokio::test]
 async fn literal_search_is_sorted_bounded_and_reports_skips() {
     let (dir, mut workspace) = setup();

--- a/src/nano/workspace/tests.rs
+++ b/src/nano/workspace/tests.rs
@@ -117,6 +117,136 @@ async fn overlapping_search_paths_do_not_repeat_results_or_charge_budgets() {
 }
 
 #[tokio::test]
+async fn search_deduplicates_aliases_on_the_actual_filesystem() {
+    let (dir, mut workspace) = setup();
+    disk::create_dir(dir.path().join("src")).unwrap();
+    disk::write(dir.path().join("src/file"), "needle\n").unwrap();
+    if !dir.path().join("SRC/file").exists() {
+        // A case-sensitive volume has two independent directories.
+        disk::create_dir(dir.path().join("SRC")).unwrap();
+        disk::write(dir.path().join("SRC/file"), "needle\n").unwrap();
+        let result = workspace
+            .search_text(
+                serde_json::from_value(json!({"paths":["src","SRC"],"query":"needle"})).unwrap(),
+                &Cancellation::default(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.matches.len(), 2);
+        assert_eq!(result.scanned_bytes, 14);
+        assert_eq!(result.visited_entries, 4);
+        assert_eq!(result.listed_entries, 2);
+        assert!(!result.truncated);
+        return;
+    }
+
+    workspace.limits.entries = 3;
+    let result = workspace
+        .search_text(
+            serde_json::from_value(json!({"paths":[".","SRC","src/file"],"query":"needle"}))
+                .unwrap(),
+            &Cancellation::default(),
+        )
+        .await
+        .unwrap();
+    assert!(!result.truncated, "{result:?}");
+    assert_eq!(result.matches.len(), 1);
+    assert_eq!(result.visited_entries, 3);
+    assert_eq!(result.listed_entries, 2);
+    assert_eq!(result.scanned_bytes, 7);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn search_reports_unsupported_names_but_hides_protected_metadata() {
+    let (dir, mut workspace) = setup();
+    for name in [
+        "notes~old",
+        "a:backup",
+        "other?",
+        "extra*",
+        "last|",
+        "more<",
+    ] {
+        disk::write(dir.path().join(name), "needle\n").unwrap();
+    }
+    disk::create_dir(dir.path().join(".git")).unwrap();
+    disk::write(dir.path().join(".git/config"), "needle\n").unwrap();
+    disk::write(dir.path().join("ferrus.db"), "needle\n").unwrap();
+    disk::write(dir.path().join("valid"), "needle\n").unwrap();
+    workspace.limits.output_bytes = 2048;
+    let result = workspace
+        .search_text(
+            serde_json::from_value(json!({"query":"needle"})).unwrap(),
+            &Cancellation::default(),
+        )
+        .await
+        .unwrap();
+    assert!(result.truncated);
+    assert_eq!(result.matches.len(), 1);
+    assert_eq!(result.matches[0].source.path, "valid");
+    assert_eq!(result.issues.len(), 4);
+    assert_eq!(result.suppressed_issues, 2);
+    assert!(
+        result
+            .issues
+            .iter()
+            .all(|issue| issue.code == Code::InvalidPath)
+    );
+    assert!(serde_json::to_vec(&result).unwrap().len() <= workspace.limits.output_bytes);
+
+    for name in [
+        "notes~old",
+        "a:backup",
+        "other?",
+        "extra*",
+        "last|",
+        "more<",
+    ] {
+        disk::remove_file(dir.path().join(name)).unwrap();
+    }
+    let result = workspace
+        .search_text(
+            serde_json::from_value(json!({"query":"needle"})).unwrap(),
+            &Cancellation::default(),
+        )
+        .await
+        .unwrap();
+    assert!(!result.truncated);
+    assert!(result.issues.is_empty());
+    assert_eq!(result.matches.len(), 1);
+}
+
+#[cfg(windows)]
+#[tokio::test]
+async fn patches_reject_nt_case_aliases_before_any_publication() {
+    let (dir, mut workspace) = setup();
+    disk::write(dir.path().join("source"), "old\n").unwrap();
+    for edits in [
+        vec![
+            update("source", "old\n", 1, "old\n", "new\n"),
+            update("\u{17f}ource", "old\n", 1, "old\n", "other\n"),
+        ],
+        vec![
+            Edit::Create {
+                path: "second".into(),
+                content: "first".into(),
+            },
+            Edit::Create {
+                path: "\u{17f}econd".into(),
+                content: "second".into(),
+            },
+        ],
+    ] {
+        let result = apply(&mut workspace, edits).await;
+        assert!(!result.complete && result.changes.is_empty(), "{result:?}");
+        assert_eq!(result.failure.unwrap().code, Code::InvalidPatch);
+        assert_eq!(disk::read(dir.path().join("source")).unwrap(), b"old\n");
+        assert!(!dir.path().join("second").exists());
+    }
+}
+
+#[tokio::test]
 async fn literal_search_is_sorted_bounded_and_reports_skips() {
     let (dir, mut workspace) = setup();
     disk::create_dir(dir.path().join("src")).unwrap();

--- a/src/nano/workspace/tests.rs
+++ b/src/nano/workspace/tests.rs
@@ -10,11 +10,13 @@ fn setup() -> (TempDir, Workspace) {
     let workspace = Workspace::new(&dir.path().canonicalize().unwrap(), Limits::default()).unwrap();
     (dir, workspace)
 }
+
 fn read(workspace: &Workspace, path: &str) -> ReadResult {
     workspace
         .read_file(serde_json::from_value(json!({"path":path})).unwrap())
         .unwrap()
 }
+
 fn update(path: &str, before: &str, start_line: usize, old: &str, new: &str) -> Edit {
     Edit::Update {
         path: path.into(),
@@ -26,11 +28,13 @@ fn update(path: &str, before: &str, start_line: usize, old: &str, new: &str) -> 
         }],
     }
 }
+
 async fn apply(workspace: &mut Workspace, edits: Vec<Edit>) -> PatchResult {
     workspace
         .apply_patch(PatchRequest { edits }, &Cancellation::default())
         .await
 }
+
 use super::patch::PatchResult;
 
 #[test]

--- a/src/nano/workspace/unix.rs
+++ b/src/nano/workspace/unix.rs
@@ -1,0 +1,181 @@
+//! Unix no-follow openat traversal and per-file publication.
+
+use super::*;
+use std::{
+    ffi::{CStr, CString},
+    os::{
+        fd::{AsRawFd, FromRawFd, IntoRawFd},
+        unix::{ffi::OsStrExt, fs::MetadataExt},
+    },
+};
+
+fn name(value: &str) -> io::Result<CString> {
+    CString::new(value).map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "NUL"))
+}
+pub(super) fn root(path: &Path) -> io::Result<File> {
+    let root = CString::new("/").unwrap();
+    // SAFETY: root is NUL-terminated; returned descriptor is owned below.
+    let fd = unsafe {
+        libc::open(
+            root.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC,
+        )
+    };
+    if fd < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: successful open returned an owned descriptor.
+    let mut directory = unsafe { File::from_raw_fd(fd) };
+    for component in path.components() {
+        if let std::path::Component::Normal(part) = component {
+            let part = CString::new(part.as_bytes()).map_err(|_| unsafe_file())?;
+            directory = open(&directory, &part, true, false)?;
+        } else if component != std::path::Component::RootDir {
+            return Err(unsafe_file());
+        }
+    }
+    Ok(directory)
+}
+fn open(parent: &File, name: &CStr, directory: bool, create: bool) -> io::Result<File> {
+    let flags = libc::O_NOFOLLOW
+        | libc::O_CLOEXEC
+        | libc::O_NONBLOCK
+        | if create {
+            libc::O_WRONLY | libc::O_CREAT | libc::O_EXCL
+        } else {
+            libc::O_RDONLY
+        }
+        | if directory { libc::O_DIRECTORY } else { 0 };
+    // SAFETY: parent and component remain live; O_EXCL never replaces an existing entry.
+    let fd = unsafe { libc::openat(parent.as_raw_fd(), name.as_ptr(), flags, 0o600) };
+    if fd < 0 {
+        let error = io::Error::last_os_error();
+        return Err(
+            if matches!(error.raw_os_error(), Some(libc::ELOOP | libc::ENOTDIR)) {
+                unsafe_file()
+            } else {
+                error
+            },
+        );
+    }
+    // SAFETY: successful openat returned an owned descriptor.
+    let file = unsafe { File::from_raw_fd(fd) };
+    let metadata = file.metadata()?;
+    if !metadata.is_dir() {
+        regular(&file)?;
+    }
+    Ok(file)
+}
+pub(super) fn child(parent: &File, value: &str, directory: bool, create: bool) -> io::Result<File> {
+    open(parent, &name(value)?, directory, create)
+}
+pub(super) fn regular(file: &File) -> io::Result<()> {
+    let metadata = file.metadata()?;
+    if !metadata.is_file() || metadata.nlink() != 1 {
+        return Err(unsafe_file());
+    }
+    Ok(())
+}
+pub(super) fn publish(
+    parent: &File,
+    target: &str,
+    temporary: &str,
+    _: &File,
+    create: bool,
+) -> io::Result<()> {
+    let target = name(target)?;
+    let temporary = name(temporary)?;
+    // SAFETY: both names are single components relative to a held directory.
+    let status = unsafe {
+        if create {
+            libc::linkat(
+                parent.as_raw_fd(),
+                temporary.as_ptr(),
+                parent.as_raw_fd(),
+                target.as_ptr(),
+                0,
+            )
+        } else {
+            libc::renameat(
+                parent.as_raw_fd(),
+                temporary.as_ptr(),
+                parent.as_raw_fd(),
+                target.as_ptr(),
+            )
+        }
+    };
+    if status != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+pub(super) fn finish_publish(parent: &File, temporary: &str, create: bool) -> io::Result<()> {
+    if create {
+        delete(parent, temporary)?;
+    }
+    Ok(())
+}
+
+pub(super) fn delete(parent: &File, value: &str) -> io::Result<()> {
+    let name = name(value)?;
+    // SAFETY: unlinkat removes the directory entry itself and never follows a symlink.
+    if unsafe { libc::unlinkat(parent.as_raw_fd(), name.as_ptr(), 0) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+pub(super) fn sync(directory: &File) -> io::Result<()> {
+    directory.sync_all()
+}
+pub(super) fn children(directory: &File, limit: usize) -> io::Result<(Vec<String>, bool)> {
+    struct Stream(*mut libc::DIR);
+    impl Drop for Stream {
+        fn drop(&mut self) {
+            // SAFETY: Stream owns the fdopendir result.
+            unsafe {
+                libc::closedir(self.0);
+            }
+        }
+    }
+    let fd = child(directory, ".", true, false)?.into_raw_fd();
+    // SAFETY: fd ownership transfers only on success.
+    let stream = unsafe { libc::fdopendir(fd) };
+    if stream.is_null() {
+        let error = io::Error::last_os_error();
+        // SAFETY: fdopendir did not consume fd on failure.
+        drop(unsafe { File::from_raw_fd(fd) });
+        return Err(error);
+    }
+    let stream = Stream(stream);
+    let mut names = Vec::new();
+    let mut unsupported_name = false;
+    loop {
+        errno::set_errno(errno::Errno(0));
+        // SAFETY: stream remains live and is accessed synchronously.
+        let entry = unsafe { libc::readdir(stream.0) };
+        if entry.is_null() {
+            let error = errno::errno().0;
+            return if error == 0 {
+                Ok((names, unsupported_name))
+            } else {
+                Err(io::Error::from_raw_os_error(error))
+            };
+        }
+        // SAFETY: readdir returned a dirent containing a NUL-terminated name.
+        let value = unsafe { CStr::from_ptr((*entry).d_name.as_ptr()) };
+        if matches!(value.to_bytes(), b"." | b"..") {
+            continue;
+        }
+        if names.len() == limit {
+            return Ok((names, true));
+        }
+        // Non-UTF-8 names are explicitly counted but cannot become model paths.
+        names.push(match value.to_str() {
+            Ok(name) => name.to_owned(),
+            Err(_) => {
+                unsupported_name = true;
+                "\0".into()
+            }
+        });
+    }
+}

--- a/src/nano/workspace/unix.rs
+++ b/src/nano/workspace/unix.rs
@@ -13,6 +13,11 @@ fn name(value: &str) -> io::Result<CString> {
     CString::new(value).map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "NUL"))
 }
 
+pub(super) fn identity(file: &File) -> io::Result<(u64, u128)> {
+    let metadata = file.metadata()?;
+    Ok((metadata.dev(), u128::from(metadata.ino())))
+}
+
 pub(super) fn root(path: &Path) -> io::Result<File> {
     let root = CString::new("/").unwrap();
     // SAFETY: root is NUL-terminated; returned descriptor is owned below.

--- a/src/nano/workspace/unix.rs
+++ b/src/nano/workspace/unix.rs
@@ -18,6 +18,14 @@ pub(super) fn identity(file: &File) -> io::Result<(u64, u128)> {
     Ok((metadata.dev(), u128::from(metadata.ino())))
 }
 
+pub(super) fn patch_name_key(name: &str) -> String {
+    use unicode_normalization::UnicodeNormalization;
+
+    // Absent targets have no inode. Conservatively reject canonical/case aliases
+    // within a batch, including on volumes that permit both spellings.
+    name.nfd().flat_map(char::to_lowercase).nfd().collect()
+}
+
 pub(super) fn root(path: &Path) -> io::Result<File> {
     let root = CString::new("/").unwrap();
     // SAFETY: root is NUL-terminated; returned descriptor is owned below.

--- a/src/nano/workspace/unix.rs
+++ b/src/nano/workspace/unix.rs
@@ -12,6 +12,7 @@ use std::{
 fn name(value: &str) -> io::Result<CString> {
     CString::new(value).map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "NUL"))
 }
+
 pub(super) fn root(path: &Path) -> io::Result<File> {
     let root = CString::new("/").unwrap();
     // SAFETY: root is NUL-terminated; returned descriptor is owned below.
@@ -21,9 +22,11 @@ pub(super) fn root(path: &Path) -> io::Result<File> {
             libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC,
         )
     };
+
     if fd < 0 {
         return Err(io::Error::last_os_error());
     }
+
     // SAFETY: successful open returned an owned descriptor.
     let mut directory = unsafe { File::from_raw_fd(fd) };
     for component in path.components() {
@@ -34,8 +37,10 @@ pub(super) fn root(path: &Path) -> io::Result<File> {
             return Err(unsafe_file());
         }
     }
+
     Ok(directory)
 }
+
 fn open(parent: &File, name: &CStr, directory: bool, create: bool) -> io::Result<File> {
     let flags = libc::O_NOFOLLOW
         | libc::O_CLOEXEC
@@ -46,6 +51,7 @@ fn open(parent: &File, name: &CStr, directory: bool, create: bool) -> io::Result
             libc::O_RDONLY
         }
         | if directory { libc::O_DIRECTORY } else { 0 };
+
     // SAFETY: parent and component remain live; O_EXCL never replaces an existing entry.
     let fd = unsafe { libc::openat(parent.as_raw_fd(), name.as_ptr(), flags, 0o600) };
     if fd < 0 {
@@ -58,17 +64,21 @@ fn open(parent: &File, name: &CStr, directory: bool, create: bool) -> io::Result
             },
         );
     }
+
     // SAFETY: successful openat returned an owned descriptor.
     let file = unsafe { File::from_raw_fd(fd) };
     let metadata = file.metadata()?;
     if !metadata.is_dir() {
         regular(&file)?;
     }
+
     Ok(file)
 }
+
 pub(super) fn child(parent: &File, value: &str, directory: bool, create: bool) -> io::Result<File> {
     open(parent, &name(value)?, directory, create)
 }
+
 pub(super) fn regular(file: &File) -> io::Result<()> {
     let metadata = file.metadata()?;
     if !metadata.is_file() || metadata.nlink() != 1 {
@@ -76,6 +86,7 @@ pub(super) fn regular(file: &File) -> io::Result<()> {
     }
     Ok(())
 }
+
 pub(super) fn publish(
     parent: &File,
     target: &str,
@@ -104,15 +115,19 @@ pub(super) fn publish(
             )
         }
     };
+
     if status != 0 {
         return Err(io::Error::last_os_error());
     }
+
     Ok(())
 }
+
 pub(super) fn finish_publish(parent: &File, temporary: &str, create: bool) -> io::Result<()> {
     if create {
         delete(parent, temporary)?;
     }
+
     Ok(())
 }
 
@@ -124,11 +139,14 @@ pub(super) fn delete(parent: &File, value: &str) -> io::Result<()> {
     }
     Ok(())
 }
+
 pub(super) fn sync(directory: &File) -> io::Result<()> {
     directory.sync_all()
 }
+
 pub(super) fn children(directory: &File, limit: usize) -> io::Result<(Vec<String>, bool)> {
     struct Stream(*mut libc::DIR);
+
     impl Drop for Stream {
         fn drop(&mut self) {
             // SAFETY: Stream owns the fdopendir result.
@@ -137,6 +155,7 @@ pub(super) fn children(directory: &File, limit: usize) -> io::Result<(Vec<String
             }
         }
     }
+
     let fd = child(directory, ".", true, false)?.into_raw_fd();
     // SAFETY: fd ownership transfers only on success.
     let stream = unsafe { libc::fdopendir(fd) };
@@ -146,6 +165,7 @@ pub(super) fn children(directory: &File, limit: usize) -> io::Result<(Vec<String
         drop(unsafe { File::from_raw_fd(fd) });
         return Err(error);
     }
+
     let stream = Stream(stream);
     let mut names = Vec::new();
     let mut unsupported_name = false;
@@ -161,14 +181,17 @@ pub(super) fn children(directory: &File, limit: usize) -> io::Result<(Vec<String
                 Err(io::Error::from_raw_os_error(error))
             };
         }
+
         // SAFETY: readdir returned a dirent containing a NUL-terminated name.
         let value = unsafe { CStr::from_ptr((*entry).d_name.as_ptr()) };
         if matches!(value.to_bytes(), b"." | b"..") {
             continue;
         }
+
         if names.len() == limit {
             return Ok((names, true));
         }
+
         // Non-UTF-8 names are explicitly counted but cannot become model paths.
         names.push(match value.to_str() {
             Ok(name) => name.to_owned(),

--- a/src/nano/workspace/windows.rs
+++ b/src/nano/workspace/windows.rs
@@ -41,6 +41,26 @@ pub(super) fn search_key(path: &str) -> Vec<u16> {
         .collect()
 }
 
+pub(super) fn identity(file: &File) -> io::Result<(u64, u128)> {
+    let mut info = FILE_ID_INFO::default();
+    // SAFETY: the opened handle and output structure remain live for this call.
+    if unsafe {
+        GetFileInformationByHandleEx(
+            file.as_raw_handle(),
+            FileIdInfo,
+            (&mut info as *mut FILE_ID_INFO).cast(),
+            size_of::<FILE_ID_INFO>() as u32,
+        )
+    } == 0
+    {
+        return Err(io::Error::last_os_error());
+    }
+    Ok((
+        info.VolumeSerialNumber,
+        u128::from_le_bytes(info.FileId.Identifier),
+    ))
+}
+
 pub(super) fn root(path: &Path) -> io::Result<File> {
     let file = OpenOptions::new()
         .read(true)

--- a/src/nano/workspace/windows.rs
+++ b/src/nano/workspace/windows.rs
@@ -1,0 +1,357 @@
+//! Windows handle-relative opens reject every reparse point before use.
+
+use super::*;
+use std::{
+    fs::OpenOptions,
+    mem::{offset_of, size_of},
+    os::windows::{
+        fs::{MetadataExt, OpenOptionsExt},
+        io::{AsRawHandle, FromRawHandle},
+    },
+};
+use windows_sys::{
+    Wdk::{
+        Foundation::OBJECT_ATTRIBUTES,
+        Storage::FileSystem::{
+            FILE_CREATE, FILE_DIRECTORY_FILE, FILE_NON_DIRECTORY_FILE, FILE_OPEN,
+            FILE_OPEN_FOR_BACKUP_INTENT, FILE_OPEN_REPARSE_POINT, FILE_SYNCHRONOUS_IO_NONALERT,
+            NtCreateFile,
+        },
+    },
+    Win32::{
+        Foundation::{
+            ERROR_NO_MORE_FILES, HANDLE, OBJ_CASE_INSENSITIVE, OBJ_DONT_REPARSE,
+            RtlNtStatusToDosError, STATUS_NOT_A_DIRECTORY, STATUS_REPARSE_POINT_ENCOUNTERED,
+            UNICODE_STRING,
+        },
+        Storage::FileSystem::*,
+        System::IO::IO_STATUS_BLOCK,
+    },
+};
+
+pub(super) fn root(path: &Path) -> io::Result<File> {
+    let file = OpenOptions::new()
+        .read(true)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(path)?;
+    let meta = file.metadata()?;
+    if !meta.is_dir() || meta.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+        return Err(unsafe_file());
+    }
+    Ok(file)
+}
+pub(super) fn child(parent: &File, value: &str, directory: bool, create: bool) -> io::Result<File> {
+    if directory && value == "." {
+        return parent.try_clone();
+    }
+    open(parent, value, directory, create, create)
+}
+fn open(
+    parent: &File,
+    value: &str,
+    directory: bool,
+    create: bool,
+    delete: bool,
+) -> io::Result<File> {
+    let mut name: Vec<u16> = value.encode_utf16().collect();
+    let length = u16::try_from(name.len() * 2).map_err(|_| unsafe_file())?;
+    let name = UNICODE_STRING {
+        Length: length,
+        MaximumLength: length,
+        Buffer: name.as_mut_ptr(),
+    };
+    let attributes = OBJECT_ATTRIBUTES {
+        Length: size_of::<OBJECT_ATTRIBUTES>() as u32,
+        RootDirectory: parent.as_raw_handle() as HANDLE,
+        ObjectName: &name,
+        Attributes: OBJ_CASE_INSENSITIVE | OBJ_DONT_REPARSE,
+        SecurityDescriptor: std::ptr::null(),
+        SecurityQualityOfService: std::ptr::null(),
+    };
+    let mut handle = std::ptr::null_mut();
+    let mut status_block = IO_STATUS_BLOCK::default();
+    // SAFETY: the held parent, name buffer and structs remain live for this synchronous call.
+    let status = unsafe {
+        NtCreateFile(
+            &mut handle,
+            FILE_GENERIC_READ
+                | if create {
+                    FILE_GENERIC_WRITE | WRITE_DAC | WRITE_OWNER
+                } else {
+                    0
+                }
+                | if delete { DELETE } else { 0 },
+            &attributes,
+            &mut status_block,
+            std::ptr::null(),
+            FILE_ATTRIBUTE_NORMAL,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            if create { FILE_CREATE } else { FILE_OPEN },
+            FILE_OPEN_REPARSE_POINT
+                | FILE_SYNCHRONOUS_IO_NONALERT
+                | FILE_OPEN_FOR_BACKUP_INTENT
+                | if directory {
+                    FILE_DIRECTORY_FILE
+                } else if create || delete {
+                    FILE_NON_DIRECTORY_FILE
+                } else {
+                    0
+                },
+            std::ptr::null(),
+            0,
+        )
+    };
+    if status < 0 {
+        if matches!(
+            status,
+            STATUS_NOT_A_DIRECTORY | STATUS_REPARSE_POINT_ENCOUNTERED
+        ) {
+            return Err(unsafe_file());
+        }
+        // SAFETY: status conversion has no side effects.
+        return Err(io::Error::from_raw_os_error(
+            unsafe { RtlNtStatusToDosError(status) } as i32,
+        ));
+    }
+    if handle.is_null() {
+        return Err(io::Error::other("empty handle"));
+    }
+    // SAFETY: NtCreateFile returned a new owned handle.
+    let file = unsafe { File::from_raw_handle(handle) };
+    let meta = file.metadata()?;
+    if meta.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+        return Err(unsafe_file());
+    }
+    if !meta.is_dir() {
+        regular(&file)?;
+    }
+    Ok(file)
+}
+pub(super) fn regular(file: &File) -> io::Result<()> {
+    let mut info = BY_HANDLE_FILE_INFORMATION::default();
+    // SAFETY: the file and output structure remain live.
+    if unsafe { GetFileInformationByHandle(file.as_raw_handle(), &mut info) } == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if !file.metadata()?.is_file()
+        || info.nNumberOfLinks != 1
+        || info.dwFileAttributes & (FILE_ATTRIBUTE_REPARSE_POINT | FILE_ATTRIBUTE_DEVICE) != 0
+    {
+        return Err(unsafe_file());
+    }
+    Ok(())
+}
+pub(super) fn publish(
+    parent: &File,
+    target: &str,
+    _: &str,
+    file: &File,
+    create: bool,
+) -> io::Result<()> {
+    let name: Vec<u16> = target.encode_utf16().collect();
+    let bytes = (offset_of!(FILE_RENAME_INFO, FileName) + name.len() * 2)
+        .max(size_of::<FILE_RENAME_INFO>());
+    let mut storage = vec![0_u64; bytes.div_ceil(8)];
+    let info = storage.as_mut_ptr().cast::<FILE_RENAME_INFO>();
+    // SAFETY: storage is aligned and sized for the header plus the full UTF-16 name.
+    unsafe {
+        (*info).Anonymous.ReplaceIfExists = !create;
+        (*info).RootDirectory = parent.as_raw_handle();
+        (*info).FileNameLength = (name.len() * 2) as u32;
+        std::ptr::copy_nonoverlapping(
+            name.as_ptr(),
+            std::ptr::addr_of_mut!((*info).FileName).cast::<u16>(),
+            name.len(),
+        );
+        if SetFileInformationByHandle(
+            file.as_raw_handle(),
+            FileRenameInfo,
+            info.cast(),
+            bytes as u32,
+        ) == 0
+        {
+            return Err(io::Error::last_os_error());
+        }
+    }
+    Ok(())
+}
+pub(super) fn finish_publish(_: &File, _: &str, _: bool) -> io::Result<()> {
+    Ok(())
+}
+
+pub(super) fn delete(parent: &File, value: &str) -> io::Result<()> {
+    let file = open(parent, value, false, false, true)?;
+    discard(&file)
+}
+pub(super) fn discard(file: &File) -> io::Result<()> {
+    let info = FILE_DISPOSITION_INFO { DeleteFile: true };
+    // SAFETY: the handle and typed disposition structure remain live.
+    if unsafe {
+        SetFileInformationByHandle(
+            file.as_raw_handle(),
+            FileDispositionInfo,
+            (&info as *const FILE_DISPOSITION_INFO).cast(),
+            size_of::<FILE_DISPOSITION_INFO>() as u32,
+        )
+    } == 0
+    {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+pub(super) fn sync(_: &File) -> io::Result<()> {
+    Ok(())
+}
+pub(super) fn children(directory: &File, limit: usize) -> io::Result<(Vec<String>, bool)> {
+    let mut storage = vec![0_u64; 8192];
+    let mut restart = true;
+    let mut names = Vec::new();
+    let mut unsupported_name = false;
+    loop {
+        // SAFETY: storage is aligned, writable and has the advertised 64 KiB size.
+        if unsafe {
+            GetFileInformationByHandleEx(
+                directory.as_raw_handle(),
+                if restart {
+                    FileIdBothDirectoryRestartInfo
+                } else {
+                    FileIdBothDirectoryInfo
+                },
+                storage.as_mut_ptr().cast(),
+                65536,
+            )
+        } == 0
+        {
+            let error = io::Error::last_os_error();
+            return if error.raw_os_error() == Some(ERROR_NO_MORE_FILES as i32) {
+                Ok((names, unsupported_name))
+            } else {
+                Err(error)
+            };
+        }
+        restart = false;
+        let bytes = storage.as_ptr().cast::<u8>();
+        let mut cursor = 0;
+        loop {
+            let fixed = offset_of!(FILE_ID_BOTH_DIR_INFO, FileName);
+            if cursor + fixed > 65536 {
+                return Err(unsafe_file());
+            }
+            // SAFETY: fixed fields fit in the checked buffer; read_unaligned tolerates drivers.
+            let info = unsafe { bytes.add(cursor).cast::<FILE_ID_BOTH_DIR_INFO>() };
+            // SAFETY: fixed fields were bounds-checked above.
+            let (next, length) = unsafe {
+                (
+                    std::ptr::addr_of!((*info).NextEntryOffset).read_unaligned() as usize,
+                    std::ptr::addr_of!((*info).FileNameLength).read_unaligned() as usize,
+                )
+            };
+            let start = cursor + fixed;
+            if length == 0 || length % 2 != 0 || length > 65536 - start {
+                return Err(unsafe_file());
+            }
+            let end = start + length;
+            let wide: Vec<u16> = (start..end)
+                .step_by(2)
+                .map(|offset| {
+                    // SAFETY: each code unit fits in the checked name region.
+                    unsafe { bytes.add(offset).cast::<u16>().read_unaligned() }
+                })
+                .collect();
+            if !matches!(wide.as_slice(), [46] | [46, 46]) {
+                if names.len() == limit {
+                    return Ok((names, true));
+                }
+                names.push(match String::from_utf16(&wide) {
+                    Ok(name) => name,
+                    Err(_) => {
+                        unsupported_name = true;
+                        "\0".into()
+                    }
+                });
+            }
+            if next == 0 {
+                break;
+            }
+            if next < end - cursor || next >= 65536 - cursor {
+                return Err(unsafe_file());
+            }
+            cursor += next;
+        }
+    }
+}
+
+pub(super) fn copy_security(source: &File, target: &File) -> io::Result<()> {
+    use windows_sys::Win32::{
+        Foundation::LocalFree,
+        Security::{
+            Authorization::{GetSecurityInfo, SE_FILE_OBJECT, SetSecurityInfo},
+            DACL_SECURITY_INFORMATION, GROUP_SECURITY_INFORMATION, GetSecurityDescriptorControl,
+            OWNER_SECURITY_INFORMATION, PROTECTED_DACL_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR,
+            SE_DACL_PROTECTED, UNPROTECTED_DACL_SECURITY_INFORMATION,
+        },
+    };
+    struct Descriptor(PSECURITY_DESCRIPTOR);
+    impl Drop for Descriptor {
+        fn drop(&mut self) {
+            // SAFETY: GetSecurityInfo allocated this descriptor with LocalAlloc.
+            unsafe {
+                LocalFree(self.0);
+            }
+        }
+    }
+    let mut owner = std::ptr::null_mut();
+    let mut group = std::ptr::null_mut();
+    let mut dacl = std::ptr::null_mut();
+    let mut descriptor = std::ptr::null_mut();
+    let information =
+        DACL_SECURITY_INFORMATION | OWNER_SECURITY_INFORMATION | GROUP_SECURITY_INFORMATION;
+    // SAFETY: handles and out-pointers are valid for the duration of the call.
+    let status = unsafe {
+        GetSecurityInfo(
+            source.as_raw_handle(),
+            SE_FILE_OBJECT,
+            information,
+            &mut owner,
+            &mut group,
+            &mut dacl,
+            std::ptr::null_mut(),
+            &mut descriptor,
+        )
+    };
+    if status != 0 {
+        return Err(io::Error::from_raw_os_error(status as i32));
+    }
+    let descriptor = Descriptor(descriptor);
+    if owner.is_null() || group.is_null() {
+        return Err(unsafe_file());
+    }
+    let mut control = 0;
+    let mut revision = 0;
+    // SAFETY: the descriptor owns every SID and ACL pointer until after SetSecurityInfo.
+    if unsafe { GetSecurityDescriptorControl(descriptor.0, &mut control, &mut revision) } == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let inheritance = if control & SE_DACL_PROTECTED != 0 {
+        PROTECTED_DACL_SECURITY_INFORMATION
+    } else {
+        UNPROTECTED_DACL_SECURITY_INFORMATION
+    };
+    // SAFETY: all SID/ACL pointers remain owned by descriptor. The new empty file
+    // was opened with WRITE_DAC and WRITE_OWNER; failure precedes any content write.
+    let status = unsafe {
+        SetSecurityInfo(
+            target.as_raw_handle(),
+            SE_FILE_OBJECT,
+            information | inheritance,
+            owner,
+            group,
+            dacl,
+            std::ptr::null(),
+        )
+    };
+    if status != 0 {
+        return Err(io::Error::from_raw_os_error(status as i32));
+    }
+    Ok(())
+}

--- a/src/nano/workspace/windows.rs
+++ b/src/nano/workspace/windows.rs
@@ -30,6 +30,17 @@ use windows_sys::{
     },
 };
 
+pub(super) fn search_key(path: &str) -> Vec<u16> {
+    use windows_sys::Wdk::System::SystemServices::RtlUpcaseUnicodeChar;
+
+    path.encode_utf16()
+        .map(|unit| {
+            // SAFETY: this pure NT mapping accepts any UTF-16 code unit.
+            unsafe { RtlUpcaseUnicodeChar(unit) }
+        })
+        .collect()
+}
+
 pub(super) fn root(path: &Path) -> io::Result<File> {
     let file = OpenOptions::new()
         .read(true)

--- a/src/nano/workspace/windows.rs
+++ b/src/nano/workspace/windows.rs
@@ -14,8 +14,9 @@ use windows_sys::{
         Foundation::OBJECT_ATTRIBUTES,
         Storage::FileSystem::{
             FILE_CREATE, FILE_DIRECTORY_FILE, FILE_NON_DIRECTORY_FILE, FILE_OPEN,
-            FILE_OPEN_FOR_BACKUP_INTENT, FILE_OPEN_REPARSE_POINT, FILE_SYNCHRONOUS_IO_NONALERT,
-            NtCreateFile,
+            FILE_OPEN_FOR_BACKUP_INTENT, FILE_OPEN_REPARSE_POINT, FILE_RENAME_INFORMATION,
+            FILE_SYNCHRONOUS_IO_NONALERT, FileRenameInformation, NtCreateFile,
+            NtSetInformationFile,
         },
     },
     Win32::{
@@ -34,18 +35,23 @@ pub(super) fn root(path: &Path) -> io::Result<File> {
         .read(true)
         .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT)
         .open(path)?;
+
     let meta = file.metadata()?;
     if !meta.is_dir() || meta.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
         return Err(unsafe_file());
     }
+
     Ok(file)
 }
+
 pub(super) fn child(parent: &File, value: &str, directory: bool, create: bool) -> io::Result<File> {
     if directory && value == "." {
         return parent.try_clone();
     }
+
     open(parent, value, directory, create, create)
 }
+
 fn open(
     parent: &File,
     value: &str,
@@ -55,11 +61,13 @@ fn open(
 ) -> io::Result<File> {
     let mut name: Vec<u16> = value.encode_utf16().collect();
     let length = u16::try_from(name.len() * 2).map_err(|_| unsafe_file())?;
+
     let name = UNICODE_STRING {
         Length: length,
         MaximumLength: length,
         Buffer: name.as_mut_ptr(),
     };
+
     let attributes = OBJECT_ATTRIBUTES {
         Length: size_of::<OBJECT_ATTRIBUTES>() as u32,
         RootDirectory: parent.as_raw_handle() as HANDLE,
@@ -68,6 +76,7 @@ fn open(
         SecurityDescriptor: std::ptr::null(),
         SecurityQualityOfService: std::ptr::null(),
     };
+
     let mut handle = std::ptr::null_mut();
     let mut status_block = IO_STATUS_BLOCK::default();
     // SAFETY: the held parent, name buffer and structs remain live for this synchronous call.
@@ -101,6 +110,7 @@ fn open(
             0,
         )
     };
+
     if status < 0 {
         if matches!(
             status,
@@ -108,37 +118,45 @@ fn open(
         ) {
             return Err(unsafe_file());
         }
+
         // SAFETY: status conversion has no side effects.
         return Err(io::Error::from_raw_os_error(
             unsafe { RtlNtStatusToDosError(status) } as i32,
         ));
     }
+
     if handle.is_null() {
         return Err(io::Error::other("empty handle"));
     }
+
     // SAFETY: NtCreateFile returned a new owned handle.
     let file = unsafe { File::from_raw_handle(handle) };
     let meta = file.metadata()?;
     if meta.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
         return Err(unsafe_file());
     }
+
     if !meta.is_dir() {
         regular(&file)?;
     }
+
     Ok(file)
 }
+
 pub(super) fn regular(file: &File) -> io::Result<()> {
     let mut info = BY_HANDLE_FILE_INFORMATION::default();
     // SAFETY: the file and output structure remain live.
     if unsafe { GetFileInformationByHandle(file.as_raw_handle(), &mut info) } == 0 {
         return Err(io::Error::last_os_error());
     }
+
     if !file.metadata()?.is_file()
         || info.nNumberOfLinks != 1
         || info.dwFileAttributes & (FILE_ATTRIBUTE_REPARSE_POINT | FILE_ATTRIBUTE_DEVICE) != 0
     {
         return Err(unsafe_file());
     }
+
     Ok(())
 }
 pub(super) fn publish(
@@ -149,12 +167,13 @@ pub(super) fn publish(
     create: bool,
 ) -> io::Result<()> {
     let name: Vec<u16> = target.encode_utf16().collect();
-    let bytes = (offset_of!(FILE_RENAME_INFO, FileName) + name.len() * 2)
-        .max(size_of::<FILE_RENAME_INFO>());
+    let bytes = size_of::<FILE_RENAME_INFORMATION>() + name.len() * 2;
+
     let mut storage = vec![0_u64; bytes.div_ceil(8)];
-    let info = storage.as_mut_ptr().cast::<FILE_RENAME_INFO>();
+    let info = storage.as_mut_ptr().cast::<FILE_RENAME_INFORMATION>();
+    let mut status_block = IO_STATUS_BLOCK::default();
     // SAFETY: storage is aligned and sized for the header plus the full UTF-16 name.
-    unsafe {
+    let status = unsafe {
         (*info).Anonymous.ReplaceIfExists = !create;
         (*info).RootDirectory = parent.as_raw_handle();
         (*info).FileNameLength = (name.len() * 2) as u32;
@@ -163,18 +182,28 @@ pub(super) fn publish(
             std::ptr::addr_of_mut!((*info).FileName).cast::<u16>(),
             name.len(),
         );
-        if SetFileInformationByHandle(
+
+        // Pass the held directory directly to NT. The Win32 rename wrapper can
+        // reject RootDirectory rather than resolve this name relative to it.
+        NtSetInformationFile(
             file.as_raw_handle(),
-            FileRenameInfo,
+            &mut status_block,
             info.cast(),
             bytes as u32,
-        ) == 0
-        {
-            return Err(io::Error::last_os_error());
-        }
+            FileRenameInformation,
+        )
+    };
+
+    if status < 0 {
+        // SAFETY: status conversion has no side effects.
+        return Err(io::Error::from_raw_os_error(
+            unsafe { RtlNtStatusToDosError(status) } as i32,
+        ));
     }
+
     Ok(())
 }
+
 pub(super) fn finish_publish(_: &File, _: &str, _: bool) -> io::Result<()> {
     Ok(())
 }
@@ -183,6 +212,7 @@ pub(super) fn delete(parent: &File, value: &str) -> io::Result<()> {
     let file = open(parent, value, false, false, true)?;
     discard(&file)
 }
+
 pub(super) fn discard(file: &File) -> io::Result<()> {
     let info = FILE_DISPOSITION_INFO { DeleteFile: true };
     // SAFETY: the handle and typed disposition structure remain live.
@@ -197,11 +227,14 @@ pub(super) fn discard(file: &File) -> io::Result<()> {
     {
         return Err(io::Error::last_os_error());
     }
+
     Ok(())
 }
+
 pub(super) fn sync(_: &File) -> io::Result<()> {
     Ok(())
 }
+
 pub(super) fn children(directory: &File, limit: usize) -> io::Result<(Vec<String>, bool)> {
     let mut storage = vec![0_u64; 8192];
     let mut restart = true;
@@ -229,7 +262,9 @@ pub(super) fn children(directory: &File, limit: usize) -> io::Result<(Vec<String
                 Err(error)
             };
         }
+
         restart = false;
+
         let bytes = storage.as_ptr().cast::<u8>();
         let mut cursor = 0;
         loop {
@@ -237,6 +272,7 @@ pub(super) fn children(directory: &File, limit: usize) -> io::Result<(Vec<String
             if cursor + fixed > 65536 {
                 return Err(unsafe_file());
             }
+
             // SAFETY: fixed fields fit in the checked buffer; read_unaligned tolerates drivers.
             let info = unsafe { bytes.add(cursor).cast::<FILE_ID_BOTH_DIR_INFO>() };
             // SAFETY: fixed fields were bounds-checked above.
@@ -246,10 +282,12 @@ pub(super) fn children(directory: &File, limit: usize) -> io::Result<(Vec<String
                     std::ptr::addr_of!((*info).FileNameLength).read_unaligned() as usize,
                 )
             };
+
             let start = cursor + fixed;
             if length == 0 || length % 2 != 0 || length > 65536 - start {
                 return Err(unsafe_file());
             }
+
             let end = start + length;
             let wide: Vec<u16> = (start..end)
                 .step_by(2)
@@ -258,10 +296,12 @@ pub(super) fn children(directory: &File, limit: usize) -> io::Result<(Vec<String
                     unsafe { bytes.add(offset).cast::<u16>().read_unaligned() }
                 })
                 .collect();
+
             if !matches!(wide.as_slice(), [46] | [46, 46]) {
                 if names.len() == limit {
                     return Ok((names, true));
                 }
+
                 names.push(match String::from_utf16(&wide) {
                     Ok(name) => name,
                     Err(_) => {
@@ -270,12 +310,15 @@ pub(super) fn children(directory: &File, limit: usize) -> io::Result<(Vec<String
                     }
                 });
             }
+
             if next == 0 {
                 break;
             }
+
             if next < end - cursor || next >= 65536 - cursor {
                 return Err(unsafe_file());
             }
+
             cursor += next;
         }
     }
@@ -291,7 +334,9 @@ pub(super) fn copy_security(source: &File, target: &File) -> io::Result<()> {
             SE_DACL_PROTECTED, UNPROTECTED_DACL_SECURITY_INFORMATION,
         },
     };
+
     struct Descriptor(PSECURITY_DESCRIPTOR);
+
     impl Drop for Descriptor {
         fn drop(&mut self) {
             // SAFETY: GetSecurityInfo allocated this descriptor with LocalAlloc.
@@ -300,12 +345,14 @@ pub(super) fn copy_security(source: &File, target: &File) -> io::Result<()> {
             }
         }
     }
+
     let mut owner = std::ptr::null_mut();
     let mut group = std::ptr::null_mut();
     let mut dacl = std::ptr::null_mut();
     let mut descriptor = std::ptr::null_mut();
     let information =
         DACL_SECURITY_INFORMATION | OWNER_SECURITY_INFORMATION | GROUP_SECURITY_INFORMATION;
+
     // SAFETY: handles and out-pointers are valid for the duration of the call.
     let status = unsafe {
         GetSecurityInfo(
@@ -319,24 +366,29 @@ pub(super) fn copy_security(source: &File, target: &File) -> io::Result<()> {
             &mut descriptor,
         )
     };
+
     if status != 0 {
         return Err(io::Error::from_raw_os_error(status as i32));
     }
+
     let descriptor = Descriptor(descriptor);
     if owner.is_null() || group.is_null() {
         return Err(unsafe_file());
     }
+
     let mut control = 0;
     let mut revision = 0;
     // SAFETY: the descriptor owns every SID and ACL pointer until after SetSecurityInfo.
     if unsafe { GetSecurityDescriptorControl(descriptor.0, &mut control, &mut revision) } == 0 {
         return Err(io::Error::last_os_error());
     }
+
     let inheritance = if control & SE_DACL_PROTECTED != 0 {
         PROTECTED_DACL_SECURITY_INFORMATION
     } else {
         UNPROTECTED_DACL_SECURITY_INFORMATION
     };
+
     // SAFETY: all SID/ACL pointers remain owned by descriptor. The new empty file
     // was opened with WRITE_DAC and WRITE_OWNER; failure precedes any content write.
     let status = unsafe {
@@ -350,8 +402,10 @@ pub(super) fn copy_security(source: &File, target: &File) -> io::Result<()> {
             std::ptr::null(),
         )
     };
+
     if status != 0 {
         return Err(io::Error::from_raw_os_error(status as i32));
     }
+
     Ok(())
 }


### PR DESCRIPTION
## Summary

Add native `read_file`, `search_text`, and `apply_patch` tools to Nano's `Tools` port. Reads and literal searches return bounded results with workspace identity, content digests, and explicit truncation. Exact patches require matching base digests and validate the entire batch before writing.

Use directory-relative filesystem operations to confine access to the authorized workspace, protect Git and Ferrus state, and preserve existing permissions. Report partial publications with per-file hashes so the engine can stop for reconciliation.

Closes #76.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Enhancement
- [ ] Performance
- [ ] Documentation
- [ ] Refactor
- [ ] Security
- [ ] Breaking change

## Workflow impact (if applicable)

- [x] No impact
- [ ] Minor change (does not alter lifecycle semantics)
- [ ] Changes behavior of an existing step
- [ ] Introduces new state/transition

Adds an internal tool implementation without changing task lifecycle semantics or existing agent integrations. Host authorization and Executor launch wiring remain separate; these tools do not execute processes, rebuild graphs, or modify Git staging/history.

## Checklist

- [x] I added/updated tests where it makes sense
- [x] I updated docs/examples if needed
- [x] This change is backwards-compatible (or clearly marked as breaking)
- [x] I ran formatting/lints locally (if applicable)

## Notes for reviewers

- Patches use exact, ordered line hunks with explicit LF/CRLF content. Publication is per file; a later failure retains the applied prefix and returns an unknown-effect outcome. Multi-file rollback and crash reconciliation are outside this change; recovery is tracked in #84.
- Review Unix and Windows confinement, no-overwrite creation, permission preservation, and partial-result accounting. Digest rechecks are optimistic and cannot exclude a concurrent external writer between the final check and publication.
- Local validation: `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test`, including the `nano-openai` configuration. Focused tests cover limits, stale bases, unsafe paths, partial writes, and Engine/journal integration. The live provider smoke test remains opt-in.
- Windows filesystem/private modules and their tests passed cross-target compilation and Clippy. Windows runtime validation is left to CI.
